### PR TITLE
fix vPeriod.__repr__

### DIFF
--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -535,7 +535,7 @@ class vPeriod(object):
             p = (self.start, self.duration)
         else:
             p = (self.start, self.end)
-        return 'vPeriod(%r)' % p
+        return 'vPeriod(%r)' % (p, )
 
 
 class vWeekday(compat.unicode_type):


### PR DESCRIPTION
Without this fix following code does not work:

p = vPeriod((datetime.datetime(2016, 5, 20, 9, 0), datetime.datetime(2016, 5, 20, 10, 0)))
print(p)