### PR TITLE
Quote all version strings in Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 cache: pip
 python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
-  - pypy
-  - pypy3
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "pypy"
+  - "pypy3"
 install:
   - pip install tox
 script:


### PR DESCRIPTION
Per the feedback from @polyzen in PR #246, in YAML, numeric bare strings are interpreted as floats, not strings. Versions are strings and should not be coerced to a float. For example, 7.10 isn't the same as 7.1.

For more details, see Travis issue:

https://github.com/travis-ci/docs-travis-ci-com/pull/1537