### PR TITLE
Issue 268 - support for BYWEEKDAY

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 Minor changes:
 
-- ...
+- Added support for BYWEEKDAY in vRecur ref: #268 
 
 Breaking changes:
 

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -66,6 +66,7 @@ icalendar contributors
 - Michał Górny <mgorny@gentoo.org>
 - Pronoy <lukex9442@gmail.com>
 - Abe Hanoka <abe@habet.dev>
+- `Natasha Mattson <https://github.com/natashamm`_
 
 Find out who contributed::
 

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -643,7 +643,7 @@ class vRecur(CaselessDict):
     # Mac iCal ignores RRULEs where FREQ is not the first rule part.
     # Sorts parts according to the order listed in RFC 5545, section 3.3.10.
     canonical_order = ("FREQ", "UNTIL", "COUNT", "INTERVAL",
-                       "BYSECOND", "BYMINUTE", "BYHOUR", "BYDAY",
+                       "BYSECOND", "BYMINUTE", "BYHOUR", "BYDAY", "BYWEEKDAY",
                        "BYMONTHDAY", "BYYEARDAY", "BYWEEKNO", "BYMONTH",
                        "BYSETPOS", "WKST")
 
@@ -662,6 +662,7 @@ class vRecur(CaselessDict):
         'WKST': vWeekday,
         'BYDAY': vWeekday,
         'FREQ': vFrequency,
+        'BYWEEKDAY': vWeekday,
     })
 
     def __init__(self, *args, **kwargs):

--- a/src/icalendar/tests/test_unit_prop.py
+++ b/src/icalendar/tests/test_unit_prop.py
@@ -322,6 +322,18 @@ class TestProp(unittest.TestCase):
             b'BYMONTH=1'
         )
 
+        r = vRecur.from_ical('FREQ=WEEKLY;INTERVAL=1;BYWEEKDAY=TH')
+        
+        self.assertEqual(
+            r,
+            {'FREQ': ['WEEKLY'], 'INTERVAL': [1], 'BYWEEKDAY': ['TH']}
+        )
+
+        self.assertEqual(
+            vRecur(r).to_ical(),
+            b'FREQ=WEEKLY;INTERVAL=1;BYWEEKDAY=TH'
+        )
+
         # Some examples from the spec
         r = vRecur.from_ical('FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1')
         self.assertEqual(vRecur(r).to_ical(),


### PR DESCRIPTION
Add support for BYWEEKDAY in the RRULE based on https://github.com/collective/icalendar/issues/268

Background: [dateutil](https://dateutil.readthedocs.io/en/stable/rrule.html) renamed BYDAY to BYWEEKDAY to "avoid the ambiguity of that keyword". Note that RFC 5545 uses BYDAY only.

From https://github.com/collective/icalendar/issues/268