### PR TITLE
replace substrings of type byte instead of string

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -102,7 +102,7 @@ The rendered view is easier to read::
 So, let's define a function so we can easily display to_ical() output::
 
   >>> def display(cal):
-  ...    return cal.to_ical().replace('\r\n', '\n').strip()
+  ...    return cal.to_ical().replace(b'\r\n', b'\n').strip()
 
 You can set multiple properties like this::
 


### PR DESCRIPTION
`to_ical()` returns a `bytes` object, not a string 

"The methods on bytes and bytearray objects don’t accept strings as their arguments, just as the methods on strings don’t accept bytes as their arguments."
https://docs.python.org/3/library/stdtypes.html#bytes-and-bytearray-operations