### PR TITLE
Create a release message pointing people to the changelog and PyPI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,5 +139,9 @@ jobs:
       name: github-release
     steps:
       - uses: actions/checkout@v4
-      - name: create release
+      - name: Create GitHub release from tag
         uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          body: "To view the changes, please see the [Changelog](https://icalendar.readthedocs.io/en/latest/changelog.html). This release can be installed from [PyPI](https://pypi.org/project/icalendar/#history)."
+          generateReleaseNotes: false

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 Minor changes:
 
 - Test that all code works with both ``pytz`` and ``zoneinfo``.
+- Add message to GitHub release, pointing to the changelog
 - Make coverage report submission optional for pull requests
 - Rename ``master`` branch to ``main``, see `Issue
   <https://github.com/collective/icalendar/issues/627>`_


### PR DESCRIPTION
This adds a message to the release.

I use this at the OpenWebCalendar.

See this release:
https://github.com/collective/icalendar/releases/tag/v5.0.13
See this release:
https://github.com/niccokunzmann/open-web-calendar/releases/tag/v1.35