### PR TITLE
remove getattr() call where [] can be used

### DIFF
--- a/src/icalendar/tests/test_parsing.py
+++ b/src/icalendar/tests/test_parsing.py
@@ -10,7 +10,8 @@ from icalendar import vRecur
 ])
 def test_event_to_ical_is_inverse_of_from_ical(events, event_name):
     """Make sure that an event's ICS is equal to the ICS it was made from."""
-    assert events[event_name].to_ical() == event.raw_ics
+    event = events[event_name]
+    assert event.to_ical() == event.raw_ics
 
 def test_decode_rrule_attribute_error_issue_70(events):
     # Issue #70 - e.decode("RRULE") causes Attribute Error

--- a/src/icalendar/tests/test_parsing.py
+++ b/src/icalendar/tests/test_parsing.py
@@ -9,8 +9,8 @@ from icalendar import vRecur
     ('issue_184_broken_representation_of_period'),
 ])
 def test_event_to_ical_is_inverse_of_from_ical(events, event_name):
-    event = getattr(events, event_name)
-    assert event.to_ical() == event.raw_ics
+    """Make sure that an event's ICS is equal to the ICS it was made from."""
+    assert events[event_name].to_ical() == event.raw_ics
 
 def test_decode_rrule_attribute_error_issue_70(events):
     # Issue #70 - e.decode("RRULE") causes Attribute Error


### PR DESCRIPTION
Using getattr can be avoided by using getitem