### PR TITLE
Adjust assertion of max_error_length test

### DIFF
--- a/src/icalendar/tests/calendars/pr_480_summary_with_colon.ics
+++ b/src/icalendar/tests/calendars/pr_480_summary_with_colon.ics
@@ -1,0 +1,7 @@
+BEGIN:VCALENDAR
+BEGIN:VEVENT
+SUMMARY:Example calendar with a ': ' in the summary
+END:VEVENT
+BEGIN:VEVENT
+SUMMARY:Another event with a ': ' in the summary
+END:VEVENT

--- a/src/icalendar/tests/test_components_break_on_bad_ics.py
+++ b/src/icalendar/tests/test_components_break_on_bad_ics.py
@@ -31,6 +31,7 @@ def test_rdate_dosent_become_none_on_invalid_input_issue_464(events):
     'big_bad_calendar',
     'small_bad_calendar',
     'multiple_calendar_components',
+    'pr_480_summary_with_colon',
 ])
 def test_error_message_doesnt_get_too_big(calendars, calendar_name):
     with pytest.raises(ValueError) as exception:

--- a/src/icalendar/tests/test_components_break_on_bad_ics.py
+++ b/src/icalendar/tests/test_components_break_on_bad_ics.py
@@ -35,5 +35,6 @@ def test_rdate_dosent_become_none_on_invalid_input_issue_464(events):
 def test_error_message_doesnt_get_too_big(calendars, calendar_name):
     with pytest.raises(ValueError) as exception:
         calendars[calendar_name]
-    assert len(str(exception).split(': ')[1]) <= 100
+    # Ignore part before first : for the test.
+    assert len(str(exception).split(': ', 1)[1]) <= 100
 


### PR DESCRIPTION
Some message parts may be hidden from the assertion because of multiple splitting. See #473 and [this](https://github.com/collective/icalendar/pull/473/files)for context.