### PR TITLE
4.x branch: Fix for issue 518 (to_ical() with RRULE BYDAY values>=10)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 4.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Bug fixes:
+
+- to_ical() now accepts RRULE BYDAY values>=10 (Issue #518)
 
 
 4.1.0 (2022-07-11)

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -56,6 +56,7 @@ icalendar contributors
 - Clive Stevens <clivest2@gmail.com>
 - Dalton Durst <github@daltondur.st>
 - Kamil Mańkowski <kam193@wp.pl>
+- Matt Lewis <git@semiprime.com>
 
 Find out who contributed::
 

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -71,7 +71,7 @@ DATETIME_PART = '(?:%s)?(?:%s)?' % (DATE_PART, TIME_PART)
 WEEKS_PART = r'(\d+)W'
 DURATION_REGEX = re.compile(r'([-+]?)P(?:%s|%s)$'
                             % (WEEKS_PART, DATETIME_PART))
-WEEKDAY_RULE = re.compile(r'(?P<signal>[+-]?)(?P<relative>[\d]?)'
+WEEKDAY_RULE = re.compile(r'(?P<signal>[+-]?)(?P<relative>[\d]{0,2})'
                           r'(?P<weekday>[\w]{2})$')
 
 

--- a/src/icalendar/tests/test_recurrence.py
+++ b/src/icalendar/tests/test_recurrence.py
@@ -60,3 +60,41 @@ class TestRecurrence(unittest.TestCase):
         self.assertEqual(exdate[0].to_ical(), b'20120529T100000')
 
         # TODO: test for embedded timezone information!
+
+    def test_byday_to_ical(self):
+        'Test the BYDAY rule is correctly processed by to_ical().'
+        TEST_CASES = (
+            # Test some YEARLY BYDAY repeats
+            ('YEARLY', '1SU', datetime.date(2016,1,3), # 1st Sunday in year
+                b'BEGIN:VEVENT\r\nSUMMARY:Event YEARLY 1SU\r\nDTSTART;VALUE=DATE:20160103\r\nRRULE:FREQ=YEARLY;BYDAY=1SU\r\nEND:VEVENT\r\n'),
+            ('YEARLY', '53MO', datetime.date(1984,12,31), # 53rd Mon in (leap) year
+                b'BEGIN:VEVENT\r\nSUMMARY:Event YEARLY 53MO\r\nDTSTART;VALUE=DATE:19841231\r\nRRULE:FREQ=YEARLY;BYDAY=53MO\r\nEND:VEVENT\r\n'),
+            ('YEARLY', '-1TU', datetime.date(1999,12,28), # Last Tues in year
+                b'BEGIN:VEVENT\r\nSUMMARY:Event YEARLY -1TU\r\nDTSTART;VALUE=DATE:19991228\r\nRRULE:FREQ=YEARLY;BYDAY=-1TU\r\nEND:VEVENT\r\n'),
+            ('YEARLY', '-17WE', datetime.date(2000,9,6), # 17th-last Wed in year
+                b'BEGIN:VEVENT\r\nSUMMARY:Event YEARLY -17WE\r\nDTSTART;VALUE=DATE:20000906\r\nRRULE:FREQ=YEARLY;BYDAY=-17WE\r\nEND:VEVENT\r\n'),
+            # Test some MONTHLY BYDAY repeats
+            ('MONTHLY', '2TH', datetime.date(2003,4,10), # 2nd Thurs in month
+                b'BEGIN:VEVENT\r\nSUMMARY:Event MONTHLY 2TH\r\nDTSTART;VALUE=DATE:20030410\r\nRRULE:FREQ=MONTHLY;BYDAY=2TH\r\nEND:VEVENT\r\n'),
+            ('MONTHLY', '-3FR', datetime.date(2017,5,12), # 3rd-last Fri in month
+                b'BEGIN:VEVENT\r\nSUMMARY:Event MONTHLY -3FR\r\nDTSTART;VALUE=DATE:20170512\r\nRRULE:FREQ=MONTHLY;BYDAY=-3FR\r\nEND:VEVENT\r\n'),
+            ('MONTHLY', '-5SA', datetime.date(2053,11,1), # 5th-last Sat in month
+                b'BEGIN:VEVENT\r\nSUMMARY:Event MONTHLY -5SA\r\nDTSTART;VALUE=DATE:20531101\r\nRRULE:FREQ=MONTHLY;BYDAY=-5SA\r\nEND:VEVENT\r\n'),
+            # Specifically test examples from the report of Issue #518
+            # https://github.com/collective/icalendar/issues/518
+            ('YEARLY', '9MO', datetime.date(2023,2,27), # 9th Monday in year
+                b'BEGIN:VEVENT\r\nSUMMARY:Event YEARLY 9MO\r\nDTSTART;VALUE=DATE:20230227\r\nRRULE:FREQ=YEARLY;BYDAY=9MO\r\nEND:VEVENT\r\n'),
+            ('YEARLY', '10MO', datetime.date(2023,3,6), # 10th Monday in year
+                b'BEGIN:VEVENT\r\nSUMMARY:Event YEARLY 10MO\r\nDTSTART;VALUE=DATE:20230306\r\nRRULE:FREQ=YEARLY;BYDAY=10MO\r\nEND:VEVENT\r\n'),
+            )
+        for c in TEST_CASES:
+            self._dotest_byday_to_ical(*c)
+
+    def _dotest_byday_to_ical(self, freq, byday, dtstart, expected):
+        'Called by test_byday_to_ical() with various parameters'
+        event = icalendar.Event()
+        event.add('SUMMARY', ' '.join(['Event', freq, byday]))
+        event.add('DTSTART', dtstart)
+        event.add('RRULE', {'FREQ':[freq], 'BYDAY':byday})
+        ical = event.to_ical()
+        self.assertEqual(ical, expected)


### PR DESCRIPTION
Issue 518 fix for the 4.x branch (already fixed in master branch). Issue: https://github.com/collective/icalendar/issues/518

The fix itself is the same as in the master branch. The test code has been adapted because the corresponding test code in 4.x uses the unittest module, rather than pytest as in the master branch.

All tests pass (run with setup.py test). Without the fix, the new tests give 3 failures.

Justification for inclusion in 4.x branch: It's a crashing bug. The fix is low risk (never say zero risk!).
