### PR TITLE
Fixes bug when date-time is recognized as time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ New:
 
 Fixes:
 
+- Fixed date-time being recognized as date or time during parsing. Added
+  better error handling to parsing from ical strings.
+  [stlaz]
+
 - Added __version__ attribute to init.py
   [TomTry]
 

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -36,6 +36,7 @@ icalendar contributors
 - Ronan Dunklau <ronan@dunklau.fr>
 - Russ <russ@rw.id.au>
 - Sidnei da Silva <sidnei@enfoldsystems.com>
+- Stanislav Láznička <slaznick@redhat.com>
 - Stanislav Ochotnicky <sochotnicky@redhat.com>
 - Stefan Schwarzer <sschwarzer@sschwarzer.net>
 - Thomas Bruederli <thomas@roundcube.net>

--- a/src/icalendar/parser.py
+++ b/src/icalendar/parser.py
@@ -341,7 +341,7 @@ class Contentline(compat.unicode_type):
             return (name, params, values)
         except ValueError as exc:
             raise ValueError(
-                u"Content line could not be parsed into parts: %r: %s"
+                u"Content line could not be parsed into parts: '%s': %s"
                 % (self, exc)
             )
 

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -313,13 +313,15 @@ class vDDDTypes(object):
         u = ical.upper()
         if u.startswith(('P', '-P', '+P')):
             return vDuration.from_ical(ical)
-        try:
+
+        if len(ical) in (15, 16):
             return vDatetime.from_ical(ical, timezone=timezone)
-        except ValueError:
-            try:
-                return vDate.from_ical(ical)
-            except ValueError:
-                return vTime.from_ical(ical)
+        elif len(ical) == 8:
+            return vDate.from_ical(ical)
+        elif len(ical) in (6,7):
+            return vTime.from_ical(ical)
+        else:
+            raise ValueError("Expected datetime, date, or time, got: '%s'" % ical)
 
 
 class vDate(object):

--- a/src/icalendar/tests/test_fixed_issues.py
+++ b/src/icalendar/tests/test_fixed_issues.py
@@ -200,7 +200,9 @@ X
 END:VEVENT"""
         event = icalendar.Calendar.from_ical(ical_str)
         self.assertTrue(isinstance(event, icalendar.Event))
-        self.assertTrue(event.is_broken)
+        self.assertEqual(event.errors,
+            [(None, "Content line could not be parsed into parts: 'X': Invalid content line")]
+        )
 
     def test_issue_104__no_ignore_exceptions(self):
         """


### PR DESCRIPTION
Date-time was recognized incorrectly as a date or time. This resulted
in wrong representation of some iCalendar strings.

Also adds "errors" list in Component for saving error strings from parsing.

https://github.com/collective/icalendar/issues/174
https://github.com/collective/icalendar/issues/168
=============================================================
This is my first fork and pull request ever, hopefully I did it right.