### PR TITLE
Fix ResourceWarnings in setup.py when Python warnings are enabled

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,11 @@ with open('src/icalendar/__init__.py', 'rb') as f:
 
 
 shortdesc = 'iCalendar parser/generator'
-longdesc = codecs.open('README.rst', encoding='utf-8').read() + '\n'
-longdesc += codecs.open('CHANGES.rst', encoding='utf-8').read() + '\n'
-longdesc += codecs.open('LICENSE.rst', encoding='utf-8').read()
-
+longdesc = ''
+for fname in ['README.rst', 'CHANGES.rst', 'LICENSE.rst']:
+    with codecs.open(fname, encoding='utf-8') as f:
+        longdesc += f.read()
+        longdesc += '\n'
 
 tests_require = []
 install_requires = [


### PR DESCRIPTION
Always explicitly close files. Use a context manager to make this easier.