### PR TITLE
Add fixes for OSS-Fuzz bugs and test cases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ New features:
 Bug fixes:
 
 - ...
+- Fixed index error in cal.py when attempting to pop from an empty stack
+- Fixed type error in prop.py when attempting to join strings into a byte-string
+- Caught Wrong Date Format in ical_fuzzer to resolve fuzzing coverage blocker
 
 5.0.11 (2023-11-03)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,25 @@
 Changelog
 =========
 
+5.0.12 (unreleased)
+-------------------
+
+Minor changes:
+
+- ...
+
+Breaking changes:
+
+- ...
+
+New features:
+
+- ...
+
+Bug fixes:
+
+- ...
+
 5.0.11 (2023-11-03)
 -------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 Minor changes:
 
-- ...
+- Augmented fuzzer to optionally convert multiple calendars from a source string
 
 Breaking changes:
 

--- a/src/icalendar/parser_tools.py
+++ b/src/icalendar/parser_tools.py
@@ -1,8 +1,10 @@
+from typing import Any
+
 SEQUENCE_TYPES = (list, tuple)
 DEFAULT_ENCODING = 'utf-8'
 
 
-def from_unicode(value, encoding='utf-8') -> bytes:
+def from_unicode(value: Any, encoding='utf-8') -> bytes:
     """
     Converts a value to bytes, even if it already is bytes
     :param value: The value to convert
@@ -10,10 +12,10 @@ def from_unicode(value, encoding='utf-8') -> bytes:
     :return: The bytes representation of the value
     """
     if isinstance(value, bytes):
-        return value
+        value = value
     elif isinstance(value, str):
         try:
-            return value.encode(encoding)
+            value = value.encode(encoding)
         except UnicodeEncodeError:
             value = value.encode('utf-8', 'replace')
     return value

--- a/src/icalendar/parser_tools.py
+++ b/src/icalendar/parser_tools.py
@@ -2,6 +2,23 @@ SEQUENCE_TYPES = (list, tuple)
 DEFAULT_ENCODING = 'utf-8'
 
 
+def from_unicode(value, encoding='utf-8') -> bytes:
+    """
+    Converts a value to bytes, even if it already is bytes
+    :param value: The value to convert
+    :param encoding: The encoding to use in the conversion
+    :return: The bytes representation of the value
+    """
+    if isinstance(value, bytes):
+        return value
+    elif isinstance(value, str):
+        try:
+            return value.encode(encoding)
+        except UnicodeEncodeError:
+            value = value.encode('utf-8', 'replace')
+    return value
+
+
 def to_unicode(value, encoding='utf-8'):
     """Converts a value to unicode, even if it is already a unicode string.
     """

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -53,6 +53,7 @@ from icalendar.parser import unescape_char
 from icalendar.parser_tools import DEFAULT_ENCODING
 from icalendar.parser_tools import SEQUENCE_TYPES
 from icalendar.parser_tools import to_unicode
+from icalendar.parser_tools import from_unicode
 from icalendar.timezone_cache import _timezone_cache
 from icalendar.windows_to_olson import WINDOWS_TO_OLSON
 
@@ -251,21 +252,8 @@ class vDDDLists:
         self.dts = vDDD
 
     def to_ical(self):
-        dts_ical = [dt.to_ical() for dt in self.dts]
-
-        # Make sure all elements are of the same type
-        if dts_ical and all(isinstance(dt, type(dts_ical[0])) for dt in dts_ical):
-            first_dt = dts_ical[0]
-            if isinstance(first_dt, bytes):
-                return b",".join(dts_ical)
-            elif isinstance(first_dt, str):
-                return ",".join(dts_ical)
-            else:
-                raise ValueError(f"Unexpected type {type(first_dt)} in vDDD list!")
-        elif not dts_ical:
-            return b""
-        else:
-            raise ValueError("Type mismatch in vDDD list!")
+        dts_ical = (from_unicode(dt.to_ical()) for dt in self.dts)
+        return b",".join(dts_ical)
 
     @staticmethod
     def from_ical(ical, timezone=None):

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -62,13 +62,11 @@ import pytz
 import re
 import time as _time
 
-
 DURATION_REGEX = re.compile(r'([-+]?)P(?:(\d+)W)?(?:(\d+)D)?'
                             r'(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$')
 
 WEEKDAY_RULE = re.compile(r'(?P<signal>[+-]?)(?P<relative>[\d]{0,2})'
                           r'(?P<weekday>[\w]{2})$')
-
 
 ####################################################
 # handy tzinfo classes you can use.
