### PR TITLE
Lines should be folded

### DIFF
--- a/src/icalendar/parser.py
+++ b/src/icalendar/parser.py
@@ -496,7 +496,7 @@ class Contentlines(list):
 
     def to_ical(self):
         "Simply join self."
-        return '\r\n'.join(map(str, self))
+        return '\r\n'.join(l.to_ical() for l in self if l)
 
     def from_ical(st):
         "Parses a string into content lines"


### PR DESCRIPTION
When I call `to_ical` on a `Calendar` object the resulting lines are not folded.
This happens because the `to_ical` method in the `Calendar` class doesn't call the equivalent method in `Contentline`. This patch seems to solve this issue.
