### PR TITLE
Move pip cache into Python setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,13 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.config[0] }}
+        # for caching, see 
+        # https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages
         cache: 'pip'
+        cache-dependency-path: |
+          setup.*
+          tox.ini
+          requirements*.txt
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,19 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.config[0] }}
-    - name: Pip cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.config[0] }}-
-          ${{ runner.os }}-pip-
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 Minor changes:
 
 - No longer run the ``plone.app.event`` tests.
+- Move pip caching into Python setup action.
 
 Breaking changes:
 


### PR DESCRIPTION
This is now possible:
https://github.com/actions/setup-python#caching-packages-dependencies