### PR TITLE
duration may have extra '+' in value

### DIFF
--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -310,7 +310,7 @@ class vDDDTypes(object):
         if isinstance(ical, cls):
             return ical.dt
         u = ical.upper()
-        if u.startswith('-P') or u.startswith('P'):
+        if u.startswith('-P') or u.startswith('P') or u.startswith('+P'):
             return vDuration.from_ical(ical)
         try:
             return vDatetime.from_ical(ical, timezone=timezone)


### PR DESCRIPTION
from rfc5545 spec:
 dur-value = (["+"] / "-") "P" (dur-date / dur-time / dur-week)

Signed-off-by: Hiroaki KAWAI kawai@stratosphere.co.jp
