### PR TITLE
Added more instrumentation + caught one more exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Minor changes:
 - Added exclusion of fuzzing corpus in MANIFEST.in
 - Augmented fuzzer to optionally convert multiple calendars from a source string
 - Added additional exception handling of defined errors to fuzzer, to allow fuzzer to explore deeper
+- Added more instrumentation to fuzz-harness
 Breaking changes:
 
 - ...

--- a/src/icalendar/fuzzing/ical_fuzzer.py
+++ b/src/icalendar/fuzzing/ical_fuzzer.py
@@ -17,9 +17,7 @@
 import atheris
 import sys
 
-with atheris.instrument_imports(
-        include=['icalendar'],
-        exclude=['pytz', 'six', 'site_packages', 'pkg_resources', 'dateutil']):
+with atheris.instrument_imports():
     import icalendar
 
 _value_error_matches = [
@@ -28,7 +26,7 @@ _value_error_matches = [
     'alue MUST', 'Key name', 'Invalid content line', 'does not exist',
     'base 64', 'must use datetime', 'Unknown date type', 'Wrong',
     'Start time', 'iCalendar', 'recurrence', 'float, float', 'utc offset',
-    'parent'
+    'parent', 'MUST be a datetime'
 ]
 
 


### PR DESCRIPTION
Another quick PR, I added another defined exception that was holding up fuzzer progress and made a tweak to see if we can get more intelligent instrumentation and coverage exploration. 

A suggestion would be collecting all raised exceptions under a common base-class, such as CalendarException, so the fuzzer can just do except CalendarException as opposed to string-matching multiple ValueErrors. This would also help users of the library in their error-handling, as well. 