### PR TITLE
Fuzzer Work: Added More Exception Handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Minor changes:
 - Added corpus to fuzzing directory
 - Added exclusion of fuzzing corpus in MANIFEST.in
 - Augmented fuzzer to optionally convert multiple calendars from a source string
-
+- Added additional exception handling of defined errors to fuzzer, to allow fuzzer to explore deeper
 Breaking changes:
 
 - ...

--- a/src/icalendar/fuzzing/ical_fuzzer.py
+++ b/src/icalendar/fuzzing/ical_fuzzer.py
@@ -24,7 +24,11 @@ with atheris.instrument_imports(
 
 _value_error_matches = [
     "component", "parse", "Expected", "Wrong date format", "END encountered",
-    "vDDD", 'recurrence', 'Wrong datetime', 'Offset must', 'Invalid iCalendar'
+    "vDDD", 'recurrence', 'Offset must', 'Invalid iCalendar',
+    'alue MUST', 'Key name', 'Invalid content line', 'does not exist',
+    'base 64', 'must use datetime', 'Unknown date type', 'Wrong',
+    'Start time', 'iCalendar', 'recurrence', 'float, float', 'utc offset',
+    'parent'
 ]
 
 


### PR DESCRIPTION
This PR adds more substrings to the fuzzer's exception checks to ensure that it does not report expected exceptions as crashes. With this merged, deeper coverage should be achieved to discover more edge cases. 