### PR TITLE
Fix broken link in doc.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ New features:
 
 Bug fixes:
 
-- Documentation link fix, see [issue](https://github.com/collective/icalendar/issues/614)
+- Documentation link fix, see issue https://github.com/collective/icalendar/issues/614
 
 6.0.0a0 (2024-06-03)
 --------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ New features:
 
 Bug fixes:
 
-- ...
+- Documentation link fix, see [issue](https://github.com/collective/icalendar/issues/614)
 
 6.0.0a0 (2024-06-03)
 --------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ New features:
 
 Bug fixes:
 
-- Documentation link fix, see issue https://github.com/collective/icalendar/issues/614
+- Fix link to stable release of tox in documentation.
 
 6.0.0a0 (2024-06-03)
 --------------------

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -75,6 +75,7 @@ icalendar contributors
 - Bastian Wegge <wegge@crossbow.de>
 - `Steve Piercy <https://github.com/stevepiercy>`_
 - Jeffrey Whewhetu <jeffwhewhetu@gmail.com>
+- `Soham Dutta <https://github.com/NP-compete>`
 
 Find out who contributed::
 

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -75,7 +75,7 @@ icalendar contributors
 - Bastian Wegge <wegge@crossbow.de>
 - `Steve Piercy <https://github.com/stevepiercy>`_
 - Jeffrey Whewhetu <jeffwhewhetu@gmail.com>
-- `Soham Dutta <https://github.com/NP-compete>`
+- `Soham Dutta <https://github.com/NP-compete>`_
 
 Find out who contributed::
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -64,7 +64,7 @@ To run all tests in all environments, simply run ``tox``
 You may not have all Python versions installed or
 you may want to run a specific one.
 Have a look at the `documentation
-<https://tox.wiki/en/4.16.0/user_guide.html#cli>`__.
+<https://tox.wiki/en/stable/user_guide.html#cli>`_.
 This is how you can run ``tox`` with Python 3.9:
 
 .. code-block:: shell

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -64,7 +64,7 @@ To run all tests in all environments, simply run ``tox``
 You may not have all Python versions installed or
 you may want to run a specific one.
 Have a look at the `documentation
-<https://tox.wiki/en/latest/example/general.html#selecting-one-or-more-environments-to-run-tests-against>`__.
+<https://tox.wiki/en/4.16.0/user_guide.html#cli>`__.
 This is how you can run ``tox`` with Python 3.9:
 
 .. code-block:: shell


### PR DESCRIPTION
Issue: https://github.com/collective/icalendar/issues/614

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--688.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->