### PR TITLE
Fixed vDatetime.to_ical() so that the doctests at lines 515 and 527 pass...

### DIFF
--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -73,7 +73,7 @@ class vBinary:
     'This is gibberish'
 
     The roundtrip test
-    >>> x = 'Binary data ï¿½ ï¿½ ï¿½ \x13 \x56'
+    >>> x = 'Binary data æ ø å \x13 \x56'
     >>> vBinary(x).to_ical()
     'QmluYXJ5IGRhdGEg5iD4IOUgEyBW'
     >>> vBinary.from_ical('QmluYXJ5IGRhdGEg5iD4IOUgEyBW')
@@ -1041,12 +1041,12 @@ class vText(unicode):
     If you pass a unicode object, it will be utf-8 encoded. As this is the
     (only) standard that RFC 2445 support.
 
-    >>> t = vText(u'international chars ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ ï¿½')
+    >>> t = vText(u'international chars æøå ÆØÅ ü')
     >>> t.to_ical()
     'international chars \\xc3\\xa6\\xc3\\xb8\\xc3\\xa5 \\xc3\\x86\\xc3\\x98\\xc3\\x85 \\xc3\\xbc'
 
     Unicode is converted to utf-8
-    >>> t = vText(u'international ï¿½ ï¿½ ï¿½')
+    >>> t = vText(u'international æ ø å')
     >>> t.to_ical()
     'international \\xc3\\xa6 \\xc3\\xb8 \\xc3\\xa5'
 
@@ -1361,12 +1361,12 @@ class TypesFactory(CaselessDict):
     datetime.datetime(2005, 1, 1, 12, 30)
 
     It can also be used to directly encode property and parameter values
-    >>> comment = factory.to_ical('comment', u'by Rasmussen, Max Mï¿½ller')
+    >>> comment = factory.to_ical('comment', u'by Rasmussen, Max Møller')
     >>> str(comment)
     'by Rasmussen\\\\, Max M\\xc3\\xb8ller'
     >>> factory.to_ical('priority', 1)
     '1'
-    >>> factory.to_ical('cn', u'Rasmussen, Max Mï¿½ller')
+    >>> factory.to_ical('cn', u'Rasmussen, Max Møller')
     'Rasmussen\\\\, Max M\\xc3\\xb8ller'
 
     >>> factory.from_ical('cn', 'Rasmussen\\\\, Max M\\xc3\\xb8ller')


### PR DESCRIPTION
.... It was failing to print the Z at the end of the string.
