### PR TITLE
Fix non-ascii TZID and TZNAME handling in python 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix non-ASCII TZID and TZNAME parameter handling #237 [clivest]
 
 
 3.11.6 (2017-08-04)

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -52,6 +52,7 @@ icalendar contributors
 - tisto <tisto@plone.org>
 - TomTry <tom.try@gmail.com>
 - Andreas Ruppen <andreas.ruppen@gmail.com>
+- Clive Stevens <clivest2@gmail.com>
 
 Find out who contributed::
 


### PR DESCRIPTION
Following on from #237, I realised this problem only occurs when using python 2. I've done the inexact conversion to str only when running in python 2. This retains the full zone name in python 3 but unfortunately makes timezone handling slightly different when running in different python versions. What do you think?