### PR TITLE
[WIP] Create GitHub Releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,8 +122,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: create release
-        uses: elgohr/Github-Release-Action@v5
-        env:
-          GH_TOKEN: ${{ github.token }}
-        with:
-          title: ${{ github.ref_name }}
+        uses: ncipollo/release-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,6 +124,6 @@ jobs:
       - name: create release
         uses: elgohr/Github-Release-Action@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         with:
           title: ${{ github.ref_name }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Breaking changes:
 
 New features:
 
-- ...
+- Create GitHub releases for each tag.
 
 Bug fixes:
 


### PR DESCRIPTION
This fixes #563.

See the [v5.0.12 tag](https://github.com/collective/icalendar/releases/tag/v5.0.12).