### PR TITLE
Allow docs to build on Python 3.12 by replacing `pkg_resources` with …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ Breaking changes:
       import icalendar
       icalendar.use_pytz()
 
+- Replaced ``pkg_resources.get_distribution`` with ``importlib.metadata`` in
+  ``docs/conf.py`` to allow building docs on Python 3.12.
+
 New features:
 
 - ...

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ files.
 .. _`BSD`: https://github.com/collective/icalendar/issues/2
 
 Quick start guide
------------
+-----------------
 
 ``icalendar`` enables you to **create**, **inspect** and **modify**
 calendaring information with Python.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 # icalendar documentation build configuration file
-import pkg_resources
+import importlib.metadata
 import datetime
 import os
 
@@ -28,7 +28,7 @@ master_doc = 'index'
 project = 'icalendar'
 this_year = datetime.date.today().year
 copyright = f'{this_year}, Plone Foundation'
-version = pkg_resources.get_distribution('icalendar').version
+version = importlib.metadata.version('icalendar')
 release = version
 
 exclude_patterns = ['_build', 'lib', 'bin', 'include', 'local']

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -73,6 +73,7 @@ icalendar contributors
 - Matt Lewis <git@semiprime.com>
 - Felix Stupp <felix.stupp@banananet.work>
 - Bastian Wegge <wegge@crossbow.de>
+- `Steve Piercy <https://github.com/stevepiercy>`_
 
 Find out who contributed::
 


### PR DESCRIPTION
…`importlib.metadata`.

- Fix underline length in README.rst

See #635