### PR TITLE
Fix test_with_doctest.py to run on Windows.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 Minor changes:
 
 - add ``__all__`` variable to each modules in ``icalendar`` package
+- Adapt ``test_with_doctest.py`` to correctly run on Windows.
 
 Breaking changes:
 

--- a/src/icalendar/tests/test_with_doctest.py
+++ b/src/icalendar/tests/test_with_doctest.py
@@ -21,13 +21,13 @@ HERE = os.path.dirname(__file__) or "."
 ICALENDAR_PATH = os.path.dirname(HERE)
 
 PYTHON_FILES = [
-    os.path.join(dirpath, filename)
+    "/".join((dirpath, filename))
     for dirpath, dirnames, filenames in os.walk(ICALENDAR_PATH)
     for filename in filenames if filename.lower().endswith(".py") and 'fuzzing' not in dirpath
 ]
 
 MODULE_NAMES = [
-    "icalendar" + python_file[len(ICALENDAR_PATH):-3].replace("/", ".")
+    "icalendar" + python_file[len(ICALENDAR_PATH):-3].replace("\\", "/").replace("/", ".")
     for python_file in PYTHON_FILES
 ]
 


### PR DESCRIPTION
On Windows, test_with_doctest.py fails because file and module paths have backslashes on them instead of forward slashes or dots. This PR fixes that by using a forward slash instead of `os.path.join` and by also substituting backslashes by forward slashes to figure out module names.

Happy to address any feedback or to close if it's not a necessary change.