### PR TITLE
Remove custom merge strategy for changelog

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-CHANGES.rst merge=union


### PR DESCRIPTION
This causes old PRs to add the changelog entry to already released
versions. It happened to me while rebasing #207