### PR TITLE
add missing import pytz in example

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -263,6 +263,7 @@ Init the calendar::
 
   >>> cal = Calendar()
   >>> from datetime import datetime
+  >>> import pytz
 
 Some properties are required to be compliant::
 


### PR DESCRIPTION
The example uses the pytz module:
`event.add('dtstart', datetime(2005,4,4,8,0,0,tzinfo=pytz.utc))`
But doesn't import it