### PR TITLE
Do not create a universal wheel for the release.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,10 +7,9 @@ ignore =
 
 [zest.releaser]
 python-file-with-version = src/icalendar/__init__.py
-create-wheel = yes
 
 [bdist_wheel]
-universal = 1
+universal = 0
 
 [metadata]
 license_files = LICENSE.rst


### PR DESCRIPTION
Very minor thing: I see that release [5.0.0 has a universal wheel](https://pypi.org/project/icalendar/5.0.0/#files), but the package is Python 3 only.
And `zest.releaser.create-wheel` is not needed, since we already have a `bdist_wheel` section.