### PR TITLE
Default type vText when converting vRecur to ical

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ New features:
 Bug fixes:
 
 - Fixed a docs issue related to building on Read the Docs [davidfischer]
+- Use ``vText`` as default type, when convert recurrence definition to ical string. [kam193] 
 
 
 4.0.4 (2019-11-25)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Bug fixes:
 
 - Fixed a docs issue related to building on Read the Docs [davidfischer]
 - Use ``vText`` as default type, when convert recurrence definition to ical string. [kam193] 
+- Enable CI for Python 3.7 and more reduce Hypothesis iteration due to CI timeout. [kam193]
 
 
 4.0.4 (2019-11-25)

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -55,6 +55,7 @@ icalendar contributors
 - Andreas Ruppen <andreas.ruppen@gmail.com>
 - Clive Stevens <clivest2@gmail.com>
 - Dalton Durst <github@daltondur.st>
+- Kamil Mańkowski <kam193@wp.pl>
 
 Find out who contributed::
 

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -673,7 +673,7 @@ class vRecur(CaselessDict):
     def to_ical(self):
         result = []
         for key, vals in self.sorted_items():
-            typ = self.types[key]
+            typ = self.types.get(key, vText)
             if not isinstance(vals, SEQUENCE_TYPES):
                 vals = [vals]
             vals = b','.join(typ(val).to_ical() for val in vals)

--- a/src/icalendar/tests/test_unit_prop.py
+++ b/src/icalendar/tests/test_unit_prop.py
@@ -332,6 +332,11 @@ class TestProp(unittest.TestCase):
         # and some errors
         self.assertRaises(ValueError, vRecur.from_ical, 'BYDAY=12')
 
+        # when key is not RFC-compliant, parse it as vText
+        r = vRecur.from_ical('FREQ=MONTHLY;BYOTHER=TEXT;BYEASTER=-3')
+        self.assertEqual(vRecur(r).to_ical(),
+                         b'FREQ=MONTHLY;BYEASTER=-3;BYOTHER=TEXT')
+
     def test_prop_vText(self):
         from ..prop import vText
 


### PR DESCRIPTION
Use default type `vText` when converting recurrence definition to ical string. 

This is similar to `from_ical` behavior, that allows to set anything as recurrence key and treats it as `vText`; but at the same time, `to_ical` has strictly limited list of supported types and no default type, so the rule `x == vDataType.from_ical(VDataType(x).to_ical())` (from https://github.com/collective/icalendar/blob/master/src/icalendar/prop.py#L33) is broken. 

Furthermore, with this we can use non-standard recurrence keys (like `BYEASTER` supported by `deteutil`). 

This is a fix without breaking changes. 