### PR TITLE
Recurring rules and trailing semicolons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 - Documentation fixes.
   [t-8ch, thet]
 
+- Made RRULE tolerant of trailing semicolons.
+  [sleeper]
+
 
 3.8.4 (2014-11-01)
 ------------------

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -665,11 +665,10 @@ class vRecur(CaselessDict):
             return ical
         try:
             recur = cls()
-            if ical[-1] == ';':
-                ical = ical[0:-1]
             for pairs in ical.split(';'):
-                key, vals = pairs.split('=')
-                recur[key] = cls.parse_type(key, vals)
+                if len(pairs) >= 3:
+                    key, vals = pairs.split('=')
+                    recur[key] = cls.parse_type(key, vals)
             return dict(recur)
         except:
             raise ValueError('Error in recurrence rule: %s' % ical)

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -665,8 +665,8 @@ class vRecur(CaselessDict):
             return ical
         try:
             recur = cls()
-						if ical[-1] == ';':
-							ical = ical[0:-1]
+            if ical[-1] == ';':
+                ical = ical[0:-1]
             for pairs in ical.split(';'):
                 key, vals = pairs.split('=')
                 recur[key] = cls.parse_type(key, vals)

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -665,6 +665,8 @@ class vRecur(CaselessDict):
             return ical
         try:
             recur = cls()
+						if ical[-1] == ';':
+							ical = ical[0:-1]
             for pairs in ical.split(';'):
                 key, vals = pairs.split('=')
                 recur[key] = cls.parse_type(key, vals)

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -666,9 +666,11 @@ class vRecur(CaselessDict):
         try:
             recur = cls()
             for pairs in ical.split(';'):
-                if len(pairs) >= 3:
+                try:
                     key, vals = pairs.split('=')
-                    recur[key] = cls.parse_type(key, vals)
+                except ValueError:
+                    continue
+                recur[key] = cls.parse_type(key, vals)
             return dict(recur)
         except:
             raise ValueError('Error in recurrence rule: %s' % ical)


### PR DESCRIPTION
I ran iCalendar on a calendar from CalReply.com (SyFy are using them for their episode reminders - http://on.syfy.com/) and got hit with this:

```
Traceback (most recent call last):
  File "/usr/lib/python3.4/site-packages/icalendar/prop.py", line 669, in from_ical
    key, vals = pairs.split('=')
ValueError: need more than 1 value to unpack
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  ...
  File "/usr/lib/python3.4/site-packages/icalendar/cal.py", line 350, in from_ical
    vals = factory(factory.from_ical(vals))
  File "/usr/lib/python3.4/site-packages/icalendar/prop.py", line 673, in from_ical
    raise ValueError('Error in recurrence rule: %s' % ical)
ValueError: Error in recurrence rule: FREQ=YEARLY;BYMONTH=11;BYDAY=1SU;
```
I don't know if this complies with the standards to have a trailing semicolon on the RRULE records or if you've ran into this before, but here's a patch anyway.