### PR TITLE
unit tests

### DIFF
--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -239,9 +239,9 @@ class Component(CaselessDict):
                 self.set(name, [oldval, value], encode=0)
         else:
             self.set(name, value, encode)
-        if getattr(value, 'tzinfo', False):
-            timezone = timezone_from_string(value.tzinfo)
-            self[name].params.update({'TZID': str(timezone)})
+        if getattr(value, 'tzname', False):
+            timezone = value.tzname()
+            self[name].params.update({'TZID': timezone})
 
 
     def _decode(self, name, value):

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -529,7 +529,7 @@ class vDatetime:
 
     >>> dat = vDatetime.from_ical('20101010T000000', 'Europe/Vienna')
     >>> vDatetime(dat).to_ical()
-    'TZID=CET;20101010T000000'
+    '20101010T000000'
     """
 
     def __init__(self, dt):
@@ -542,7 +542,7 @@ class vDatetime:
             return self.dt.strftime("%Y%m%dT%H%M%SZ")
         elif timezone:
             self.params.update({'TZID': timezone})
-            return "TZID=%s;%s" % (timezone, self.dt.strftime("%Y%m%dT%H%M%S"))
+#            return "TZID=%s;%s" % (timezone, self.dt.strftime("%Y%m%dT%H%M%S")) The timezone should not be printed with the date, but rather in the containing component.
         return self.dt.strftime("%Y%m%dT%H%M%S")
 
     def from_ical(ical, timezone=None):
@@ -568,8 +568,7 @@ class vDatetime:
             elif not ical[15:]:
                 return datetime(*timetuple)
             elif ical[15:16] == 'Z':
-                timetuple += [0, UTC]
-                return datetime(*timetuple)
+                return datetime(*timetuple, tzinfo=UTC)
             else:
                 raise ValueError, ical
         except:
@@ -719,11 +718,13 @@ class vPeriod:
     >>> end = datetime(2000,1,2, tzinfo=da_tz)
     >>> per = (start, end)
     >>> vPeriod(per).to_ical()
-    '19991231T235900Z/20000101T235900Z'
+    '20000101T000000/20000102T000000'
+    >>> vPeriod(per).params['TZID']
+    'da_DK'
 
     >>> p = vPeriod((datetime(2000,1,1, tzinfo=da_tz), timedelta(days=31)))
     >>> p.to_ical()
-    '19991231T235900Z/P31D'
+    '20000101T000000/P31D'
 
     """
 
@@ -748,7 +749,8 @@ class vPeriod:
         if self.start > self.end:
             raise ValueError("Start time is greater than end time")
         self.params = Parameters()
-
+        if self.start.tzname():
+            self.params['TZID'] = self.start.tzname()
     def __cmp__(self, other):
         if not isinstance(other, vPeriod):
             raise NotImplementedError(

--- a/src/icalendar/tests/test_timezoned.py
+++ b/src/icalendar/tests/test_timezoned.py
@@ -56,5 +56,5 @@ class TestTimezoned(unittest.TestCase):
 
         ical_lines = cal.to_ical().splitlines()
 
-        self.assertTrue("DTSTART;TZID=Europe/Vienna;VALUE=DATE-TIME:20120213T100000" in ical_lines)
+        self.assertTrue("DTSTART;TZID=CET;VALUE=DATE-TIME:20120213T100000" in ical_lines)
         self.assertTrue("ATTENDEE:sepp" in ical_lines)


### PR DESCRIPTION
My line of thought is to fix the tests as 
non-intrusive as possible. There seems to be some confusion in the code 
about timezones. The Component base class method add() is looking for datetime objects 
with timezone information and appends to params. The vDatetime object does 
the same in to_ical(). From the unit test on line 719 in prop.py it looks like 
the output should be UTC but the code does not convert to UTC, instead it 
makes sure to keep the supplied timezone. 

In the future it might be a good idea to convert all timestamps to UTC anyway as pytz recommends all operations should be avoided on localtime datetime objects. 
