### PR TITLE
Fix `vText.__repr__` `BytesWarning`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Minor changes:
 - Move pip caching into Python setup action.
 - Check that issue #165 can be closed.
 - Updated about.rst for issue #527
+- Avoid ``vText.__repr__`` BytesWarning.
 
 Breaking changes:
 

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -43,6 +43,7 @@ icalendar contributors
 - Thomas Bruederli <thomas@roundcube.net>
 - Thomas Weißschuh <thomas@t-8ch.de>
 - Victor Varvaryuk <victor.varvariuc@gmail.com>
+- Ville Skyttä <ville.skytta@iki.fi>
 - Wichert Akkerman <wichert@wiggy.net>
 - cillianderoiste <cillian.deroiste@gmail.com>
 - fitnr <fitnr@fakeisthenewreal>

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -719,7 +719,7 @@ class vText(str):
         return self
 
     def __repr__(self):
-        return f"vText('{self.to_ical()}')"
+        return f"vText('{self.to_ical()!r}')"
 
     def to_ical(self):
         return escape_char(self).encode(self.encoding)


### PR DESCRIPTION
Exposed by running in `python3 -b` mode.