### PR TITLE
Revert "fix Sphinx build"

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,3 @@
-Sphinx>=1.2.3 
-Sphinx<=5.1.1
+Sphinx>=1.2.3
 sphinx_rtd_theme
 .


### PR DESCRIPTION
This reverts commit f4b50d6b9621f71f5fb1c128dd010789093603e8.

This is to check if the usual, non-pinned installation works like it did before.

fixes #419