### PR TITLE
Make documentation build under Python 3.12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 Minor changes:
 
 - Add funding information
+- Make documentation build with Python 3.12
 - Update windows to olson conversion for Greenland Standard Time
 - Extend examples in Usage with alarm and recurrence
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ commands =
 [testenv:docs]
 deps =
     -r {toxinidir}/requirements_docs.txt
+    setuptools
 changedir = docs
 allowlist_externals = make
 commands =


### PR DESCRIPTION
`setuptools` might not be installed. This installs it to build the documentation with Python 3.12.

See also:
- https://stackoverflow.com/a/10538412/1320237

```
phinx v7.3.7 in Verwendung

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/nicco/icalendar/.tox/docs/lib/python3.12/site-packages/sphinx/config.py", line 509, in eval_config_file
    exec(code, namespace)  # NoQA: S102
    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/nicco/icalendar/docs/conf.py", line 2, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

I hope that works with lower versions of Python, too.