### PR TITLE
Rename master to main in docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -325,7 +325,7 @@ New features:
 - No longer test on Python 3.4, 3.5 and PyPy2, because we cannot get it to work.
   Technically it should still work, it is just no longer tested.
   Do not expect much development on branch 4.x anymore.
-  The master branch will be for the remaining Python versions that we support.
+  The main branch will be for the remaining Python versions that we support.
   [maurits]
 
 Bug fixes:
@@ -965,7 +965,7 @@ Fixes:
   [garbas]
 
 - hook out github repository to https://readthedocs.org service so sphinx
-  documentation is generated on each commit (for master). Documentation can be
+  documentation is generated on each commit (for main). Documentation can be
   visible on: https://icalendar.readthedocs.io/en/latest/
   [garbas]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 Minor changes:
 
 - Test that all code works with both ``pytz`` and ``zoneinfo``.
+- Rename ``master`` branch to ``main``, see `Issue
+  <https://github.com/collective/icalendar/issues/627>`_
 
 Breaking changes:
 

--- a/README.rst
+++ b/README.rst
@@ -24,9 +24,9 @@ files.
    :target: https://pypi.org/project/icalendar/#files
    :alt: Downloads from PyPI
 
-.. image:: https://img.shields.io/github/actions/workflow/status/collective/icalendar/tests.yml?branch=master&label=master&logo=github
-    :target: https://github.com/collective/icalendar/actions/workflows/tests.yml?query=branch%3Amaster
-    :alt: GitHub Actions build status for master
+.. image:: https://img.shields.io/github/actions/workflow/status/collective/icalendar/tests.yml?branch=main&label=main&logo=github
+    :target: https://github.com/collective/icalendar/actions/workflows/tests.yml?query=branch%3Amain
+    :alt: GitHub Actions build status for main
 
 .. image:: https://img.shields.io/github/actions/workflow/status/collective/icalendar/tests.yml?branch=4.x&label=4.x&logo=github
     :target: https://github.com/collective/icalendar/actions/workflows/tests.yml?query=branch%3A4.x++
@@ -175,8 +175,8 @@ you can receive all the latest updates, and switch back to version 5.x behavior:
     >>> dt.tzinfo
     <DstTzInfo 'Europe/Vienna' CET+1:00:00 STD>
 
-Version 6 is on `branch master <https://github.com/collective/icalendar/>`_ with compatibility to Python versions ``3.7+`` and ``PyPy3``.
-We expect the ``master`` branch with versions ``6+`` to receive the latest updates and features.
+Version 6 is on `branch main <https://github.com/collective/icalendar/>`_ with compatibility to Python versions ``3.7+`` and ``PyPy3``.
+We expect the ``main`` branch with versions ``6+`` to receive the latest updates and features.
 
 Version 5
 ~~~~~~~~~

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -70,9 +70,9 @@ However, only people with ``PyPI environment access for GitHub Actions`` can app
 
    .. code-block:: bash
 
-       git checkout master
+       git checkout main
        git pull
-       git checkout -b release master
+       git checkout -b release main
        git add CHANGES.rst src/icalendar/__init__.py docs/install.rst
        git commit -m"version 5.0.0"
 
@@ -90,7 +90,7 @@ However, only people with ``PyPI environment access for GitHub Actions`` can app
 
    .. code-block:: bash
 
-       git checkout master
+       git checkout main
        git pull
        git branch -d release
        git push -d origin release
@@ -99,7 +99,7 @@ However, only people with ``PyPI environment access for GitHub Actions`` can app
 
    .. code-block:: bash
 
-       git checkout master
+       git checkout main
        git pull
        git tag v5.0.0
        git push upstream v5.0.0 # could be origin or whatever reference
@@ -137,13 +137,13 @@ However, only people with ``PyPI environment access for GitHub Actions`` can app
 
    .. code-block:: bash
 
-       git checkout master
+       git checkout main
        git pull
        git add CHANGES.rst
        git commit -m"Add new CHANGELOG section for future release
 
        See https://icalendar.readthedocs.io/en/latest/maintenance.html#new-releases"
-       git push upstream master # could be origin or whatever reference
+       git push upstream main # could be origin or whatever reference
 
 Links
 -----

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -372,5 +372,5 @@ Print out the calendar::
 More documentation
 ==================
 
-Have a look at the `tests <https://github.com/collective/icalendar/tree/master/src/icalendar/tests>`__ of this package to get more examples.
+Have a look at the `tests <https://github.com/collective/icalendar/tree/main/src/icalendar/tests>`__ of this package to get more examples.
 All modules and classes docstrings, which document how they work.


### PR DESCRIPTION
We switched to `main`, see #627.