### PR TITLE
remove dead link

### DIFF
--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -135,8 +135,6 @@ Links
 This section contains useful links for maintainers and contributors:
 
 - `Future of icalendar, looking for maintainer #360 <https://github.com/collective/icalendar/discussions/360>`__
-- `Team icalendar-admin <https://github.com/orgs/collective/teams/icalendar-admin>`__
-- `Team icalendar-contributor <https://github.com/orgs/collective/teams/icalendar-contributor>`__
 - `Comment on the Plone tests running with icalendar <https://github.com/collective/icalendar/pull/447#issuecomment-1277643634>`__
 
 


### PR DESCRIPTION
The links to teams are only available to members of the team for everyone else it returns a 404 error

Discussion here:
https://github.com/collective/icalendar/commit/a8bbfb9349cfc2baa5ef1c2ec02514accb0833d1#commitcomment-91538993