### PR TITLE
describe purpose of the branches master and 4.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Since we pour more `effort into maintaining and developing icalendar <https://gi
 we split the project into two:
 
 - `Branch ``4.x`` <https://github.com/collective/icalendar/tree/4.x>`__ with maximum compatibility to Python versions ``2.7`` and ``3.4+``, ``PyPy2`` and ``PyPy3``.
-- `Branch ``master`` <https://github.com/collective/icalendar/>`__ with the compatibility to Python versions ``3.8+`` and ``PyPy3``.
+- `Branch ``master`` <https://github.com/collective/icalendar/>`__ with the compatibility to Python versions ``3.7+`` and ``PyPy3``.
 
 We expect the ``master`` branch with versions ``5+`` receive the latest updates and features,
 and the ``4.x`` branch the subset of security and bug fixes only.

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,22 @@ files.
 .. _`pytz`: https://pypi.org/project/pytz/
 .. _`BSD`: https://github.com/collective/icalendar/issues/2
 
+Versions and Compatibility
+--------------------------
+
+``icalendar`` is a critical project used by many. It has been there for a long time and maintaining
+long-term compatibility with projects conflicts partially with providing and using the features that
+the latest Python versions bring.
+
+Since we pour more `effort into maintaining and developing icalendar <https://github.com/collective/icalendar/discussions/360>`__,
+we split the project into two:
+
+- `Branch ``4.x`` <https://github.com/collective/icalendar/tree/4.x>`__ with maximum compatibility to Python versions ``2.7`` and ``3.4+``, ``PyPy2`` and ``PyPy3``.
+- `Branch ``master`` <https://github.com/collective/icalendar/>`__ with the compatibility to Python versions ``3.8+`` and ``PyPy3``.
+
+We expect the ``master`` branch with versions ``5+`` receive the latest updates and features,
+and the ``4.x`` branch the subset of security and bug fixes only.
+We recomment migrating to later Python versions and also providing feedback if you depend on the ``4.x`` features.
 
 Related projects
 ================


### PR DESCRIPTION
@mauritsvanrees @geier
I created this PR to make the purpose of the branches clear.
There is some difference between the branch purpose as pointed out in https://github.com/collective/icalendar/discussions/360:

> Increase master branch version to 5 (or 6 if needed). This should keep working on Plone 6.0 (which is near beta), which means Python 3.7-3.10.

and this PR https://github.com/collective/icalendar/pull/366

> [Require Python 3.8.](https://github.com/collective/icalendar/pull/366/commits/c73cab2c101beaf2a13c7e8d7037da3340123033)

How to approach this?