### PR TITLE
ignore venv folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ src/icalendar.egg-info/
 !.gitattributes
 !.github
 !.gitignore
+venv

--- a/venv/pyvenv.cfg
+++ b/venv/pyvenv.cfg
@@ -1,3 +1,0 @@
-home = /usr/bin
-include-system-site-packages = false
-version = 3.10.6


### PR DESCRIPTION
This deletes and ignores a folder people use for testing.

see https://github.com/collective/icalendar/pull/324/files#diff-1da1691e79f01938d280502610d5e64a64ca71ef6efaa9fa5addbc4a8082843b