### PR TITLE
IndexError fixes + bool(Component) to return True

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ New:
 
 Fixes:
 
+- Fixed possible IndexError exception during parsing of an ical string.
+  [stlaz]
+
 - Fixed date-time being recognized as date or time during parsing. Added
   better error handling to parsing from ical strings.
   [stlaz]

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -362,7 +362,10 @@ class Component(CaselessDict):
             # we are adding properties to the current top of the stack
             else:
                 factory = types_factory.for_property(name)
-                component = stack[-1]
+                component = stack[-1] if stack else None
+                if not component:
+                    raise ValueError('Property "{prop}" does not have '
+                                     'a parent component.'.format(prop=name))
                 datetime_names = ('DTSTART', 'DTEND', 'RECURRENCE-ID', 'DUE',
                                   'FREEBUSY', 'RDATE', 'EXDATE')
                 try:

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -93,6 +93,21 @@ class Component(CaselessDict):
     #    """
     #    return name in not_compliant
 
+    def __bool__(self):
+        """
+        Returns True, CaselessDict would return False if it had no items
+        """
+        return True
+
+    # python 2 compatibility
+    __nonzero__ = __bool__
+
+    def is_empty(self):
+        """
+        Returns True if Component has no items or subcomponents, else False
+        """
+        return True if not (list(self.values()) + self.subcomponents) else False
+
     #############################
     # handling of property values
 

--- a/src/icalendar/tests/test_fixed_issues.py
+++ b/src/icalendar/tests/test_fixed_issues.py
@@ -360,3 +360,12 @@ END:VCALENDAR"""
             b'DTEND:20150905T100000Z\r\nUID:123\r\n'
             b'END:VEVENT\r\nEND:VCALENDAR\r\n'
         )
+
+    def test_index_error_issue(self):
+        """
+        Found an issue where from_ical() would raise IndexError for properties
+        without parent components
+        """
+
+        with self.assertRaises(ValueError):
+            cal = icalendar.Calendar.from_ical('VERSION:2.0')

--- a/src/icalendar/tests/test_unit_cal.py
+++ b/src/icalendar/tests/test_unit_cal.py
@@ -18,9 +18,14 @@ class TestCalComponent(unittest.TestCase):
         c = Component()
         c.name = 'VCALENDAR'
 
+        self.assertTrue(c)
+        self.assertTrue(c.is_empty())
+
         # Every key defines a property.A property can consist of either a
         # single item. This can be set with a single value...
         c['prodid'] = '-//max m//icalendar.mxm.dk/'
+        self.assertFalse(c.is_empty())
+
         self.assertEqual(
             c,
             Calendar({'PRODID': '-//max m//icalendar.mxm.dk/'})


### PR DESCRIPTION
Hi,

Found an IndexError in Component.from_ical() at https://github.com/collective/icalendar/blob/master/src/icalendar/cal.py#L350 so I replaced it with ValueError instead.

Also added \_\_bool\_\_() in Component so the instances of the class return True on bool() check (https://github.com/collective/icalendar/issues/141). Without it, the check at https://github.com/collective/icalendar/blob/master/src/icalendar/cal.py#L317 might always fail and raise Exception even for Components with ignore_exceptions == True.