### PR TITLE
add badge for https://readthedocs.org/projects/icalendar/

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,10 @@ files.
     :target: https://github.com/collective/icalendar/actions/workflows/tests.yml?query=branch%3A4.x++
     :alt: GitHub Actions build status for 4.x
 
+.. image:: https://readthedocs.org/projects/icalendar/badge/?version=latest
+    :target: https://icalendar.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
+
 .. _`icalendar`: https://pypi.org/project/icalendar/
 .. _`RFC 5545`: https://www.ietf.org/rfc/rfc5545.txt
 .. _`python-dateutil`: https://github.com/dateutil/dateutil/


### PR DESCRIPTION
This refers to https://github.com/collective/icalendar/issues/325

The idea: We want to know when the readTheDocs build fails.