### PR TITLE
implement hash and __eq__ for vDDDTypes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,11 +14,11 @@ Breaking changes:
 
 New features:
 
-- ...
+- vDDDTypes is hashable #487 #492 [niccokunzmann]
 
 Bug fixes:
 
-- ...
+- vDDDTypes' equality also checks the dt attribute #497 #492 [niccokunzmann]
 
 5.0.2 (2022-11-03)
 ------------------

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -320,7 +320,7 @@ class vDDDTypes:
 
     def __eq__(self, other):
         if isinstance(other, vDDDTypes):
-            return self.params == other.params
+            return self.params == other.params and self.dt == other.dt
         return False
 
     def __hash__(self):

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -323,6 +323,9 @@ class vDDDTypes:
             return self.params == other.params
         return False
 
+    def __hash__(self):
+        return hash(self.dt)
+
     @classmethod
     def from_ical(cls, ical, timezone=None):
         if isinstance(ical, cls):

--- a/src/icalendar/tests/test_unit_prop.py
+++ b/src/icalendar/tests/test_unit_prop.py
@@ -6,8 +6,11 @@ from icalendar.parser import Parameters
 import unittest
 from icalendar.prop import vDatetime
 from icalendar.windows_to_olson import WINDOWS_TO_OLSON
-
+import pytest
 import pytz
+from ..prop import vDDDTypes
+from copy import deepcopy
+
 
 
 class TestProp(unittest.TestCase):
@@ -111,27 +114,6 @@ class TestProp(unittest.TestCase):
 
         # Bad input
         self.assertRaises(ValueError, vDDDTypes, 42)
-
-    def test_vDDDTypes_equivalance(self):
-        from ..prop import vDDDTypes
-        from copy import deepcopy
-
-        vDDDTypes = [
-                vDDDTypes(pytz.timezone('US/Eastern').localize(datetime(year=2022, month=7, day=22, hour=12, minute=7))),
-                vDDDTypes(datetime(year=2022, month=7, day=22, hour=12, minute=7)),
-                vDDDTypes(date(year=2022, month=7, day=22)),
-                vDDDTypes(time(hour=22, minute=7, second=2))]
-
-        for v_type in vDDDTypes:
-            self.assertEqual(v_type, deepcopy(v_type))
-            for other in vDDDTypes:
-                if other is v_type:
-                    continue
-                self.assertNotEqual(v_type, other)
-
-            # see if equivalnce fails for other types
-            self.assertNotEqual(v_type, 42)
-            self.assertNotEqual(v_type, 'test')
 
     def test_prop_vDate(self):
         from ..prop import vDate
@@ -517,6 +499,37 @@ class TestProp(unittest.TestCase):
             'Rasmussen, Max M\xf8ller'
         )
 
+
+
+vDDDTypes = [
+    vDDDTypes(pytz.timezone('US/Eastern').localize(datetime(year=2022, month=7, day=22, hour=12, minute=7))),
+    vDDDTypes(datetime(year=2022, month=7, day=22, hour=12, minute=7)),
+    vDDDTypes(date(year=2022, month=7, day=22)),
+    vDDDTypes(time(hour=22, minute=7, second=2))
+]
+
+def identity(x):
+    return x
+
+@pytest.mark.parametrize("map", [
+    deepcopy,
+    identity,
+    hash,
+])
+@pytest.mark.parametrize("v_type", vDDDTypes)
+@pytest.mark.parametrize("other", vDDDTypes)
+def test_vDDDTypes_equivalance(map, v_type, other):
+    if v_type is other:
+        assert map(v_type) == map(other), f"identity implies equality: {map.__name__}()"
+        assert not (map(v_type) != map(other)), f"identity implies equality: {map.__name__}()"
+    else:
+        assert map(v_type) != map(other), f"expected inequality: {map.__name__}()"
+        assert not (map(v_type) == map(other)), f"expected inequality: {map.__name__}()"
+
+@pytest.mark.parametrize("v_type", vDDDTypes)
+def test_inequality_with_different_types(v_type):
+    assert v_type != 42
+    assert v_type != 'test'
 
 class TestPropertyValues(unittest.TestCase):
 

