### PR TITLE
Get version in docs without pkg_resources

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 # icalendar documentation build configuration file
-import pkg_resources
 import datetime
 import os
+import sys
 
+base_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '..')
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+sys.path.append(os.path.join(base_dir, 'src'))
 
 try:
     import sphinx_rtd_theme
@@ -29,7 +32,16 @@ master_doc = 'index'
 project = u'icalendar'
 this_year = datetime.date.today().year
 copyright = u'{}, Plone Foundation'.format(this_year)
-version = pkg_resources.get_distribution('icalendar').version
+
+# Read the version number
+with open(os.path.join(base_dir, 'src/icalendar/__init__.py')) as f:
+    for line in f.readlines():
+        if line.startswith('__version__'):
+            version_info = {}
+            exec(line, None, version_info)
+            version = version_info['__version__']
+            break
+
 release = version
 
 exclude_patterns = ['_build', 'lib', 'bin', 'include', 'local']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 # icalendar documentation build configuration file
+import ast
 import datetime
 import os
+import re
 import sys
 
 base_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), '..')
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+_version_re = re.compile(r'__version__\s+=\s+(.*)')
 
 sys.path.append(os.path.join(base_dir, 'src'))
 
@@ -35,12 +38,8 @@ copyright = u'{}, Plone Foundation'.format(this_year)
 
 # Read the version number
 with open(os.path.join(base_dir, 'src/icalendar/__init__.py')) as f:
-    for line in f.readlines():
-        if line.startswith('__version__'):
-            version_info = {}
-            exec(line, None, version_info)
-            version = version_info['__version__']
-            break
+    version = str(ast.literal_eval(_version_re.search(
+        f.read().decode('utf-8')).group(1)))
 
 release = version
 

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,3 +1,2 @@
 Sphinx>=1.2.3
 sphinx_rtd_theme
-.


### PR DESCRIPTION
- Reads the version from `icalendar/__init__.py`
- Appends the path to icalendar to the Python path like how the sphinx-quickstart sample `conf.py` recommends

This should fix the docs build on Read the Docs which hasn't built in a [few years](http://readthedocs.org/projects/icalendar/builds/).