### PR TITLE
Assertion for VTIMEZONE sub-components' DTSTART

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- added an assertion that VTIMEZONE sub-components' DTSTART must be of type
+  DATETIME [geier]
 
 
 3.11.4 (2017-05-10)

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -575,6 +575,9 @@ class Timezone(Component):
         for component in self.walk():
             if type(component) == Timezone:
                 continue
+            assert isinstance(component['DTSTART'].dt, datetime), (
+                "VTIMEZONEs sub-components' DTSTART must be of type datetime, not date"
+            )
             try:
                 tzname = str(component['TZNAME'])
             except KeyError:


### PR DESCRIPTION
This deals with #218 so far, as it prints a proper warning when the assert is failing and prevents the creation of badly broken VEVENTS.