### PR TITLE
Fixed a bad replace in parser.py.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ New features:
 Bug fixes:
 
 - Fix link to stable release of tox in documentation.
+- Fix a bad bytes replace in unescape_char.
 
 6.0.0a0 (2024-07-03)
 --------------------

--- a/src/icalendar/parser.py
+++ b/src/icalendar/parser.py
@@ -40,7 +40,7 @@ def unescape_char(text):
     elif isinstance(text, bytes):
         return text.replace(b'\\N', b'\\n')\
                    .replace(b'\r\n', b'\n')\
-                   .replace(b'\n', b'\n')\
+                   .replace(b'\\n', b'\n')\
                    .replace(b'\\,', b',')\
                    .replace(b'\\;', b';')\
                    .replace(b'\\\\', b'\\')

--- a/src/icalendar/tests/test_parsing.py
+++ b/src/icalendar/tests/test_parsing.py
@@ -3,7 +3,7 @@ import pytest
 import base64
 from icalendar import Calendar, vRecur, vBinary, Event
 from datetime import datetime
-from icalendar.parser import Contentline, Parameters
+from icalendar.parser import Contentline, Parameters, unescape_char
 
 @pytest.mark.parametrize('calendar_name', [
     # Issue #178 - A component with an unknown/invalid name is represented
@@ -188,3 +188,6 @@ def test_escaped_characters_read(event_name, expected_cn, expected_ics, events):
     event = events[event_name]
     assert event['ORGANIZER'].params['CN'] == expected_cn
     assert event['ORGANIZER'].to_ical() == expected_ics.encode('utf-8')
+def test_unescape_char():
+    assert unescape_char(b'123') == b'123'
+    assert unescape_char(b"\\n") == b"\n"

--- a/src/icalendar/tests/test_parsing.py
+++ b/src/icalendar/tests/test_parsing.py
@@ -188,6 +188,7 @@ def test_escaped_characters_read(event_name, expected_cn, expected_ics, events):
     event = events[event_name]
     assert event['ORGANIZER'].params['CN'] == expected_cn
     assert event['ORGANIZER'].to_ical() == expected_ics.encode('utf-8')
+    
 def test_unescape_char():
     assert unescape_char(b'123') == b'123'
     assert unescape_char(b"\\n") == b"\n"


### PR DESCRIPTION
This pull request fixes issue #525, where there was a bad replace in parser.py

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--694.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->