### PR TITLE
Update documentation for versions 3.8+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,7 +52,7 @@ New features:
 
 Bug fixes:
 
-- Change documentation to represent compatibility to Python 3.8+ and PyPy3
+- Change documentation to represent compatibility with Python 3.8 - 3.12, and PyPy3.
 - Rename RFC 2445 to RFC 5545, see `Issue 278
   <https://github.com/collective/icalendar/issues/278>`_
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,7 +42,7 @@ New features:
 
 Bug fixes:
 
-- ...
+- Change documentation to represent compatibility to Python 3.8+ and PyPy3
 
 5.0.13 (2024-06-20)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -166,7 +166,7 @@ you can receive all the latest updates, and switch back to earlier behavior:
     <DstTzInfo 'Europe/Vienna' CET+1:00:00 STD>
 
 Version 6 is on `branch main <https://github.com/collective/icalendar/>`_.
-It is compatible with Python versions 3.7 - 3.11, and PyPy3.
+It is compatible with Python versions 3.8 - 3.12, and PyPy3.
 We expect the ``main`` branch with versions ``6+`` to receive the latest updates and features.
 
 Related projects

--- a/README.rst
+++ b/README.rst
@@ -136,21 +136,8 @@ with the same result:
     X-DT-ZONEINFO;TZID=Europe/London:20240619T100100
     END:VEVENT
 
-
-
-Versions and Compatibility
---------------------------
-
-``icalendar`` is a critical project used by many. It has been there for a long time and maintaining
-long-term compatibility with projects conflicts partially with providing and using the features that
-the latest Python versions bring.
-
-Volunteers pour `effort into maintaining and developing icalendar
-<https://github.com/collective/icalendar/discussions/360>`_.
-Below, you can find an overview of the versions and how we maintain them.
-
-Version 6
-~~~~~~~~~
+Version 6 with zoneinfo
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Version 6 of ``icalendar`` switches the timezone implementation to ``zoneinfo``.
 This only affects you if you parse ``icalendar`` objects with ``from_ical()``.
@@ -166,7 +153,7 @@ By default and since 6.0.0, ``zoneinfo`` timezones are created.
     ZoneInfo(key='Europe/Vienna')
 
 If you would like to continue to receive ``pytz`` timezones in as parse results,
-you can receive all the latest updates, and switch back to version 5.x behavior:
+you can receive all the latest updates, and switch back to earlier behavior:
 
 .. code:: python
 
@@ -175,22 +162,8 @@ you can receive all the latest updates, and switch back to version 5.x behavior:
     >>> dt.tzinfo
     <DstTzInfo 'Europe/Vienna' CET+1:00:00 STD>
 
-Version 6 is on `branch master <https://github.com/collective/icalendar/>`_ with compatibility to Python versions ``3.7+`` and ``PyPy3``.
-We expect the ``master`` branch with versions ``6+`` to receive the latest updates and features.
-
-Version 5
-~~~~~~~~~
-
-Version 5 uses only the ``pytz`` timezone implementation, and not ``zoneinfo``.
-No updates will be released for this.
-Please use version 6 and switch to use ``zoneinfo`` as documented above.
-
-Version 4
-~~~~~~~~~
-
-Version 4 is on `branch 4.x <https://github.com/collective/icalendar/tree/4.x>`_ with maximum compatibility with Python versions ``2.7`` and ``3.4+``, ``PyPy2`` and ``PyPy3``.
-The ``4.x`` branch only receives security and bug fixes if someone makes the effort.
-We recommend migrating to later Python versions and also providing feedback if you depend on the ``4.x`` features.
+Version 6 is on `branch main <https://github.com/collective/icalendar/>`_ with compatibility to C-Python and PyPy3.
+We expect the ``main`` branch with versions ``6+`` to receive the latest updates and features.
 
 Related projects
 ================

--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,8 @@ you can receive all the latest updates, and switch back to earlier behavior:
     >>> dt.tzinfo
     <DstTzInfo 'Europe/Vienna' CET+1:00:00 STD>
 
-Version 6 is on `branch main <https://github.com/collective/icalendar/>`_ with compatibility to C-Python and PyPy3.
+Version 6 is on `branch main <https://github.com/collective/icalendar/>`_.
+It is compatible with Python versions 3.7 - 3.11, and PyPy3.
 We expect the ``main`` branch with versions ``6+`` to receive the latest updates and features.
 
 Related projects


### PR DESCRIPTION
This compacts the documentation.
Mentions of old versions are removed.
A concise path from 5.x to 6.0 is outlined.
master -> main

Contributes to https://github.com/collective/icalendar/issues/513