### PR TITLE
cli: Display datetimes in local timezone

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Changelog
 
 Minor changes:
 
-- ...
+- The cli utility now displays start and end datetimes in the user's local timezone.
+  Ref: #561
+  [vimpostor]
 
 Breaking changes:
 

--- a/src/icalendar/cli.py
+++ b/src/icalendar/cli.py
@@ -52,10 +52,10 @@ def view(event):
         end = event.decoded('dtend', default=start)
     duration = event.decoded('duration', default=end - start)
     if isinstance(start, datetime):
-        start = start.astimezone(start.tzinfo)
+        start = start.astimezone()
     start = start.strftime('%c')
     if isinstance(end, datetime):
-        end = end.astimezone(end.tzinfo)
+        end = end.astimezone()
     end = end.strftime('%c')
 
     return f"""    Organizer: {organizer}


### PR DESCRIPTION
This makes up for a much nicer UX for users of the cli utility.
Before this patch the start and end datetimes were always displayed with a fixed timezone (the timezone of the calendar creator).
This meant that users had to manually calculate the time in their own timezone.

With this patch the times are printed in the expected format, i.e. in the user's own local timezone.

It seems that in 7a8d584b an attempt was already made to implement this, but unfortunately `start.astimezone(start.tzinfo)` is a no-op and does absolutely nothing. Instead no arguments have to be passed to the `astimezone()` function to convert to the user's timezone, see https://docs.python.org/3/library/datetime.html#datetime.datetime.astimezone

The unit test has been adapted to check for the output in the correct timezone.
