### PR TITLE
Make coverage report optional in case it fails to submit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Test
       run: tox -e ${{ matrix.config[1] }}
     - name: Upload coverage data to coveralls.io
-      run: coveralls --service=github-actions || which coveralls
+      run: coveralls --service=github || which coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_REPO_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -66,7 +66,7 @@ jobs:
     - name: Install dependencies
       run: pip3 install --upgrade coveralls
     - name: Upload coverage
-      run: coveralls --service=github-actions --finish || which coveralls
+      run: coveralls --service=github --finish || which coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_REPO_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Test
       run: tox -e ${{ matrix.config[1] }}
     - name: Upload coverage data to coveralls.io
-      run: coveralls --service=github-actions
+      run: coveralls --service=github-actions || which coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_REPO_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -66,7 +66,7 @@ jobs:
     - name: Install dependencies
       run: pip3 install --upgrade coveralls
     - name: Upload coverage
-      run: coveralls --service=github-actions --finish
+      run: coveralls --service=github-actions --finish || which coveralls
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_REPO_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,9 @@ jobs:
     # see https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-support
     name: Submit test coverage
     needs: run-tests
+    # always finalize coverage aftest tests ran
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-not-requiring-successful-dependent-jobs
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     container: python:3-slim
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Minor changes:
 
 - Test that all code works with both ``pytz`` and ``zoneinfo``.
 - Make coverage report submission optional for pull requests
+- Parallelize coverage
 - Rename ``master`` branch to ``main``, see `Issue
   <https://github.com/collective/icalendar/issues/627>`_
 - Added missing public classes and functions to API documentation.


### PR DESCRIPTION
Sometimes, we get this error:
coveralls.exception.CoverallsException: Could not submit coverage: 422 Client Error: Unprocessable Entity for url: https://coveralls.io/api/v1/jobs

This PR allows the error to happen while also maintaining the test result and making sure that we actually installed all dependencies.

This is a follow up from
https://github.com/collective/icalendar/pull/644
main branch failed:
https://github.com/collective/icalendar/actions/runs/9663149658/job/26654629821