### PR TITLE
Add a readthedocs config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,21 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: requirements_docs.txt
+    - method: pip
+      path: .

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed a docs issue related to building on Read the Docs [davidfischer]
 
 
 4.0.3 (2018-10-10)


### PR DESCRIPTION
Add a [Read the Docs configuration file](https://docs.readthedocs.io/en/stable/config-file/v2.html). This config file has a few advantages:

* Versioning your Read the Docs build options (eg. the requirements file, Python version) rather than having those live only in the RTD dashboard.
* There are some things that can only be configured in the config file although icalendar doesn't rely on them currently.

The [current build](https://readthedocs.org/projects/icalendar/builds/9067589/) on Read the Docs is failing. There are a few issues but I verified that this config file would solve them:

* The docs requirements file isn't installed and so `icalendar` itself isn't installed. The docs build relies on this package being installed.
* The requirements file specifies installing `.` which only works if `pip install` is run from the same directory.

This is an alternative to #262 and if this is merged that one can be closed.