### PR TITLE
No longer run the plone.app.event tests.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,7 @@ jobs:
         - ["3.10",  "py310"]
         - ["pypy-3.9", "pypy3"]
         - ["3.10",  "docs"]
-        - ["3.10",  "plone"]
-        - ["3.11.0-rc.1",  "py311"]
+        - ["3.11",  "py311"]
 
     runs-on: ubuntu-latest
     name: ${{ matrix.config[1] }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 Minor changes:
 
-- ...
+- No longer run the ``plone.app.event`` tests.
 
 Breaking changes:
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # to run for a specific environment, use ``tox -e ENVNAME``
 [tox]
-envlist = py37,py38,py39,py310,pypy3,docs,plone
+envlist = py37,py38,py39,py310,py311,pypy3,docs
 # Note: the 'docs' env creates a 'build' directory which may interfere in strange ways
 # with the other environments.  You might see this when you run the tests in parallel.
 # See https://github.com/collective/icalendar/pull/359#issuecomment-1214150269
@@ -23,17 +23,3 @@ changedir = docs
 allowlist_externals = make
 commands =
     make html
-
-[testenv:plone]
-usedevelop = False
-install = False
-python = 3.10
-commands_pre =
-# Install Plone and explicitly the single package that uses icalendar, plus the test runner.
-    pip install Plone plone.app.event[test] zope.testrunner -c https://dist.plone.org/release/6.0-dev/constraints.txt
-# Install the dev version of the package, mostly so we can safely point to the path with the tests.
-    pip install -e "git+https://github.com/plone/plone.app.event.git\#egg=plone.app.event"
-# icalendar is pinned in the constraints, but we want the current dev version.
-    pip install -e {toxinidir}
-commands =
-    zope-testrunner --test-path={envdir}/src/plone-app-event {posargs:-vc}


### PR DESCRIPTION
Also, run the Python 3.11 tests with the latest Python 3.11, instead of a release candidate.

In the last two weekly cron tests, the plone tests fail with:

    ModuleNotFoundError: No module named 'plone.app.event'

I see the same locally, and I have no idea why.

This seems a good time to stop running the `plone.app.event` tests within `icalendar`.  We ran them until now to prevent changes from creeping in that negatively affect Plone, which is where this module was born.  But so far, nothing like that has happened.  And occasionally these tests break because of reasons that have nothing to do with `icalendar`, so they distract from maintenance of this package.  So let's stop doing this.