### PR TITLE
Check distribution build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,11 +71,29 @@ jobs:
         parallel-finished: true
         format: cobertura
 
+  test-distribution:
+    name: Check built package
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install wheel twine
+    - name: Build distribution files
+      run: python setup.py bdist_wheel sdist
+    - name: Check distribution files
+      run: twine check dist/*
+
   deploy-tag-to-pypi:
     # only deploy on tags, see https://stackoverflow.com/a/58478262/1320237
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
     - run-tests
+    - test-distribution
     runs-on: ubuntu-latest
     # This environment stores the TWINE_USERNAME and TWINE_PASSWORD
     # see https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
@@ -92,7 +110,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -133,7 +151,8 @@ jobs:
     # only deploy on tags, see https://stackoverflow.com/a/58478262/1320237
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
-      - run-tests
+    - run-tests
+    - test-distribution
     runs-on: ubuntu-latest
     environment:
       name: github-release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install wheel twine
+        pip install wheel twine setuptools
     - name: Build distribution files
       run: python setup.py bdist_wheel sdist
     - name: Check distribution files
@@ -115,7 +115,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install wheel twine
+        pip install wheel twine setuptools
     - name: Check the tag
       run: |
         PACKAGE_VERSION=`python setup.py --version`

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,7 @@ jobs:
 
   test-distribution:
     name: Check built package
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Minor changes:
 - Remove 4.x badge
 - Update list of ``tox`` environments
 - Use Coveralls' GitHub Action
+- Check distribution in CI
 
 Breaking changes:
 

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ files.
 .. _`BSD`: https://github.com/collective/icalendar/issues/2
 
 Quick start guide
------------------
+=================
 
 ``icalendar`` enables you to **create**, **inspect** and **modify**
 calendaring information with Python.
@@ -58,7 +58,7 @@ To **install** the package, run::
 
 
 Inspect Files
-~~~~~~~~~~~~~
+-------------
 
 You can open an ``.ics`` file and see all the events::
 
@@ -74,7 +74,7 @@ You can open an ``.ics`` file and see all the events::
   International Women's Day
 
 Modify Content
-~~~~~~~~~~~~~~
+--------------
 
 Such a calendar can then be edited and saved again.
 
@@ -91,7 +91,7 @@ Such a calendar can then be edited and saved again.
 
 
 Create Events, TODOs, Journals, Alarms, ...
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------------------
 
 ``icalendar`` supports the creation and parsing of all kinds of objects
 in the iCalendar (RFC 5545) standard.
@@ -114,7 +114,7 @@ Have a look at `more examples
 <https://icalendar.readthedocs.io/en/latest/usage.html>`_.
 
 Use timezones of your choice
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 
 With ``icalendar``, you can localize your events to take place in different
 timezones.
@@ -141,7 +141,7 @@ with the same result:
     END:VEVENT
 
 Version 6 with zoneinfo
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 Version 6 of ``icalendar`` switches the timezone implementation to ``zoneinfo``.
 This only affects you if you parse ``icalendar`` objects with ``from_ical()``.

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
     version=version,
     description=shortdesc,
     long_description=longdesc,
+    long_description_content_type="text/x-rst",
     classifiers=[  # https://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
The release tag failed for v6.0.0a0.

```
Checking dist/icalendar-6.0.0a0-py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         line 212: Severe: Title level inconsistent:                            
                                                                                
         Changelog                                                              
         =========                                                              
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
Checking dist/icalendar-6.0.0a0.tar.gz: FAILED
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.                                                      
         line 212: Severe: Title level inconsistent:                            
                                                                                
         Changelog                                                              
         =========                                                              
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.   
Error: Process completed with exit code 1.
```

This adds tests and dependencies to make sure that PRs do not break just at the release time but before.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--685.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->