### PR TITLE
Add __all__ attributes to icalendar modules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Minor changes:
 - Rename ``master`` branch to ``main``, see `Issue
   <https://github.com/collective/icalendar/issues/627>`_
 - Added missing public classes and functions to API documentation.
-- Improved namespace management in the icalendar directory.
+- Improved namespace management in the ``icalendar`` directory.
 - Add Python version badge and badge for test coverage
 - Remove 4.x badge
 - Update list of ``tox`` environments

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Minor changes:
 - Rename ``master`` branch to ``main``, see `Issue
   <https://github.com/collective/icalendar/issues/627>`_
 - Added missing public classes and functions to API documentation.
+- Improved namespace management in the icalendar directory.
 - Add Python version badge and badge for test coverage
 - Remove 4.x badge
 - Update list of ``tox`` environments

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -74,6 +74,7 @@ icalendar contributors
 - Felix Stupp <felix.stupp@banananet.work>
 - Bastian Wegge <wegge@crossbow.de>
 - `Steve Piercy <https://github.com/stevepiercy>`_
+- Jeffrey Whewhetu <jeffwhewhetu@gmail.com>
 
 Find out who contributed::
 

--- a/src/icalendar/__init__.py
+++ b/src/icalendar/__init__.py
@@ -44,3 +44,9 @@ from icalendar.parser import (
 
 # Switching the timezone provider
 from icalendar.timezone import use_pytz, use_zoneinfo
+
+
+__all__ = ['Calendar', 'Event', 'Todo', 'Journal', 'Timezone', 'TimezoneStandard', 'TimezoneDaylight', 'FreeBusy', 'Alarm',
+          'ComponentFactory', 'vBinary', 'vBoolean', 'vCalAddress', 'vDatetime', 'vDate', 'vDDDTypes', 'vDuration',
+          'vFloat, 'vInt', 'vPeriod','vWeekday', 'vFrequency', 'vRecur', 'vText', 'vTime', 'vUri', 'vGeo', 'vUTCOffset',
+          'vTypesFactory', 'Parameters', 'q_split', 'q_join', 'use_pytz', 'use_zoneinfo']

--- a/src/icalendar/__init__.py
+++ b/src/icalendar/__init__.py
@@ -48,5 +48,5 @@ from icalendar.timezone import use_pytz, use_zoneinfo
 
 __all__ = ['Calendar', 'Event', 'Todo', 'Journal', 'Timezone', 'TimezoneStandard', 'TimezoneDaylight', 'FreeBusy', 'Alarm',
           'ComponentFactory', 'vBinary', 'vBoolean', 'vCalAddress', 'vDatetime', 'vDate', 'vDDDTypes', 'vDuration',
-          'vFloat, 'vInt', 'vPeriod','vWeekday', 'vFrequency', 'vRecur', 'vText', 'vTime', 'vUri', 'vGeo', 'vUTCOffset',
+          'vFloat', 'vInt', 'vPeriod','vWeekday', 'vFrequency', 'vRecur', 'vText', 'vTime', 'vUri', 'vGeo', 'vUTCOffset',
           'vTypesFactory', 'Parameters', 'q_split', 'q_join', 'use_pytz', 'use_zoneinfo']


### PR DESCRIPTION
This commit improves the namespace management within the `icalendar` directory by adding __all__ attributes to the `__init__.py` files of each module. This allows for clearer control over what is imported when using wildcard imports.
Closes #638