### PR TITLE
add badges for download and PyPI version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,13 @@ files.
 .. image:: https://travis-ci.org/collective/icalendar.svg?branch=master
     :target: https://travis-ci.org/collective/icalendar
 
+.. image:: https://badge.fury.io/py/icalendar.svg
+   :target: https://pypi.org/project/icalendar/
+   :alt: Python Package Version on PyPI
+
+.. image:: https://img.shields.io/pypi/dm/icalendar.svg
+   :target: https://pypi.org/project/icalendar/#files
+   :alt: Downloads from PyPI
 
 .. _`icalendar`: https://pypi.org/project/icalendar/
 .. _`RFC 5545`: https://www.ietf.org/rfc/rfc5545.txt


### PR DESCRIPTION
It adds two badges.

![](https://badge.fury.io/py/icalendar.svg)
shows which version is there - quite useful to know and nice to see that it changes after deploy

![](https://img.shields.io/pypi/dm/icalendar.svg)
makes sure we know that this is important and used a lot!