### PR TITLE
Drop requirement for setuptools package from setup.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 
 Breaking changes:
 
-- *add item here*
+- Removed ``setuptools`` as a dependency as it was only required by setup.py
+  and not by the package.
 
 New features:
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ with Python.
     :Homepage: http://icalendar.readthedocs.org
     :Code: http://github.com/collective/icalendar
     :Mailing list: http://github.com/collective/icalendar/issues
-    :Dependencies: `setuptools`_ and since version 3.0 we depend on `pytz`_.
+    :Dependencies: `python-dateutil`_ and `pytz`_.
     :Compatible with: Python 2.6, 2.7 and 3.3+
     :License: `BSD`_
 
@@ -72,8 +72,8 @@ a suggestion to icalendar-dev@codespeak.net to take over maintaining of
 .. _`icalendar`: http://pypi.python.org/pypi/icalendar
 .. _`plone.app.event`: http://github.com/plone/plone.app.event
 .. _`Plone`: http://plone.org
+.. _`python-dateutil`: https://github.com/dateutil/dateutil/
 .. _`pytz`: http://pypi.python.org/pypi/pytz
-.. _`setuptools`: http://pypi.python.org/pypi/setuptools
 .. _`RFC`: http://www.ietf.org/rfc/rfc5545.txt
 .. _`BSD`: https://github.com/collective/icalendar/issues/2
 
@@ -96,4 +96,3 @@ Output from coverage test::
     src/icalendar/tools               16      0   100%
     --------------------------------------------------
     TOTAL                           1152     81    93%
-

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ tests_require = []
 install_requires = [
     'python-dateutil',
     'pytz',
-    'setuptools',
 ]
 
 if sys.version_info[:2] == (2, 6):


### PR DESCRIPTION
setuptools is shipped with Python, no need to include it as a requirement. It
is bad form to include it as a requirement as pip will try to pull in the
latest version.