### PR TITLE
Add missing mandatory fields to user generated components

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,9 +66,8 @@ Related projects
 Examples
 ================
 Create a calendear and add an event to it (master branch)
-..example-code::
 
-    .. codeblock:: python
+.. code-block:: python
 
     #!/usr/bin/env python3
     from dateutil import tz
@@ -100,15 +99,15 @@ Create a calendear and add an event to it (master branch)
         main()
 
 
-    You can view it with the handy CLI tool by:
+You can view it with the handy CLI tool by:
 
-    .. codeblock:: bash
+.. code-block:: text
 
     python SCRIPT-NAME.py > sample.ics && pythom -m icalendar.cli sample.ics
 
-    Create a ics file with 5 alarms, each 10 minutes apart
+Create a ics file with 5 alarms, each 10 minutes apart
 
-    .. codeblock:: python
+.. code-block:: python
 
     #!/usr/bin/env python3
     from datetime import datetime, timedelta

--- a/README.rst
+++ b/README.rst
@@ -61,3 +61,73 @@ Related projects
 * `icalevents <https://github.com/irgangla/icalevents>`_. It is built on top of icalendar and allows you to query iCal files and get the events happening on specific dates. It manages recurrent events as well.
 * `recurring-ical-events <https://pypi.org/project/recurring-ical-events/>`_. Library to query an ``ICalendar`` object for events happening at a certain date or within a certain time.
 * `x-wr-timezone <https://pypi.org/project/x-wr-timezone/>`_. Library to make ``ICalendar`` objects and files using the non-standard ``X-WR-TIMEZONE`` compliant with the standard (RFC 5545).
+
+
+Examples
+================
+Create a calendear and add an event to it (master branch)
+..example-code::
+
+    .. codeblock:: python
+
+    #!/usr/bin/env python3
+    from dateutil import tz
+    from datetime import datetime
+
+    from icalendar import ComponentWithRequiredFieldsFactory, vDatetime
+
+    def main():
+        component_factory = ComponentWithRequiredFieldsFactory(tzid='Europe/Warsaw')
+
+        calendar = component_factory['VCALENDAR']()
+        event = component_factory['VEVENT'](
+                DTSTART=vDDDTypes(datetime.now()),
+                DTEND=vDDDTypes(datetime(year=2050, month=7, day=22, hour=12)),
+                SUMMARY='A sentence succinctly describing the event',
+                LOCATION='Where the event will take place',
+                ORGANIZER='organizer@example.com',
+                DESCRIPTION='Longer and more detailed version of the summary\nIt can also be multi-line',
+                COMMENT='A comment')
+        event.add('attendee', 'attendee@example.com')
+        event.add('attendee', 'attendee1@example.com')
+        timezone = component_factory['VTIMEZONE']()
+        calendar.add_component(timezone)
+        calendar.add_component(event)
+        print(calendar.to_ical().decode('utf-8'))
+
+
+    if __name__ == '__main__':
+        main()
+
+
+    You can view it with the handy CLI tool by:
+
+    .. codeblock:: bash
+
+    python SCRIPT-NAME.py > sample.ics && pythom -m icalendar.cli sample.ics
+
+    Create a ics file with 5 alarms, each 10 minutes apart
+
+    .. codeblock:: python
+
+    #!/usr/bin/env python3
+    from datetime import datetime, timedelta
+
+    from icalendar import ComponentWithRequiredFieldsFactory, vDatetime
+
+    def main():
+        now = datetime.now()
+        alarms_triggers = [now + timedelta(minutes=10 * i) for i in range(5)]
+        component_factory = ComponentWithRequiredFieldsFactory(tzid='Europe/Warsaw', alarm_trigger_supplier=lambda: alarms_triggers.pop())
+
+        calendar = component_factory['VCALENDAR']()
+        calendar.add_component(component_factory['VTIMEZONE']())
+
+        for _ in alarms_triggers:
+            calendar.add_component(component_factory['VALARM']())
+
+        print(calendar.to_ical().decode('utf-8'))
+
+    if __name__ == '__main__':
+        main()
+

--- a/src/icalendar/__init__.py
+++ b/src/icalendar/__init__.py
@@ -11,6 +11,7 @@ from icalendar.cal import (
     FreeBusy,
     Alarm,
     ComponentFactory,
+    ComponentWithRequiredFieldsFactory,
 )
 # Property Data Value Types
 from icalendar.prop import (

--- a/src/icalendar/tests/test_unit_cal.py
+++ b/src/icalendar/tests/test_unit_cal.py
@@ -6,7 +6,6 @@ import icalendar
 import pytz
 import re
 
-
 class TestCalComponent(unittest.TestCase):
 
     def test_cal_Component(self):
@@ -356,7 +355,6 @@ class TestCalComponent(unittest.TestCase):
 
 
 class TestCal(unittest.TestCase):
-
     def test_cal_ComponentFactory(self):
         ComponentFactory = icalendar.cal.ComponentFactory
         factory = ComponentFactory()
@@ -370,6 +368,18 @@ class TestCal(unittest.TestCase):
         self.assertEqual(
             factory.get('VCALENDAR', icalendar.cal.Component),
             icalendar.cal.Calendar)
+
+    def test_cal_ComponentWithRequiredFieldsFactory_properly_creates_components(self):
+        from icalendar.cal import Event, Journal, Todo, FreeBusy, Timezone, TimezoneStandard, TimezoneDaylight, Alarm, Calendar
+        names = ['VEVENT', 'VTODO', 'VJOURNAL', 'VFREEBUSY', 'VTIMEZONE', 'VALARM', 'VCALENDAR']
+        component_types = [Event, Todo, Journal, FreeBusy, Timezone, Alarm, Calendar]
+
+        component_factory = icalendar.cal.ComponentWithRequiredFieldsFactory(alarm_trigger_supplier=lambda: datetime.now())
+        for name, component_type in zip(names, component_types):
+            component = component_factory[name]()
+            self.assertIsInstance(component, component_type)
+            for required_field in component.required:
+                self.assertIn(required_field, component)
 
     def test_cal_Calendar(self):
         # Setting up a minimal calendar component looks like this


### PR DESCRIPTION
This pull requests attempts to solve #315 by exposing a new ComponentFactory that's supposed to be 'user-firendly'.  I added some examples in the README.

I think it wouldn't be correct to make the old ComponentFactory return components with all the required fields, since that might  overwrite some properties during parsing that we wouldn't want to overwritten, e.g [DTSTAMP](https://www.rfc-editor.org/rfc/rfc5545#section-3.8.7.2) on events. Moreover, if parsed components don't provide them, I don't think a parser should fix that implicitly, but rather throw an error.

Lastly, I need some help with figuring out what should be put in the DTSTART field inside the TimeZoneStandard/TimeZoneDaylight component, the RFC says that it ought to be 'the effective onset date and local time for the time zone sub-component', but I have no clue how to get the value using the libraries.