### PR TITLE
Fixes unknown component represented as known one

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ New:
 
 Fixes:
 
+- Fixed cal.Component.from_ical() representing an unknown component
+  as one of the known.
+  [stlaz]
+
 - Fixed date-time being recognized as date or time during parsing. Added
   better error handling to parsing from ical strings.
   [stlaz]

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -325,7 +325,7 @@ class Component(CaselessDict):
                 # try and create one of the components defined in the spec,
                 # otherwise get a general Components for robustness.
                 c_name = vals.upper()
-                c_class = component_factory.get(c_name, cls)
+                c_class = component_factory.get(c_name, Component)
                 component = c_class()
                 if not getattr(component, 'name', ''):  # undefined components
                     component.name = c_name

--- a/src/icalendar/tests/test_fixed_issues.py
+++ b/src/icalendar/tests/test_fixed_issues.py
@@ -360,3 +360,44 @@ END:VCALENDAR"""
             b'DTEND:20150905T100000Z\r\nUID:123\r\n'
             b'END:VEVENT\r\nEND:VCALENDAR\r\n'
         )
+
+    def test_issue_178(self):
+        """
+        Issue #178 - A component with an unknown/invalid name is represented
+        as one of the known components, the information about the original
+        component name is lost
+        """
+
+        # Parsing of a nonstandard component
+        ical_str = '\r\n'.join(['BEGIN:MYCOMP', 'END:MYCOMP'])
+        cal = icalendar.Calendar.from_ical(ical_str)
+        self.assertEqual(cal.to_ical(),
+                         b'BEGIN:MYCOMP\r\nEND:MYCOMP\r\n')
+
+        # Nonstandard component inside other components, also has properties
+        ical_str = '\r\n'.join(['BEGIN:VCALENDAR',
+                                'BEGIN:UNKNOWN',
+                                'UID:1234',
+                                'END:UNKNOWN',
+                                'END:VCALENDAR'])
+
+        cal = icalendar.Calendar.from_ical(ical_str)
+        self.assertEqual(cal.errors, [])
+        self.assertEqual(cal.to_ical(),
+                         b'BEGIN:VCALENDAR\r\nBEGIN:UNKNOWN\r\nUID:1234\r\n'
+                         b'END:UNKNOWN\r\nEND:VCALENDAR\r\n')
+
+        # Nonstandard component is able to contain other components
+        ical_str = '\r\n'.join(['BEGIN:MYCOMPTOO',
+                                'DTSTAMP:20150121T080000',
+                                'BEGIN:VEVENT',
+                                'UID:12345',
+                                'DTSTART:20150122',
+                                'END:VEVENT',
+                                'END:MYCOMPTOO'])
+        cal = icalendar.Calendar.from_ical(ical_str)
+        self.assertEqual(cal.errors, [])
+        self.assertEqual(cal.to_ical(),
+                         b'BEGIN:MYCOMPTOO\r\nDTSTAMP:20150121T080000\r\n'
+                         b'BEGIN:VEVENT\r\nDTSTART:20150122\r\nUID:12345\r\n'
+                         b'END:VEVENT\r\nEND:MYCOMPTOO\r\n')


### PR DESCRIPTION
from_ical() caused unknown an component to be represented as a known
one, losing the name information about the original component

https://github.com/collective/icalendar/issues/178

===================
The fix was rather trivial in the end