--- a/src/icalendar/tests/test_unit_prop.py
+++ b/src/icalendar/tests/test_unit_prop.py
@@ -505,6 +505,7 @@ vDDDTypes_list = [
     vDDDTypes(pytz.timezone('US/Eastern').localize(datetime(year=2022, month=7, day=22, hour=12, minute=7))),
     vDDDTypes(datetime(year=2022, month=7, day=22, hour=12, minute=7)),
     vDDDTypes(date(year=2022, month=7, day=22)),
+    vDDDTypes(date(year=2022, month=7, day=23)),
     vDDDTypes(time(hour=22, minute=7, second=2))
 ]
 

--- a/src/icalendar/tests/test_unit_prop.py
+++ b/src/icalendar/tests/test_unit_prop.py
@@ -501,7 +501,7 @@ class TestProp(unittest.TestCase):
 
 
 
-vDDDTypes = [
+vDDDTypes_list = [
     vDDDTypes(pytz.timezone('US/Eastern').localize(datetime(year=2022, month=7, day=22, hour=12, minute=7))),
     vDDDTypes(datetime(year=2022, month=7, day=22, hour=12, minute=7)),
     vDDDTypes(date(year=2022, month=7, day=22)),
@@ -516,8 +516,8 @@ def identity(x):
     identity,
     hash,
 ])
-@pytest.mark.parametrize("v_type", vDDDTypes)
-@pytest.mark.parametrize("other", vDDDTypes)
+@pytest.mark.parametrize("v_type", vDDDTypes_list)
+@pytest.mark.parametrize("other", vDDDTypes_list)
 def test_vDDDTypes_equivalance(map, v_type, other):
     if v_type is other:
         assert map(v_type) == map(other), f"identity implies equality: {map.__name__}()"
@@ -526,7 +526,7 @@ def test_vDDDTypes_equivalance(map, v_type, other):
         assert map(v_type) != map(other), f"expected inequality: {map.__name__}()"
         assert not (map(v_type) == map(other)), f"expected inequality: {map.__name__}()"
 
-@pytest.mark.parametrize("v_type", vDDDTypes)
+@pytest.mark.parametrize("v_type", vDDDTypes_list)
 def test_inequality_with_different_types(v_type):
     assert v_type != 42
     assert v_type != 'test'

--- a/src/icalendar/tests/test_unit_prop.py
+++ b/src/icalendar/tests/test_unit_prop.py
@@ -4,13 +4,12 @@ from datetime import time
 from datetime import timedelta
 from icalendar.parser import Parameters
 import unittest
-from icalendar.prop import vDatetime
+from icalendar.prop import vDatetime, vDDDTypes
 from icalendar.windows_to_olson import WINDOWS_TO_OLSON
 import pytest
 import pytz
-from ..prop import vDDDTypes
 from copy import deepcopy
-
+from dateutil import tz
 
 
 class TestProp(unittest.TestCase):
@@ -504,6 +503,7 @@ class TestProp(unittest.TestCase):
 vDDDTypes_list = [
     vDDDTypes(pytz.timezone('US/Eastern').localize(datetime(year=2022, month=7, day=22, hour=12, minute=7))),
     vDDDTypes(datetime(year=2022, month=7, day=22, hour=12, minute=7)),
+    vDDDTypes(datetime(year=2022, month=7, day=22, hour=12, minute=7, tzinfo=tz.UTC)),
     vDDDTypes(date(year=2022, month=7, day=22)),
     vDDDTypes(date(year=2022, month=7, day=23)),
     vDDDTypes(time(hour=22, minute=7, second=2))


### PR DESCRIPTION
This adds tests and an implementation of `__hash__` for vDDDTypes to fix #487.

- add `__hash__`
- add `.dt` comparison to `__eq__` so that the equality is really tested.