### PR TITLE
Reintroduce cal.Component.is_broken

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ New:
 Fixes:
 
 - Fix testsuite for use with ``dateutil>=2.5``. Refs #195.
+- Reintroduce cal.Component.is_broken that was removed with 3.9.2 [geier]
 
 
 3.9.2 (2016-02-05)

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -106,6 +106,10 @@ class Component(CaselessDict):
         """
         return True if not (list(self.values()) + self.subcomponents) else False  # noqa
 
+    @property
+    def is_broken(self):
+        return bool(self.errors)
+
     #############################
     # handling of property values
 

--- a/src/icalendar/tests/test_fixed_issues.py
+++ b/src/icalendar/tests/test_fixed_issues.py
@@ -200,6 +200,7 @@ X
 END:VEVENT"""
         event = icalendar.Calendar.from_ical(ical_str)
         self.assertTrue(isinstance(event, icalendar.Event))
+        self.assertTrue(event.is_broken)  # REMOVE FOR NEXT MAJOR RELEASE
         self.assertEqual(
             event.errors,
             [(None, "Content line could not be parsed into parts: 'X': Invalid content line")]  # noqa


### PR DESCRIPTION
cal.Component.is_broken got removed with 3.9.2 but should not have been
removed before 4.0.0

This should (partly) fix #184