### PR TITLE
UTC tzid fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Timestamps in UTC does not need tzid
+  Ref: #338
+  Fixes: #335
 
 
 4.0.9 (2021-10-16)

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -305,12 +305,9 @@ class vDDDTypes(object):
         if (isinstance(dt, datetime) or isinstance(dt, time))\
                 and getattr(dt, 'tzinfo', False):
             tzinfo = dt.tzinfo
-            if tzinfo is not pytz.utc and\
-               (tzutc is None or not isinstance(tzinfo, tzutc)):
-                # set the timezone as a parameter to the property
-                tzid = tzid_from_dt(dt)
-                if tzid:
-                    self.params.update({'TZID': tzid})
+            tzid = tzid_from_dt(dt)
+            if tzid != 'UTC':
+                self.params.update({'TZID': tzid})
         self.dt = dt
 
     def to_ical(self):


### PR DESCRIPTION
This is a patch to prevent the UTC tzid to be shown when passing datestamps with tzid=utc, and utc is not pytz.utc

Test code is missing as for now.  (I'm curious if the test code passes, as it didn't pass for #334).