### PR TITLE
Analyse code coverage in tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 Minor changes:
 
+- Analyse code coverage of test files
 - Added corpus to fuzzing directory
 - Added exclusion of fuzzing corpus in MANIFEST.in
 - Augmented fuzzer to optionally convert multiple calendars from a source string

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     coverage
     hypothesis
 commands =
-    coverage run --source=src/icalendar --omit=*/tests/* --module pytest []
+    coverage run --source=src/icalendar --omit=*/tests/hypothesis/* --omit=*/tests/fuzzed/* --module pytest []
     coverage report
     coverage html
 


### PR DESCRIPTION
By analysing the code coverage in the test files, we can make sure that we do not accidentially remove a test and that all test code actually is used.

Issues to open:
- [x] run hypothesis tests
- [x] newcomer issues for writing tests for uncovered production code