### PR TITLE
dateutil import error processing

### DIFF
--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -285,7 +285,7 @@ class vDDDTypes(object):
                 and getattr(dt, 'tzinfo', False):
             tzinfo = dt.tzinfo
             if tzinfo is not pytz.utc and\
-               not (tzutc and isinstance(tzinfo, tzutc)):
+               (tzutc is None or not isinstance(tzinfo, tzutc)):
                 # set the timezone as a parameter to the property
                 tzid = tzid_from_dt(dt)
                 if tzid:

--- a/src/icalendar/tests/test_timezoned.py
+++ b/src/icalendar/tests/test_timezoned.py
@@ -2,12 +2,7 @@
 from icalendar.tests import unittest
 
 import datetime
-try:
-    import dateutil.parser
-    dateutil_loaded = True
-except ImportError:
-    dateutil_loaded = False
-
+import dateutil.parser
 import icalendar
 import os
 import pytz
@@ -133,8 +128,6 @@ class TestTimezoned(unittest.TestCase):
     def test_tzinfo_dateutil(self):
         # Test for issues #77, #63
         # references: #73,7430b66862346fe3a6a100ab25e35a8711446717
-        if not dateutil_loaded:
-            return
         date = dateutil.parser.parse('2012-08-30T22:41:00Z')
         date2 = dateutil.parser.parse('2012-08-30T22:41:00 +02:00')
         self.assertTrue(date.tzinfo.__module__ == 'dateutil.tz')


### PR DESCRIPTION
There was error when dateutil dependency is absent. Here is patch to process this case
