### PR TITLE
Include complete doc/ subdirectory in tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
-include README.rst docs/changelog.rst
+include README.rst
+graft docs
 recursive-include src/icalendar *
 recursive-exclude src/icalendar *.pyc


### PR DESCRIPTION
This helps distributions package complete package together with examples and other documentation. This is especially important since getting stable tarballs from github tags is not trivial.
