### PR TITLE
Remove is_broken property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,9 @@ Breaking changes:
 
 - Replaced ``pkg_resources.get_distribution`` with ``importlib.metadata`` in
   ``docs/conf.py`` to allow building docs on Python 3.12.
+- Remove ``is_broken`` property. Use ``errors`` instead to check if a
+  component had suppressed parsing errors.
+  See `Issue 424 <https://github.com/collective/icalendar/issues/424>`_.
 
 New features:
 

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -118,10 +118,6 @@ class Component(CaselessDict):
         """
         return True if not (list(self.values()) + self.subcomponents) else False  # noqa
 
-    @property
-    def is_broken(self):
-        return bool(self.errors)
-
     #############################
     # handling of property values
 

--- a/src/icalendar/tests/test_components_break_on_bad_ics.py
+++ b/src/icalendar/tests/test_components_break_on_bad_ics.py
@@ -9,7 +9,6 @@ def test_ignore_exceptions_on_broken_events_issue_104(events):
 
     https://github.com/collective/icalendar/issues/104
     '''
-    assert events.issue_104_mark_events_broken.is_broken # TODO: REMOVE FOR NEXT MAJOR RELEASE
     assert events.issue_104_mark_events_broken.errors == [(None, "Content line could not be parsed into parts: 'X': Invalid content line")]
 
 def test_dont_ignore_exceptions_on_broken_calendars_issue_104(calendars):
@@ -23,7 +22,6 @@ def test_rdate_dosent_become_none_on_invalid_input_issue_464(events):
     '''Issue #464 - [BUG] RDATE can become None if value is invalid
     https://github.com/collective/icalendar/issues/464
     '''
-    assert events.issue_464_invalid_rdate.is_broken
     assert ('RDATE', 'Expected period format, got: 199709T180000Z/PT5H30M') in events.issue_464_invalid_rdate.errors
     assert not b'RDATE:None' in events.issue_464_invalid_rdate.to_ical()
 
@@ -38,4 +36,3 @@ def test_error_message_doesnt_get_too_big(calendars, calendar_name):
         calendars[calendar_name]
     # Ignore part before first : for the test.
     assert len(str(exception).split(': ', 1)[1]) <= 100
-


### PR DESCRIPTION
Fix #424
Contribute to #630.

`.errors` would be enough.