### PR TITLE
Make sure parameters to certain properties propagate to the ical output

### DIFF
--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -259,7 +259,10 @@ class Component(CaselessDict):
 
         if cond:
             klass = types_factory.for_property(name)
-            return klass(value)
+            _klass = klass(value)
+            if hasattr(value, 'params') and len(value.params.keys()) > 0:
+                _klass.params = value.params
+            return _klass
 
         return value
 

--- a/src/icalendar/tests/test-property_params.py
+++ b/src/icalendar/tests/test-property_params.py
@@ -1,0 +1,17 @@
+import icalendar
+import unittest
+
+class TestPropertyParams(unittest.TestCase):
+
+    def test_property_params(self):
+        cal_address = icalendar.vCalAddress('mailto:john.doe@example.org')
+        cal_address.params["CN"] = "Doe, John"
+        ical = icalendar.Calendar()
+        ical.add('organizer', cal_address)
+
+        ical_str = icalendar.Calendar.to_ical(ical)
+        exp_str = """BEGIN:VCALENDAR\r\nORGANIZER;CN="Doe, John":mailto:john.doe@example.org\r\nEND:VCALENDAR\r\n"""
+
+        self.assertEqual(ical_str, exp_str)
+
+        raise Exception


### PR DESCRIPTION
Please find this patch and corresponding test to ensure parameters to properties correctly propagate through the stack.
