### PR TITLE
Maurits/improve testing

### DIFF
--- a/src/icalendar/tests/hypothesis/test_fuzzing.py
+++ b/src/icalendar/tests/hypothesis/test_fuzzing.py
@@ -23,7 +23,7 @@ class TestFuzzing(unittest.TestCase):
         st.tuples(key, st.dictionaries(key, value), value),
         min_size=1
     ))
-    @settings(max_examples=10**4)
+    @settings(max_examples=10**3)
     def test_main(self, lines):
         cl = Contentlines()
         for key, params, value in lines:

--- a/src/icalendar/tests/hypothesis/test_fuzzing.py
+++ b/src/icalendar/tests/hypothesis/test_fuzzing.py
@@ -27,7 +27,11 @@ class TestFuzzing(unittest.TestCase):
     def test_main(self, lines):
         cl = Contentlines()
         for key, params, value in lines:
-            params = Parameters(**params)
+            try:
+                params = Parameters(**params)
+            except TypeError:
+                # Happens when there is a random parameter 'self'...
+                continue
             cl.append(Contentline.from_parts(key, params, value))
         cl.append('')
 


### PR DESCRIPTION
Mostly, the tests on Travis often take too much time and cause Travis to timeout and fail after ten minutes.  See also https://github.com/collective/icalendar/pull/289#issuecomment-594219490

And there was a crazy TypeError in one Travis run.