### PR TITLE
fix setuptools deprecation warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 Minor changes:
 
-- ...
+- fixed setuptools deprecation warnings [mgorny]
 
 Breaking changes:
 

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -63,6 +63,7 @@ icalendar contributors
 - jacadzaca <vitouejj@gmail.com>
 - Mauro Amico <mauro.amico@gmail.com>
 - Alexander Pitkin <peleccom@gmail.com>
+- Michał Górny <mgorny@gentoo.org>
 
 Find out who contributed::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ create-wheel = yes
 universal = 1
 
 [metadata]
-license_file = LICENSE.rst
+license_files = LICENSE.rst
 
 [tool:pytest]
 norecursedirs = .* env* docs *.egg src/icalendar/tests/hypothesis

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setuptools.setup(
     author_email='plone-developers@lists.sourceforge.net',
     url='https://github.com/collective/icalendar',
     license='BSD',
-    packages=setuptools.find_packages('src'),
+    packages=setuptools.find_namespace_packages('src'),
     package_dir={'': 'src'},
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Fixes two setuptools deprecation warnings:

1. "The license_file parameter is deprecated, use license_files instead."
2. "Installing 'icalendar.tests.calendars' as data is deprecated, please list it in `packages`." and alike

The second one I've fixed the "easier" way by using `find_namespace_packages()`. If you prefer, I can change that to adding `__init__.py` files to all icalendar/tests subdirectories.