### PR TITLE
Calm down fuzzing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Reduce Hypothesis iterations to speed up testing, allowing PRs to pass
+  [UniversalSuperBox]
 
 
 4.0.3 (2018-10-10)

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -54,6 +54,7 @@ icalendar contributors
 - TomTry <tom.try@gmail.com>
 - Andreas Ruppen <andreas.ruppen@gmail.com>
 - Clive Stevens <clivest2@gmail.com>
+- Dalton Durst <github@daltondur.st>
 
 Find out who contributed::
 

--- a/src/icalendar/tests/hypothesis/test_fuzzing.py
+++ b/src/icalendar/tests/hypothesis/test_fuzzing.py
@@ -17,14 +17,13 @@ def printable_characters(**kw):
 key = st.text(string.ascii_letters + string.digits, min_size=1)
 value = printable_characters(blacklist_characters='\\;:\"')
 
-
 class TestFuzzing(unittest.TestCase):
 
     @given(lines=st.lists(
         st.tuples(key, st.dictionaries(key, value), value),
         min_size=1
     ))
-    @settings(max_examples=10**9)
+    @settings(max_examples=10**4)
     def test_main(self, lines):
         cl = Contentlines()
         for key, params, value in lines:


### PR DESCRIPTION
The fuzzing configuration introduced by https://github.com/collective/icalendar/pull/191 *did* find a novel issue in its first run. However, it is unable to run on travis-ci due to taking too long without output. I tried running it locally to make sure it wasn't Travis being Travis, and sure enough, on my i9-9880H, the operation took well over 20 minutes before I stopped it.

Because of this, I've reduced the number of examples that Hypothesis will run. This will catch fewer errors but help us get PRs back on track.

Ping @untitaker, who introduced this change originally