### PR TITLE
Added a JSONEncoder subclass that permits the Calendar tree to be encoded as JSON

### DIFF
--- a/src/icalendar/__init__.py
+++ b/src/icalendar/__init__.py
@@ -6,7 +6,7 @@ from icalendar.cal import FreeBusy, Alarm, ComponentFactory
 from icalendar.prop import vBinary, vBoolean, vCalAddress, vDatetime, vDate,\
      vDDDTypes, vDuration, vFloat, vInt, vPeriod,\
      vWeekday, vFrequency, vRecur, vText, vTime, vUri,\
-     vGeo, vUTCOffset, TypesFactory
+     vGeo, vUTCOffset, TypesFactory, ICalendarEncoder
 
 # useful tzinfo subclasses
 from icalendar.prop import FixedOffset, LocalTimezone
@@ -25,4 +25,5 @@ __all__ = [
     vGeo, vUTCOffset, TypesFactory,
     FixedOffset, LocalTimezone,
     Parameters, q_split, q_join,
+    ICalendarEncoder
 ]

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -391,7 +391,7 @@ class Component(CaselessDict):
         return properties
 
     @staticmethod
-    def from_ical(st, multiple=False):
+    def from_ical(st, multiple=False, ignoreBadLines=False):
         """
         Populates the component recursively from a string
 
@@ -412,7 +412,14 @@ class Component(CaselessDict):
         for line in Contentlines.from_ical(st): # raw parsing
             if not line:
                 continue
-            name, params, vals = line.parts()
+            try:
+                name, params, vals = line.parts()
+            except ValueError as e:
+                if ignoreBadLines:
+                    pass
+                else:
+                    raise e                
+
             uname = name.upper()
             # check for start of component
             if uname == 'BEGIN':

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -57,6 +57,9 @@ from icalendar.parser import escape_char
 from icalendar.parser import unescape_char
 from icalendar.parser import tzinfo_from_dt
 
+from json import JSONEncoder
+import json
+
 
 SequenceTypes = [TupleType, ListType]
 
@@ -1553,3 +1556,19 @@ class TypesFactory(CaselessDict):
         type_class = self.for_property(name)
         decoded = type_class.from_ical(value)
         return decoded
+
+
+class ICalendarEncoder(JSONEncoder):
+    def default(self, obj, markers=None):
+        
+        try:
+            if obj.__module__.startswith("icalendar.prop"):
+                return (obj.to_ical())
+        except AttributeError:
+            pass
+
+        if isinstance(obj, datetime):
+            return (obj.now().strftime('%Y-%m-%dT%H:%M:%S'))
+        
+        return JSONEncoder.default(self,obj)    
+


### PR DESCRIPTION
here's a working example

``` python

from json import JSONEncoder
import json
from datetime import datetime
from icalendar import Calendar, vDDDTypes, Event, ICalendarEncoder
import pprint

cal = Calendar.from_ical(open('test.ics','rb').read())

for event in cal.walk(name="VEVENT"):
    suspect = json.dumps(event, cls=ICalendarEncoder)
    working = json.loads(suspect)

pprint.pprint(working)

```
