### PR TITLE
Change readme to mention LGPL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ with Python.
     :Mailing list: http://github.com/collective/icalendar/issues
     :Dependencies: There are no other dependencies.
     :Tested with: Python 2.4 - 2.7
-    :License: ???
+    :License: LGPL 2.1
 
 ----
 


### PR DESCRIPTION
If you look in docs/license.rst you'll see that this project has been licensed under the LGPL since the codespeak.net days.

This pull request updates the readme.
