### PR TITLE
python-dateutil overall dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ shortdesc = 'iCalendar parser/generator'
 longdesc = open('README.rst').read()
 longdesc += open('CHANGES.rst').read()
 longdesc += open('LICENSE.rst').read()
-tests_require = ['unittest2', 'python-dateutil==1.5']
+tests_require = ['unittest2']
 
 setuptools.setup(
     name='icalendar',
@@ -30,6 +30,7 @@ setuptools.setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
+        'python-dateutil==1.5',
         'pytz',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ deps =
     icalendar
     unittest2
     coverage
-    python-dateutil==1.5
 commands =
     coverage erase
     coverage run --source=icalendar --omit=*tests* {envbindir}/unit2 discover icalendar []


### PR DESCRIPTION
The icalendar code depends on python-dateutil; that dependency is not limited to tests. (Reported to me by a fellow NetBSD pkgsrc developer who gave the recently updated to 3.3 package a shot but didn't have dateutil installed in the first place, as no dependency had been recorded.)
