### PR TITLE
Correct the handling of rrules within timezone definitions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- fixed rrule handling, re-enabled test_create_america_new_york()
 
 
 4.0.4 (2019-11-25)

--- a/src/icalendar/tests/test_timezoned.py
+++ b/src/icalendar/tests/test_timezoned.py
@@ -149,14 +149,9 @@ class TestTimezoned(unittest.TestCase):
 
 class TestTimezoneCreation(unittest.TestCase):
 
-    @unittest.expectedFailure
     def test_create_america_new_york(self):
         """testing America/New_York, the most complex example from the
         RFC"""
-        # FIXME
-        # This currently fails because of mixed naive and timezone
-        # aware datetimes in dtstart and until which breaks
-        # dateutil recurrence.
 
         directory = os.path.dirname(__file__)
         with open(os.path.join(directory, 'america_new_york.ics'), 'rb') as fp:


### PR DESCRIPTION
Fix for https://github.com/collective/icalendar/issues/303

This also reactivates the testcase that used to fail.