### PR TITLE
Improved test coverage in 5 places for production code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 Minor changes:
 
 - add ``__all__`` variable to each modules in ``icalendar`` package
+- Improve test coverage.
 
 Breaking changes:
 
@@ -20,6 +21,7 @@ Bug fixes:
 
 - Fix link to stable release of tox in documentation.
 - Fix a bad bytes replace in unescape_char.
+- Handle ``ValueError`` in ``vBinary.from_ical``.
 
 6.0.0a0 (2024-07-03)
 --------------------

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -97,7 +97,7 @@ class vBinary:
     def from_ical(ical):
         try:
             return base64.b64decode(ical)
-        except UnicodeError:
+        except (ValueError, UnicodeError):
             raise ValueError('Not valid base 64 encoding.')
 
     def __eq__(self, other):

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -88,7 +88,7 @@ class vBinary:
         self.params = Parameters(encoding='BASE64', value="BINARY")
 
     def __repr__(self):
-        return f"vBinary('{self.to_ical()}')"
+        return f"vBinary({self.to_ical()})"
 
     def to_ical(self):
         return binascii.b2a_base64(self.obj.encode('utf-8'))[:-1]
@@ -160,7 +160,7 @@ class vCalAddress(str):
         return self
 
     def __repr__(self):
-        return f"vCalAddress('{self.to_ical()}')"
+        return f"vCalAddress('{self}')"
 
     def to_ical(self):
         return self.encode(DEFAULT_ENCODING)

--- a/src/icalendar/tests/prop/test_unit.py
+++ b/src/icalendar/tests/prop/test_unit.py
@@ -113,6 +113,7 @@ class TestProp(unittest.TestCase):
         self.assertRaises(ValueError, vFrequency, 'bad test')
         self.assertEqual(vFrequency('daily').to_ical(), b'DAILY')
         self.assertEqual(vFrequency('daily').from_ical('MONTHLY'), 'MONTHLY')
+        self.assertRaises(ValueError, vFrequency.from_ical, 234)
 
     def test_prop_vRecur(self):
         from icalendar.prop import vRecur

--- a/src/icalendar/tests/prop/test_unit.py
+++ b/src/icalendar/tests/prop/test_unit.py
@@ -44,6 +44,9 @@ class TestProp(unittest.TestCase):
 
         dt_list = vDDDLists([datetime(2000, 1, 1), datetime(2000, 11, 11)])
         self.assertEqual(dt_list.to_ical(), b'20000101T000000,20001111T000000')
+        
+        instance = vDDDLists([])
+        self.assertFalse(instance == "value")
 
     def test_prop_vDate(self):
         from icalendar.prop import vDate

--- a/src/icalendar/tests/prop/test_vBinary.py
+++ b/src/icalendar/tests/prop/test_vBinary.py
@@ -32,7 +32,7 @@ def test_long_data():
     
 def test_repr():
     instance = vBinary("value")
-    assert repr(instance) == "vBinary('b'value'')"
+    assert repr(instance) == "vBinary(b'value')"
     
 def test_from_ical():
     with pytest.raises(ValueError, match='Not valid base 64 encoding.'):

--- a/src/icalendar/tests/prop/test_vBinary.py
+++ b/src/icalendar/tests/prop/test_vBinary.py
@@ -32,7 +32,7 @@ def test_long_data():
     
 def test_repr():
     instance = vBinary("value")
-    assert repr(instance) == "vBinary(b'value')"
+    assert repr(instance) == "vBinary(b'dmFsdWU=')"
     
 def test_from_ical():
     with pytest.raises(ValueError, match='Not valid base 64 encoding.'):

--- a/src/icalendar/tests/prop/test_vBinary.py
+++ b/src/icalendar/tests/prop/test_vBinary.py
@@ -1,4 +1,6 @@
 """Test vBinary"""
+import pytest
+
 from icalendar import vBinary
 from icalendar.parser import Parameters
 
@@ -27,3 +29,13 @@ def test_long_data():
     txt_ical = b'YWFh' * 33
     assert (vBinary(txt).to_ical() == txt_ical)
     assert (vBinary.from_ical(txt_ical) == txt)
+    
+def test_repr():
+    instance = vBinary("value")
+    assert repr(instance) == "vBinary('b'dmFsdWU='')"
+    
+def test_from_ical():
+    with pytest.raises(ValueError, match='Not valid base 64 encoding.'):
+        vBinary.from_ical("value")
+    with pytest.raises(ValueError, match='Not valid base 64 encoding.'):
+        vBinary.from_ical("áèਮ")

--- a/src/icalendar/tests/prop/test_vBinary.py
+++ b/src/icalendar/tests/prop/test_vBinary.py
@@ -32,7 +32,7 @@ def test_long_data():
     
 def test_repr():
     instance = vBinary("value")
-    assert repr(instance) == "vBinary('b'dmFsdWU='')"
+    assert repr(instance) == "vBinary('b'value'')"
     
 def test_from_ical():
     with pytest.raises(ValueError, match='Not valid base 64 encoding.'):

--- a/src/icalendar/tests/prop/test_vCalAddress.py
+++ b/src/icalendar/tests/prop/test_vCalAddress.py
@@ -17,3 +17,8 @@ def test_params():
 
 def test_from_ical():
     assert vCalAddress.from_ical(txt) == 'MAILTO:maxm@mxm.dk'
+    
+
+def test_repr():
+    instance = vCalAddress("value")
+    assert repr(instance) == "vCalAddress('b'value'')"

--- a/src/icalendar/tests/prop/test_vCalAddress.py
+++ b/src/icalendar/tests/prop/test_vCalAddress.py
@@ -21,4 +21,4 @@ def test_from_ical():
 
 def test_repr():
     instance = vCalAddress("value")
-    assert repr(instance) == "vCalAddress('b'value'')"
+    assert repr(instance) == "vCalAddress('value')"


### PR DESCRIPTION
This PR fixes issue #629 by Improving test coverage in 5 places for production code

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--696.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->