### PR TITLE
Fix invalid escape sequences in string and bytes literals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Bug fixes:
 
 - Fix non-ASCII TZID and TZNAME parameter handling #237 [clivest]
 - Wiki: update install instruction
+- Fix invalid escape sequences in string and bytes literals
 - *add item here*
 
 

--- a/src/icalendar/parser.py
+++ b/src/icalendar/parser.py
@@ -39,11 +39,11 @@ def unescape_char(text):
                    .replace(u'\\;', u';')\
                    .replace(u'\\\\', u'\\')
     elif isinstance(text, compat.bytes_type):
-        return text.replace(b'\N', b'\n')\
+        return text.replace(b'\\N', b'\\n')\
                    .replace(b'\r\n', b'\n')\
                    .replace(b'\n', b'\n')\
-                   .replace(b'\,', b',')\
-                   .replace(b'\;', b';')\
+                   .replace(b'\\,', b',')\
+                   .replace(b'\\;', b';')\
                    .replace(b'\\\\', b'\\')
 
 
@@ -109,8 +109,8 @@ def param_value(value):
 # Could be improved
 
 # [\w-] because of the iCalendar RFC
-# \. because of the vCard RFC
-NAME = re.compile('[\w\.-]+')
+# . because of the vCard RFC
+NAME = re.compile(r'[\w.-]+')
 
 UNSAFE_CHAR = re.compile('[\x00-\x08\x0a-\x1f\x7F",:;]')
 QUNSAFE_CHAR = re.compile('[\x00-\x08\x0a-\x1f\x7F"]')

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -71,8 +71,8 @@ DATETIME_PART = '(?:%s)?(?:%s)?' % (DATE_PART, TIME_PART)
 WEEKS_PART = r'(\d+)W'
 DURATION_REGEX = re.compile(r'([-+]?)P(?:%s|%s)$'
                             % (WEEKS_PART, DATETIME_PART))
-WEEKDAY_RULE = re.compile('(?P<signal>[+-]?)(?P<relative>[\d]?)'
-                          '(?P<weekday>[\w]{2})$')
+WEEKDAY_RULE = re.compile(r'(?P<signal>[+-]?)(?P<relative>[\d]?)'
+                          r'(?P<weekday>[\w]{2})$')
 
 
 ####################################################

--- a/src/icalendar/tests/test_fixed_issues.py
+++ b/src/icalendar/tests/test_fixed_issues.py
@@ -155,7 +155,7 @@ END:VEVENT"""
 
         https://github.com/collective/icalendar/issues/101
         """
-        ical_str = """BEGIN:VCALENDAR
+        ical_str = r"""BEGIN:VCALENDAR
 VERSION:2.0
 X-WR-CALNAME:Kalender von acme\, admin
 PRODID:-//The Horde Project//Horde_iCalendar Library\, Horde 3.3.5//EN

--- a/src/icalendar/tests/test_property_params.py
+++ b/src/icalendar/tests/test_property_params.py
@@ -212,5 +212,5 @@ END:VCALENDAR"""
         """
         it = Parameters(parameter1='Value1')
         self.assertTrue(
-            re.match("Parameters\({u?'PARAMETER1': 'Value1'}\)", str(it))
+            re.match(r"Parameters\({u?'PARAMETER1': 'Value1'}\)", str(it))
         )

--- a/src/icalendar/tests/test_unit_cal.py
+++ b/src/icalendar/tests/test_unit_cal.py
@@ -322,21 +322,21 @@ class TestCalComponent(unittest.TestCase):
         component['key1'] = 'value1'
 
         self.assertTrue(
-            re.match("Component\({u?'KEY1': 'value1'}\)", str(component))
+            re.match(r"Component\({u?'KEY1': 'value1'}\)", str(component))
         )
 
         calendar = Calendar()
         calendar['key1'] = 'value1'
 
         self.assertTrue(
-            re.match("VCALENDAR\({u?'KEY1': 'value1'}\)", str(calendar))
+            re.match(r"VCALENDAR\({u?'KEY1': 'value1'}\)", str(calendar))
         )
 
         event = Event()
         event['key1'] = 'value1'
 
         self.assertTrue(
-            re.match("VEVENT\({u?'KEY1': 'value1'}\)", str(event))
+            re.match(r"VEVENT\({u?'KEY1': 'value1'}\)", str(event))
         )
 
         # Representation of nested Components
@@ -347,7 +347,7 @@ class TestCalComponent(unittest.TestCase):
 
         self.assertTrue(
             re.match(
-                "Component\({u?'KEY1': 'VALUE1'}, Component\({u?'KEY1': 'value1'}\), VCALENDAR\({u?'KEY1': 'value1'}, VEVENT\({u?'KEY1': 'value1'}\)\)\)",  # nopep8
+                r"Component\({u?'KEY1': 'VALUE1'}, Component\({u?'KEY1': 'value1'}\), VCALENDAR\({u?'KEY1': 'value1'}, VEVENT\({u?'KEY1': 'value1'}\)\)\)",  # nopep8
                 str(nested)
             )
         )

--- a/src/icalendar/tests/test_unit_prop.py
+++ b/src/icalendar/tests/test_unit_prop.py
@@ -354,7 +354,7 @@ class TestProp(unittest.TestCase):
                          u'Text ; with escaped, chars')
 
         t = vText.from_ical('A string with\\; some\\\\ characters in\\it')
-        self.assertEqual(t, "A string with; some\\ characters in\it")
+        self.assertEqual(t, "A string with; some\\ characters in\\it")
 
         # We are forgiving to utf-8 encoding errors:
         # We intentionally use a string with unexpected encoding


### PR DESCRIPTION
Invalid escape sequences have been deprecated in Python 3.6. See:

https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior

> A backslash-character pair that is not a valid escape sequence now generates a DeprecationWarning. Although this will eventually become a SyntaxError, that will not be for several Python releases.

When warnings are enabled, this appears as:

```
DeprecationWarning: invalid escape sequence ...
```

Sequences discovered through test suite.