### PR TITLE
Fixed a case when parameter value was non-ascii. Added a test for the case.

### DIFF
--- a/src/icalendar/parser.py
+++ b/src/icalendar/parser.py
@@ -138,7 +138,7 @@ def validate_param_value(value, quoted=True):
 
 
 # chars presence of which in parameter value will be cause the value
-# to be enclosed in double-tuotes
+# to be enclosed in double-quotes
 QUOTABLE = re.compile("[,;: ’']")
 
 
@@ -297,8 +297,9 @@ class Parameters(CaselessDict):
         items.sort()  # To make doctests work
         for key, value in items:
             value = paramVal(value)
-            result.append('%s=%s' % (key.upper(),
-                                     value.encode(DEFAULT_ENCODING)))
+            if isinstance(value, unicode):
+                value = value.encode(DEFAULT_ENCODING)
+            result.append('%s=%s' % (key.upper(), value))
         return ';'.join(result)
 
     @staticmethod

--- a/src/icalendar/tests/test_property_params.py
+++ b/src/icalendar/tests/test_property_params.py
@@ -23,6 +23,19 @@ class TestPropertyParams(unittest.TestCase):
         ical2 = icalendar.Calendar.from_ical(ical_str)
         self.assertEqual(ical2.get('ORGANIZER').params.get('CN'), 'Doe, John')
 
+        # test unicode parameter value
+        cal_address = icalendar.vCalAddress('mailto:john.doe@example.org')
+        cal_address.params["CN"] = "Джон Доу"
+        vevent = icalendar.Event()
+        vevent['ORGANIZER'] = cal_address
+        self.assertEqual(
+            vevent.to_ical(),
+            'BEGIN:VEVENT\r\n'
+            'ORGANIZER;CN="Джон Доу":mailto:john.doe@example.org\r\n'
+            'END:VEVENT\r\n'
+        )
+        self.assertEqual(vevent['ORGANIZER'].params['CN'], 'Джон Доу')
+
     def test_quoting(self):
         # not double-quoted
         self._test_quoting(u"Aramis", 'Aramis')


### PR DESCRIPTION
I think the internals should be refactored to handle everything inside in unicode, and return the result as str only in to_ical() methods.

http://nedbatchelder.com/blog/201203/pragmatic_unicode.html
