### PR TITLE
Enhance documentation of API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ Breaking changes:
       import icalendar
       icalendar.use_pytz()
 
+- Replaced ``pkg_resources.get_distribution`` with ``importlib.metadata`` in
+  ``docs/conf.py`` to allow building docs on Python 3.12.
+
 New features:
 
 - ...

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,7 @@ Breaking changes:
 
 New features:
 
-- ...
+- Added missing public classes and functions to API documentation.
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ files.
 .. _`BSD`: https://github.com/collective/icalendar/issues/2
 
 Quick start guide
------------
+-----------------
 
 ``icalendar`` enables you to **create**, **inspect** and **modify**
 calendaring information with Python.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,8 +7,38 @@ icalendar.cal
 .. automodule:: icalendar.cal
    :members:
 
+icalendar.caselessdict
+++++++++++++++++++++++
+
+.. automodule:: icalendar.caselessdict
+   :members:
+
+icalendar.cli
++++++++++++++
+
+.. automodule:: icalendar.cli
+   :members:
+
+icalendar.parser
+++++++++++++++++
+
+.. automodule:: icalendar.parser
+   :members:
+
+icalendar.parser_tools
+++++++++++++++++++++++
+
+.. automodule:: icalendar.parser_tools
+   :members:
+
 icalendar.prop
 ++++++++++++++
 
 .. automodule:: icalendar.prop
+   :members:
+
+icalendar.tools
++++++++++++++++
+
+.. automodule:: icalendar.tools
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 # icalendar documentation build configuration file
-import pkg_resources
+import importlib.metadata
 import datetime
 import os
 
@@ -28,7 +28,7 @@ master_doc = 'index'
 project = 'icalendar'
 this_year = datetime.date.today().year
 copyright = f'{this_year}, Plone Foundation'
-version = pkg_resources.get_distribution('icalendar').version
+version = importlib.metadata.version('icalendar')
 release = version
 
 exclude_patterns = ['_build', 'lib', 'bin', 'include', 'local']

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -73,6 +73,7 @@ icalendar contributors
 - Matt Lewis <git@semiprime.com>
 - Felix Stupp <felix.stupp@banananet.work>
 - Bastian Wegge <wegge@crossbow.de>
+- `Steve Piercy <https://github.com/stevepiercy>`_
 
 Find out who contributed::
 

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -2,6 +2,7 @@
 prefer) for the classes/datatypes that are used in iCalendar:
 
 ###########################################################################
+
 # This module defines these property value data types and property parameters
 
 4.2 Defined property parameters are:


### PR DESCRIPTION
Fixes #631.

Depends on #636 for change log consistency.

I also fixed a docstring that returned this error:

```pycon
/Users/stevepiercy/projects/icalendar/src/icalendar/prop.py:docstring of icalendar.prop:4: CRITICAL: Missing matching underline for section title overline.

###########################################################################
# This module defines these property value data types and property parameters
```

Sphinx treated that line as a page title, and a blank line resolved the issue.

I'm not sure whether you want that line to be a comment or displayed, though.