### PR TITLE
Enable collection of branch coverage on test runs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Minor changes:
 - add ``__all__`` variable to each modules in ``icalendar`` package
 - Improve test coverage.
 - Adapt ``test_with_doctest.py`` to correctly run on Windows.
+- Measure branch coverage when running tests.
 
 Breaking changes:
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     hypothesis
     pytz
 commands =
-    coverage run --source=src/icalendar --omit=*/tests/hypothesis/* --omit=*/tests/fuzzed/* --module pytest []
+    coverage run --branch --source=src/icalendar --omit=*/tests/hypothesis/* --omit=*/tests/fuzzed/* --module pytest []
     coverage report
     coverage html
     coverage xml
@@ -32,7 +32,7 @@ deps =
     hypothesis
 commands =
     rm -rf build # do not mess up import
-    coverage run --source=src/icalendar --omit=*/tests/hypothesis/* --omit=*/tests/fuzzed/* --module pytest []
+    coverage run --branch --source=src/icalendar --omit=*/tests/hypothesis/* --omit=*/tests/fuzzed/* --module pytest []
     coverage report
     coverage html
     coverage xml


### PR DESCRIPTION
Having branch coverage information helps when trying to address issues like #698 and #629 (where we used it to find places to test).

This PR adds the `--branch` option to `coverage run` in tox.ini commands.

Possible downsides: test run time will likely increase, coverage numbers will probably go down. Still, the difference should not be huge and it will help improving coverage in the long term.