@@ -174,6 +172,7 @@ class vBoolean(int):
 class vCalAddress(str):
     """This just returns an unquoted string.
     """
+
     def __new__(cls, value, encoding=DEFAULT_ENCODING):
         value = to_unicode(value, encoding=encoding)
         self = super().__new__(cls, value)
@@ -194,6 +193,7 @@ class vCalAddress(str):
 class vFloat(float):
     """Just a float.
     """
+
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls, *args, **kwargs)
         self.params = Parameters()
@@ -213,6 +213,7 @@ class vFloat(float):
 class vInt(int):
     """Just an int.
     """
+
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls, *args, **kwargs)
         self.params = Parameters()
@@ -253,7 +254,7 @@ class vDDDLists:
         dts_ical = [dt.to_ical() for dt in self.dts]
 
         # Make sure all elements are of the same type
-        if dts_ical and all(type(dt) is type(dts_ical[0]) for dt in dts_ical):
+        if dts_ical and all(isinstance(dt, type(dts_ical[0])) for dt in dts_ical):
             first_dt = dts_ical[0]
             if isinstance(first_dt, bytes):
                 return b",".join(dts_ical)
@@ -261,6 +262,8 @@ class vDDDLists:
                 return ",".join(dts_ical)
             else:
                 raise ValueError(f"Unexpected type {type(first_dt)} in vDDD list!")
+        elif not dts_ical:
+            return b""
         else:
             raise ValueError("Type mismatch in vDDD list!")
 
@@ -298,6 +301,7 @@ class vCategory:
     def __eq__(self, other):
         """self == other"""
         return isinstance(other, vCategory) and self.cats == other.cats
+
 
 class TimeBase:
     """Make classes with a datetime/date comparable."""
@@ -376,6 +380,7 @@ class vDDDTypes(TimeBase):
     def __repr__(self):
         """repr(self)"""
         return f"{self.__class__.__name__}({self.dt}, {self.params})"
+
 
 class vDate(TimeBase):
     """Render and generates iCalendar date format.
@@ -527,6 +532,7 @@ class vDuration(TimeBase):
         """The time delta for compatibility."""
         return self.td
 
+
 class vPeriod(TimeBase):
     """A precise period of time.
     """
@@ -598,6 +604,7 @@ class vPeriod(TimeBase):
     def dt(self):
         """Make this cooperate with the other vDDDTypes."""
         return (self.start, (self.duration if self.by_duration else self.end))
+
 
 class vWeekday(str):
     """This returns an unquoted weekday abbrevation.
@@ -841,11 +848,13 @@ class vGeo:
     def __eq__(self, other):
         return self.to_ical() == other.to_ical()
 
+
 class vUTCOffset:
     """Renders itself as a utc offset.
     """
 
-    ignore_exceptions = False   # if True, and we cannot parse this
+    ignore_exceptions = False  # if True, and we cannot parse this
+
     # component, we will silently ignore
     # it, rather than let the exception
     # propagate upwards
@@ -907,6 +916,7 @@ class vInline(str):
     has parameters. Conversion of inline values are handled by the Component
     class, so no further processing is needed.
     """
+
     def __new__(cls, value, encoding=DEFAULT_ENCODING):
         value = to_unicode(value, encoding=encoding)
         self = super().__new__(cls, value)

--- a/src/icalendar/tests/test_oss_fuzz_errors.py
+++ b/src/icalendar/tests/test_oss_fuzz_errors.py
@@ -1,5 +1,8 @@
 """This file collects errors that the OSS FUZZ build has found."""
+from datetime import time
 from icalendar import Calendar
+from icalendar.prop import vDDDLists
+
 import pytest
 
 
@@ -7,3 +10,9 @@ def test_stack_is_empty():
     """If we get passed an invalid string, we expect to get a ValueError."""
     with pytest.raises(ValueError):
         Calendar.from_ical("END:CALENDAR")
+
+
+def test_vdd_list_type_mismatch():
+    """If we pass in a string type, we expect it to be converted to bytes"""
+    vddd_list = vDDDLists([time(hour=6, minute=6, second=6)])
+    assert vddd_list.to_ical() == b'060606'


### PR DESCRIPTION
This PR introduces the fixes to address two bugs discovered by OSS Fuzz and adds two test cases to ensure that they are not reintroduced down the line.

The bugs are as follows:
1) Type mismatch in vDDDlists.to_ical when given a date-time that resolves to a string and is joined as bytes
2) Attempting to pop from an empty stack when parsing 'BEGIN' and 'END' in to_ical
