### PR TITLE
fix variable typo

### DIFF
--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -271,7 +271,7 @@ class vCategory(object):
 
     def __init__(self, c_list):
         if not hasattr(c_list, '__iter__'):
-            d_list = [c_list]
+            c_list = [c_list]
         self.cats = [vText(c) for c in c_list]
 
     def to_ical(self):


### PR DESCRIPTION
I was browsing the code related to an issue I had with [khal](https://github.com/pimutils/khal). I'm not sure why it doesn't break anything, but this was probably a typo.