### PR TITLE
Update read the docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,9 +12,12 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all
 
-# Optionally set the version of Python and requirements required to build your docs
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: 3.7
   install:
     - requirements: requirements_docs.txt
     - method: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 Minor changes:
 
+- Update build configuration to build readthedocs. #538
 - No longer run the ``plone.app.event`` tests.
 
 Breaking changes:


### PR DESCRIPTION
see https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os
> The configuration key build.os is required to build your documentation.


![image](https://github.com/collective/icalendar/assets/564768/ed10642a-d6da-41ed-bf0a-2b1132c621b8)

#538 