### PR TITLE
Fix Oss Fuzz Build Error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ Bug fixes:
   Ref: #567
 - Add some compare functions.
   Ref: #568
+- Change OSS Fuzz build script to point to harnesses in fuzzing directory
+  Ref: #574
 
 5.0.10 (unreleased)
 -------------------

--- a/src/icalendar/fuzzing/build.sh
+++ b/src/icalendar/fuzzing/build.sh
@@ -20,6 +20,6 @@ pip3 install .
 
 # Build fuzzers in $OUT
 for fuzzer in $(find src/icalendar/fuzzing -name '*_fuzzer.py');do
-  compile_python_fuzzer "$fuzzer" 
+  compile_python_fuzzer "$fuzzer"
 done
 zip -q $OUT/ical_fuzzer_seed_corpus.zip $SRC/corpus/*

--- a/src/icalendar/fuzzing/build.sh
+++ b/src/icalendar/fuzzing/build.sh
@@ -19,7 +19,7 @@ cd "$SRC"/icalendar
 pip3 install .
 
 # Build fuzzers in $OUT
-for fuzzer in $(find $SRC -name 'src/icalendar/fuzzing/*_fuzzer.py');do
+for fuzzer in $(find $SRC -wholename 'src/icalendar/fuzzing/*_fuzzer.py');do
   compile_python_fuzzer "$fuzzer" 
 done
 zip -q $OUT/ical_fuzzer_seed_corpus.zip $SRC/corpus/*

--- a/src/icalendar/fuzzing/build.sh
+++ b/src/icalendar/fuzzing/build.sh
@@ -19,7 +19,7 @@ cd "$SRC"/icalendar
 pip3 install .
 
 # Build fuzzers in $OUT
-for fuzzer in $(find $SRC -wholename 'src/icalendar/fuzzing/*_fuzzer.py');do
+for fuzzer in $(find src/icalendar/fuzzing -name '*_fuzzer.py');do
   compile_python_fuzzer "$fuzzer" 
 done
 zip -q $OUT/ical_fuzzer_seed_corpus.zip $SRC/corpus/*


### PR DESCRIPTION
I'm currently working on switching the OSS Fuzz build to use the fuzzing harnesses hosted in icalendar. In doing that, I noticed that this change required updating the find path in the build.sh script. I tested it locally and the fuzz harnesses are able to build. 