### PR TITLE
fix to escaped characters being split across multiple lines

### DIFF
--- a/src/icalendar/parser.py
+++ b/src/icalendar/parser.py
@@ -405,7 +405,7 @@ class Contentline(str):
     True
 
     Split on even number of \\
-    >>> c=Contentline('This line has five \\ characters that only 2 should be on the next line. \\\\\\\\\\This is the test')
+    >>> c=Contentline('This line has five \\ characters that only 3 should be on the next line. \\\\\\\\\\This is the test')
     >>> ". \\\\" in c.to_ical() and " \\\\\\This" in c.to_ical()
     True
 


### PR DESCRIPTION
I was getting the following with strict 74 character splittings. Outlook could not deal with it and displayed long lines about where the \n is after "time out"

<pre>
DESCRIPTION:Carnaged Education training room booking:\nemail : daniel.blac
 k@somecompan.com.au\nname : Daniel Black\nphone : 0411111111\nmobile phone
  : \ncompany : \nfax : \nparticipants : 9\ncatering : false\nterms and con
 ditions : true\nlayout : \nconference : false\nevent type : IT Training (w
 ith equipment)\nother notes : test of event type and time in and time out\
 ntime in : 9:00\ntime out : 17:00\ndates[] : 30/04/2013\nRequest Type : Ma
 ke Booking
LOCATION:Carnaged Education Training Room - Phoenix House\, Ground floor U
 nit 8\, Somewhere
</pre>


With this patch this becomes.

<pre>
DESCRIPTION:Carnaged Education training room booking:\nemail : daniel.blac
 k@somecompan.com.au\nname : Daniel Black\nphone : 0411111111\nmobile phone
  : \ncompany : \nfax : \nparticipants : 9\ncatering : false\nterms and con
 ditions : true\nlayout : \nconference : false\nevent type : IT Training (w
 ith equipment)\nother notes : test of event type and time in and time out
 \ntime in : 9:00\ntime out : 17:00\ndates[] : 30/04/2013\nRequest Type : M
 ake Booking
LOCATION:Carnaged Education Training Room - Phoenix House\, Ground floor U
 nit 8\, Somewhere
</pre>
