### PR TITLE
Remove unnecessary compat shim, bytes

### DIFF
--- a/src/icalendar/compat.py
+++ b/src/icalendar/compat.py
@@ -4,9 +4,7 @@ import sys
 
 if sys.version_info[0] == 2:  # pragma: no cover
     unicode_type = unicode
-    bytes_type = str
     iteritems = lambda d, *args, **kwargs: iter(d.iteritems(*args, **kwargs))
 else:  # pragma: no cover
     unicode_type = str
-    bytes_type = bytes
     iteritems = lambda d, *args, **kwargs: iter(d.items(*args, **kwargs))

--- a/src/icalendar/parser.py
+++ b/src/icalendar/parser.py
@@ -20,7 +20,7 @@ import re
 def escape_char(text):
     """Format value according to iCalendar TEXT escaping rules.
     """
-    assert isinstance(text, (compat.unicode_type, compat.bytes_type))
+    assert isinstance(text, (compat.unicode_type, bytes))
     # NOTE: ORDER MATTERS!
     return text.replace(r'\N', '\n')\
                .replace('\\', '\\\\')\
@@ -31,7 +31,7 @@ def escape_char(text):
 
 
 def unescape_char(text):
-    assert isinstance(text, (compat.unicode_type, compat.bytes_type))
+    assert isinstance(text, (compat.unicode_type, bytes))
     # NOTE: ORDER MATTERS!
     if isinstance(text, compat.unicode_type):
         return text.replace('\\N', '\\n')\
@@ -40,7 +40,7 @@ def unescape_char(text):
                    .replace('\\,', ',')\
                    .replace('\\;', ';')\
                    .replace('\\\\', '\\')
-    elif isinstance(text, compat.bytes_type):
+    elif isinstance(text, bytes):
         return text.replace(b'\\N', b'\\n')\
                    .replace(b'\r\n', b'\n')\
                    .replace(b'\n', b'\n')\

--- a/src/icalendar/parser_tools.py
+++ b/src/icalendar/parser_tools.py
@@ -11,7 +11,7 @@ def to_unicode(value, encoding='utf-8'):
     """
     if isinstance(value, compat.unicode_type):
         return value
-    elif isinstance(value, compat.bytes_type):
+    elif isinstance(value, bytes):
         try:
             value = value.decode(encoding)
         except UnicodeDecodeError:


### PR DESCRIPTION
The bytes type is available on Python 2.7 & Python 3. On Python 2.7, it
is an alias of str, same as the previous value defined in compat.py.
Makes the code slightly more forward compatible with Python 3 syntax.
Observe:

    $ python2
    >>> bytes
    <type 'str'>