### PR TITLE
Add pip cache support to Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - "2.6"
   - "2.7"


### PR DESCRIPTION
Can slightly improve build times and reduce load on PyPI servers.

For documentation on cache support, see:

https://docs.travis-ci.com/user/caching/#pip-cache