### PR TITLE
Remove incorrect use of __all__

### DIFF
--- a/src/icalendar/__init__.py
+++ b/src/icalendar/__init__.py
@@ -44,16 +44,3 @@ from icalendar.parser import (
     q_split,
     q_join,
 )
-
-
-__all__ = [
-    Calendar, Event, Todo, Journal,
-    FreeBusy, Alarm, ComponentFactory,
-    Timezone, TimezoneStandard, TimezoneDaylight,
-    vBinary, vBoolean, vCalAddress, vDatetime, vDate,
-    vDDDTypes, vDuration, vFloat, vInt, vPeriod,
-    vWeekday, vFrequency, vRecur, vText, vTime, vUri,
-    vGeo, vUTCOffset, TypesFactory,
-    FixedOffset, LocalTimezone,
-    Parameters, q_split, q_join,
-]


### PR DESCRIPTION
From the docs:

> If a package’s `__init__.py` code defines a list named `__all__`, it is taken to be **the list of module names** that should be imported when `from package import *` is encountered. It is up to the package author to keep this list up-to-date when a new version of the package is released. Package authors may also decide not to support it, if they don’t see a use for importing \* from their package. For example[...]:
> 
> ```
> __all__ = ["echo", "surround", "reverse"]
> ```

As is currently in the code, this serves no purpose
