### PR TITLE
Modified how a tz aware datetime is created in from_ical to conform to t...

### DIFF
--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -74,7 +74,7 @@ class vBinary:
     'This is gibberish'
 
     The roundtrip test
-    >>> x = 'Binary data æ ø å \x13 \x56'
+    >>> x = 'Binary data ï¿½ ï¿½ ï¿½ \x13 \x56'
     >>> vBinary(x).to_ical()
     'QmluYXJ5IGRhdGEg5iD4IOUgEyBW'
     >>> vBinary.from_ical('QmluYXJ5IGRhdGEg5iD4IOUgEyBW')
@@ -565,7 +565,7 @@ class vDatetime:
                 ical[13:15],    # second
                 )))
             if tzinfo:
-                return datetime(tzinfo=tzinfo, *timetuple)
+                return tzinfo.localize(datetime(*timetuple))
             elif not ical[15:]:
                 return datetime(*timetuple)
             elif ical[15:16] == 'Z':
@@ -1049,12 +1049,12 @@ class vText(unicode):
     If you pass a unicode object, it will be utf-8 encoded. As this is the
     (only) standard that RFC 2445 support.
 
-    >>> t = vText(u'international chars æøå ÆØÅ ü')
+    >>> t = vText(u'international chars ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ ï¿½')
     >>> t.to_ical()
     'international chars \\xc3\\xa6\\xc3\\xb8\\xc3\\xa5 \\xc3\\x86\\xc3\\x98\\xc3\\x85 \\xc3\\xbc'
 
     Unicode is converted to utf-8
-    >>> t = vText(u'international æ ø å')
+    >>> t = vText(u'international ï¿½ ï¿½ ï¿½')
     >>> t.to_ical()
     'international \\xc3\\xa6 \\xc3\\xb8 \\xc3\\xa5'
 
@@ -1374,12 +1374,12 @@ class TypesFactory(CaselessDict):
     datetime.datetime(2005, 1, 1, 12, 30)
 
     It can also be used to directly encode property and parameter values
-    >>> comment = factory.to_ical('comment', u'by Rasmussen, Max Møller')
+    >>> comment = factory.to_ical('comment', u'by Rasmussen, Max Mï¿½ller')
     >>> str(comment)
     'by Rasmussen\\\\, Max M\\xc3\\xb8ller'
     >>> factory.to_ical('priority', 1)
     '1'
-    >>> factory.to_ical('cn', u'Rasmussen, Max Møller')
+    >>> factory.to_ical('cn', u'Rasmussen, Max Mï¿½ller')
     'Rasmussen\\\\, Max M\\xc3\\xb8ller'
 
     >>> factory.from_ical('cn', 'Rasmussen\\\\, Max M\\xc3\\xb8ller')


### PR DESCRIPTION
...he documentation for the pytz module at http://pytz.sourceforge.net/#example-usage.  Simply passing in tzinfo doesn't work for timezone that have Daylight Savings Time transitions.  This leads to problems when trying to convert the datetime to another timezone as the offsets may be incorrect.
