### PR TITLE
drop python<=3.7 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
         - ["pypy-3.9", "pypy3"]
         - ["3.10",  "docs"]
         - ["3.11",  "py311"]
+        - ["3.12",  "py312"]
 
     runs-on: ubuntu-latest
     name: ${{ matrix.config[1] }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,6 @@ jobs:
       matrix:
         config:
         # [Python version, tox env]
-        - ["3.7",   "py37"]
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]
         - ["3.10",  "py310"]

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     'pytz',
     # install requirements depending on python version
     # see https://www.python.org/dev/peps/pep-0508/#environment-markers
-    'backports.zoneinfo; python_version <= "3.8"',
+    'backports.zoneinfo; python_version < "3.9"',
     'tzdata'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     'pytz',
     # install requirements depending on python version
     # see https://www.python.org/dev/peps/pep-0508/#environment-markers
-    'backports.zoneinfo; python_version == "3.7" or python_version == "3.8"',
+    'backports.zoneinfo; python_version <= "3.8"',
     'tzdata'
 ]
 
@@ -39,7 +39,6 @@ setuptools.setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -57,7 +56,7 @@ setuptools.setup(
     package_dir={'': 'src'},
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=install_requires,
     entry_points = {'console_scripts': ['icalendar = icalendar.cli:main']},
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -16,7 +16,8 @@ from icalendar.prop import TypesFactory
 from icalendar.prop import vText, vDDDLists
 from icalendar.timezone import tzp
 from typing import Tuple, List
-import dateutil.rrule, dateutil.tz
+import dateutil.rrule
+import dateutil.tz
 import os
 
 

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -338,7 +338,7 @@ class vDDDTypes(TimeBase):
             self.params = Parameters({'value': 'PERIOD'})
 
         tzid = tzid_from_dt(dt) if isinstance(dt, (datetime, time)) else None
-        if not tzid is None and tzid != 'UTC':
+        if tzid is not None and tzid != 'UTC':
             self.params.update({'TZID': tzid})
 
         self.dt = dt

--- a/src/icalendar/tests/conftest.py
+++ b/src/icalendar/tests/conftest.py
@@ -5,9 +5,8 @@ except ImportError:
 import pytest
 import icalendar
 import pytz
-from datetime import datetime
 from dateutil import tz
-from icalendar.cal import Component, Calendar, Event, ComponentFactory
+from icalendar.cal import Component, Calendar
 from icalendar.timezone import tzp as _tzp
 from icalendar.timezone import TZP
 from pathlib import Path

--- a/src/icalendar/tests/prop/test_unit.py
+++ b/src/icalendar/tests/prop/test_unit.py
@@ -4,11 +4,6 @@ from datetime import time
 from datetime import timedelta
 from icalendar.parser import Parameters
 import unittest
-from icalendar.prop import vDatetime, vDDDTypes
-from icalendar.timezone.windows_to_olson import WINDOWS_TO_OLSON
-import pytest
-from copy import deepcopy
-from dateutil import tz
 
 
 class TestProp(unittest.TestCase):

--- a/src/icalendar/tests/test_cli_tool.py
+++ b/src/icalendar/tests/test_cli_tool.py
@@ -1,6 +1,6 @@
 import unittest
 
-from datetime import tzinfo, datetime
+from datetime import datetime
 from icalendar import Calendar, cli
 try:
     import zoneinfo

--- a/src/icalendar/tests/test_components_break_on_bad_ics.py
+++ b/src/icalendar/tests/test_components_break_on_bad_ics.py
@@ -1,6 +1,5 @@
 import pytest
 
-from icalendar import Event, Calendar
 
 def test_ignore_exceptions_on_broken_events_issue_104(events):
     ''' Issue #104 - line parsing error in a VEVENT
@@ -25,7 +24,7 @@ def test_rdate_dosent_become_none_on_invalid_input_issue_464(events):
     '''
     assert events.issue_464_invalid_rdate.is_broken
     assert ('RDATE', 'Expected period format, got: 199709T180000Z/PT5H30M') in events.issue_464_invalid_rdate.errors
-    assert not b'RDATE:None' in events.issue_464_invalid_rdate.to_ical()
+    assert b'RDATE:None' not in events.issue_464_invalid_rdate.to_ical()
 
 @pytest.mark.parametrize('calendar_name', [
     'big_bad_calendar',

--- a/src/icalendar/tests/test_icalendar.py
+++ b/src/icalendar/tests/test_icalendar.py
@@ -1,6 +1,3 @@
-import icalendar
-import os
-import textwrap
 from ..parser import Contentlines, Contentline, Parameters, foldline
 from ..parser import q_join, q_split, dquote
 from ..prop import vText

--- a/src/icalendar/tests/test_issue_116.py
+++ b/src/icalendar/tests/test_issue_116.py
@@ -1,10 +1,5 @@
-import unittest
 
-import datetime
 import icalendar
-import os
-import pytest
-from dateutil import tz
 
 
 def test_issue_116():

--- a/src/icalendar/tests/test_issue_165_missing_event.py
+++ b/src/icalendar/tests/test_issue_165_missing_event.py
@@ -2,7 +2,6 @@
 
    https://github.com/collective/icalendar/issues/165
 '''
-from icalendar import Calendar
 
 def test_issue_165_missing_event(calendars):
     events = list(calendars.issue_165_missing_event.walk('VEVENT'))

--- a/src/icalendar/tests/test_issue_168_parsing_invalid_calendars_no_warning.py
+++ b/src/icalendar/tests/test_issue_168_parsing_invalid_calendars_no_warning.py
@@ -2,7 +2,6 @@
 
    https://github.com/collective/icalendar/issues/168
 '''
-from icalendar import Calendar
 
 def test_issue_168_parsing_inavlid_calendars_no_warning(calendars):
     expected_error = (None, "Content line could not be parsed into parts: 'X-APPLE-RADIUS=49.91307046514149': X-APPLE-RADIUS=49.91307046514149")

--- a/src/icalendar/tests/test_issue_27_period.py
+++ b/src/icalendar/tests/test_issue_27_period.py
@@ -2,7 +2,6 @@
 
    https://github.com/collective/icalendar/issues/27
 '''
-from icalendar import Calendar
 
 def test_issue_27_multiple_periods(calendars):
     free_busy = list(calendars.issue_27_multiple_periods_in_freebusy_multiple_freebusies.walk('VFREEBUSY'))[0]

--- a/src/icalendar/tests/test_issue_350.py
+++ b/src/icalendar/tests/test_issue_350.py
@@ -2,7 +2,6 @@
 
    https://github.com/collective/icalendar/issues/350
 '''
-from icalendar import Calendar
 
 def test_issue_350(calendars):
     calendar = list(calendars.issue_350.walk('X-COMMENT'))

--- a/src/icalendar/tests/test_issue_500_vboolean_for_parameter.py
+++ b/src/icalendar/tests/test_issue_500_vboolean_for_parameter.py
@@ -2,7 +2,7 @@ from icalendar import Event, vBoolean, vCalAddress
 
 def test_vBoolean_can_be_used_as_parameter_issue_500(events):
     '''https://github.com/collective/icalendar/issues/500'''
-    attendee = vCalAddress(f'mailto:someone@example.com')
+    attendee = vCalAddress('mailto:someone@example.com')
     attendee.params['rsvp'] = vBoolean(True)
     event = Event()
     event.add('attendee', attendee)

--- a/src/icalendar/tests/test_multiple.py
+++ b/src/icalendar/tests/test_multiple.py
@@ -1,5 +1,4 @@
 """An example with multiple VCALENDAR components"""
-from icalendar import Calendar
 from icalendar.prop import vText
 
 

--- a/src/icalendar/tests/test_property_params.py
+++ b/src/icalendar/tests/test_property_params.py
@@ -1,8 +1,6 @@
 import pytest
 from icalendar import Calendar, Event, Parameters, vCalAddress
 
-import unittest
-import icalendar
 import re
 
 @pytest.mark.parametrize('parameter, expected', [

--- a/src/icalendar/tests/test_timezoned.py
+++ b/src/icalendar/tests/test_timezoned.py
@@ -1,9 +1,7 @@
-import unittest
 
 import datetime
 import dateutil.parser
 import icalendar
-import os
 from icalendar.prop import tzid_from_dt
 
 

--- a/src/icalendar/tests/test_unit_cal.py
+++ b/src/icalendar/tests/test_unit_cal.py
@@ -1,14 +1,13 @@
 import itertools
 from datetime import datetime
 from datetime import timedelta
-import unittest
 
 import pytest
 
 import icalendar
 import re
-from icalendar.cal import Component, Calendar, Event, ComponentFactory
-from icalendar import prop, cal
+from icalendar.cal import Component, Calendar, Event
+from icalendar import prop
 from icalendar.prop import tzid_from_dt
 
 

--- a/src/icalendar/tests/test_with_doctest.py
+++ b/src/icalendar/tests/test_with_doctest.py
@@ -73,6 +73,3 @@ def test_documentation_file(document, zoneinfo_only, env_for_doctest):
 
 def test_can_import_zoneinfo(env_for_doctest):
     """Allow importing zoneinfo for tests."""
-    import pytz
-    import zoneinfo
-    from dateutil import tz

--- a/src/icalendar/tests/test_with_doctest.py
+++ b/src/icalendar/tests/test_with_doctest.py
@@ -51,7 +51,7 @@ try:
         if filename.lower().endswith(".rst")
     ]
 except FileNotFoundError:
-    raise EnvironmentError("Could not find the documentation - remove the build folder and try again.")
+    raise OSError("Could not find the documentation - remove the build folder and try again.")
 
 @pytest.mark.parametrize("filename", [
     "README.rst",


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgracde --py38-plus`.