### PR TITLE
fix version of icalendar during install to major version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Minor changes:
 - Test that all code works with both ``pytz`` and ``zoneinfo``.
 - Rename ``master`` branch to ``main``, see `Issue
   <https://github.com/collective/icalendar/issues/627>`_
-
+- Fix version in documentation to ``6.*``
 - Added missing public classes and functions to API documentation.
 - Add version badge
 

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ calendaring information with Python.
 
 To **install** the package, run::
 
-    pip install icalendar
+    pip install 'icalendar==6.*'
 
 
 Inspect Files


### PR DESCRIPTION
See https://github.com/collective/icalendar/issues/630#issuecomment-2188652309

This prevents us to wonder about the next major version change and if people get confused.