### PR TITLE
add test case for unit prop

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Minor changes:
 - Update windows to olson conversion for Greenland Standard Time
 - Extend examples in Usage with alarm and recurrence
 - Document how to serve the built documentation to view with the browser
+- Improve test coverage
 
 Breaking changes:
 


### PR DESCRIPTION
This PR resolve https://github.com/collective/icalendar/issues/605

When adding test case, i still can't figured it out how to trigger __repr__ function. Could you help me with guidance to trigger that?

# Improvement
![Screenshot_11-Jun-2024_22-23-18](https://github.com/collective/icalendar/assets/22138274/a94b5f7c-8dd1-44c9-ab58-b0f442f0bbd6)
