### PR TITLE
docs: replace pytz usage to zoneinfo in documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Minor changes:
 - Make coverage report submission optional for pull requests
 - Rename ``master`` branch to ``main``, see `Issue
   <https://github.com/collective/icalendar/issues/627>`_
+- Update ``docs/usage.rst`` to use zoneinfo instead of pytz.  
 - Added missing public classes and functions to API documentation.
 - Improved namespace management in the ``icalendar`` directory.
 - Add Python version badge and badge for test coverage

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -231,10 +231,10 @@ Property parameters are automatically added, depending on the input value. For
 example, for date/time related properties, the value type and timezone
 identifier (if applicable) are automatically added here::
 
-    >>> import pytz
+    >>> import zoneinfo
     >>> event = Event()
     >>> event.add('dtstart', datetime(2010, 10, 10, 10, 0, 0,
-    ...                               tzinfo=pytz.timezone("Europe/Vienna")))
+    ...                               tzinfo=zoneinfo.ZoneInfo("Europe/Vienna")))
 
     >>> lines = event.to_ical().splitlines()
     >>> assert (
@@ -262,7 +262,7 @@ Init the calendar::
 
   >>> cal = Calendar()
   >>> from datetime import datetime
-  >>> import pytz
+  >>> import zoneinfo
 
 Some properties are required to be compliant::
 
@@ -273,9 +273,9 @@ We need at least one subcomponent for a calendar to be compliant::
 
   >>> event = Event()
   >>> event.add('summary', 'Python meeting about calendaring')
-  >>> event.add('dtstart', datetime(2005,4,4,8,0,0,tzinfo=pytz.utc))
-  >>> event.add('dtend', datetime(2005,4,4,10,0,0,tzinfo=pytz.utc))
-  >>> event.add('dtstamp', datetime(2005,4,4,0,10,0,tzinfo=pytz.utc))
+  >>> event.add('dtstart', datetime(2005,4,4,8,0,0,tzinfo=zoneinfo.ZoneInfo("UTC")))
+  >>> event.add('dtend', datetime(2005,4,4,10,0,0,tzinfo=zoneinfo.ZoneInfo("UTC")))
+  >>> event.add('dtstamp', datetime(2005,4,4,0,10,0,tzinfo=zoneinfo.ZoneInfo("UTC")))
 
 A property with parameters. Notice that they are an attribute on the value::
 


### PR DESCRIPTION
This PR closes issue #651