### PR TITLE
Allow dots in property names.

### DIFF
--- a/src/icalendar/parser.py
+++ b/src/icalendar/parser.py
@@ -98,7 +98,11 @@ def param_value(value):
 
 
 # Could be improved
-NAME = re.compile('[\w-]+')
+
+# [\w-] because of the iCalendar RFC
+# \. because of the vCard RFC
+NAME = re.compile('[\w\.-]+')
+
 UNSAFE_CHAR = re.compile('[\x00-\x08\x0a-\x1f\x7F",:;]')
 QUNSAFE_CHAR = re.compile('[\x00-\x08\x0a-\x1f\x7F"]')
 FOLD = re.compile(b'(\r?\n)+[ \t]')


### PR DESCRIPTION
This is for vCard compatibility. From RFC 6350:

```
The group construct is used to group related properties together.
```

   The group name is a syntactic convention used to indicate that all
   property names prefaced with the same group name SHOULD be grouped
   together when displayed by an application.  It has no other
   significance.  Implementations that do not understand or support
   grouping MAY simply strip off any text before a "." to the left of
   the type name and present the types and values as normal.

We could of course consider stripping off the group prefixes, but then that
data would be lost. I recommend we leave this to the user or Component
subclasses to do something meaningful with groups.
