### PR TITLE
Release v6.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,10 +12,6 @@ Minor changes:
 - Measure branch coverage when running tests.
 - Export ``Component`` base class for typing
 
-Breaking changes:
-
-- ...
-
 New features:
 
 - Use ``pyproject.toml`` file instead of ``setup.py``
@@ -23,7 +19,7 @@ New features:
 Bug fixes:
 
 - Fix link to stable release of tox in documentation.
-- Fix a bad bytes replace in unescape_char.
+- Fix a bad ``bytes`` replace in ``unescape_char``.
 - Handle ``ValueError`` in ``vBinary.from_ical``.
 - Ignore the BOM character in incorrectly encoded ics files.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -125,8 +125,8 @@ Try it out:
     Python 3.12.0 (main, Mar  1 2024, 09:09:21) [GCC 13.2.0] on linux
     Type "help", "copyright", "credits" or "license" for more information.
     >>> import icalendar
-    >>> icalendar.version_tuple[0]
-    6
+    >>> icalendar.Calendar()
+    VCALENDAR({})
 
 Build the documentation
 -----------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -122,11 +122,11 @@ Try it out:
 
 .. code-block:: pycon
 
-    Python 3.9.5 (default, Nov 23 2021, 15:27:38)
+    Python 3.12.0 (main, Mar  1 2024, 09:09:21) [GCC 13.2.0] on linux
     Type "help", "copyright", "credits" or "license" for more information.
     >>> import icalendar
-    >>> icalendar.__version__
-    '6.0.0a0'
+    >>> icalendar.version_tuple[0]
+    6
 
 Build the documentation
 -----------------------

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -62,10 +62,7 @@ However, only people with ``PyPI environment access for GitHub Actions`` can app
 
 1. Check that the ``CHANGES.rst`` is up to date with the `latest merged pull requests <https://github.com/collective/icalendar/pulls?q=is%3Apr+is%3Amerged>`__
    and the version you want to release is correctly named.
-2. Change the ``__version__`` variable in
-
-   - the ``src/icalendar/__init__.py`` file and
-3. Create a commit on the ``release`` branch (or equivalent) to release this version.
+2. Create a commit on the ``release`` branch (or equivalent) to release this version.
 
    .. code-block:: bash
 
@@ -75,17 +72,17 @@ However, only people with ``PyPI environment access for GitHub Actions`` can app
        git add CHANGES.rst src/icalendar/__init__.py docs/install.rst
        git commit -m"version 5.0.0"
 
-4. Push the commit and `create a pull request <https://github.com/collective/icalendar/compare?expand=1>`__
+3. Push the commit and `create a pull request <https://github.com/collective/icalendar/compare?expand=1>`__
    Here is an `example pull request #457 <https://github.com/collective/icalendar/pull/457>`__.
 
    .. code-block:: bash
 
        git push -u origin release
 
-5. See if the `CI-tests <https://github.com/collective/icalendar/actions>`_ are running on the pull request.
+4. See if the `CI-tests <https://github.com/collective/icalendar/actions>`_ are running on the pull request.
    If they are not running, no new release can be issued.
    If the tests are running, merge the pull request.
-6. Clean up behind you!
+5. Clean up behind you!
 
    .. code-block:: bash
 
@@ -94,7 +91,7 @@ However, only people with ``PyPI environment access for GitHub Actions`` can app
        git branch -d release
        git push -d origin release
 
-7. Create a tag for the release and see if the `CI-tests`_ are running.
+6. Create a tag for the release and see if the `CI-tests`_ are running.
 
    .. code-block:: bash
 
@@ -103,15 +100,15 @@ However, only people with ``PyPI environment access for GitHub Actions`` can app
        git tag v5.0.0
        git push upstream v5.0.0 # could be origin or whatever reference
 
-8. Once the tag is pushed and its `CI-tests`_ are passing, maintainers will get an e-mail::
+7. Once the tag is pushed and its `CI-tests`_ are passing, maintainers will get an e-mail::
 
        Subject: Deployment review in collective/icalendar
 
        tests: PyPI is waiting for your review
 
-9. If the release is approved by a maintainer. It will be pushed to `PyPI`_.
+8. If the release is approved by a maintainer. It will be pushed to `PyPI`_.
    If that happens, notify the issues that were fixed about this release.
-10. Copy this to the start of ``CHANGES.rst``::
+9. Copy this to the start of ``CHANGES.rst``::
 
        5.0.2 (unreleased)
        ------------------
@@ -132,7 +129,7 @@ However, only people with ``PyPI environment access for GitHub Actions`` can app
 
        - ...
 
-11. Push the new CHANGELOG so it is used for future changes.
+10. Push the new CHANGELOG so it is used for future changes.
 
    .. code-block:: bash
 

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -69,8 +69,8 @@ However, only people with ``PyPI environment access for GitHub Actions`` can app
        git checkout main
        git pull
        git checkout -b release main
-       git add CHANGES.rst src/icalendar/__init__.py docs/install.rst
-       git commit -m"version 5.0.0"
+       git add CHANGES.rst
+       git commit -m"version 6.0.0"
 
 3. Push the commit and `create a pull request <https://github.com/collective/icalendar/compare?expand=1>`__
    Here is an `example pull request #457 <https://github.com/collective/icalendar/pull/457>`__.

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -65,7 +65,6 @@ However, only people with ``PyPI environment access for GitHub Actions`` can app
 2. Change the ``__version__`` variable in
 
    - the ``src/icalendar/__init__.py`` file and
-   - in the ``docs/install.rst`` file (look for ``icalendar.__version__``)
 3. Create a commit on the ``release`` branch (or equivalent) to release this version.
 
    .. code-block:: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ requires-python = ">=3.8"
 
 # see https://pypi.python.org/pypi?%3Aaction=list_classifiers
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",

--- a/src/icalendar/__init__.py
+++ b/src/icalendar/__init__.py
@@ -1,53 +1,92 @@
-__version__ = '6.0.0a0'
-
 from icalendar.cal import (
+    Alarm,
     Calendar,
+    Component,
+    ComponentFactory,
     Event,
-    Todo,
+    FreeBusy,
     Journal,
     Timezone,
-    TimezoneStandard,
     TimezoneDaylight,
-    FreeBusy,
-    Alarm,
-    ComponentFactory,
-    Component
+    TimezoneStandard,
+    Todo,
 )
-# Property Data Value Types
-from icalendar.prop import (
-    vBinary,
-    vBoolean,
-    vCalAddress,
-    vDatetime,
-    vDate,
-    vDDDTypes,
-    vDuration,
-    vFloat,
-    vInt,
-    vPeriod,
-    vWeekday,
-    vFrequency,
-    vRecur,
-    vText,
-    vTime,
-    vUri,
-    vGeo,
-    vUTCOffset,
-    TypesFactory,
-)
+
 # Parameters and helper methods for splitting and joining string with escaped
 # chars.
 from icalendar.parser import (
     Parameters,
-    q_split,
     q_join,
+    q_split,
+)
+
+# Property Data Value Types
+from icalendar.prop import (
+    TypesFactory,
+    vBinary,
+    vBoolean,
+    vCalAddress,
+    vDate,
+    vDatetime,
+    vDDDTypes,
+    vDuration,
+    vFloat,
+    vFrequency,
+    vGeo,
+    vInt,
+    vPeriod,
+    vRecur,
+    vText,
+    vTime,
+    vUri,
+    vUTCOffset,
+    vWeekday,
 )
 
 # Switching the timezone provider
 from icalendar.timezone import use_pytz, use_zoneinfo
 
+from .version import __version__, __version_tuple__, version, version_tuple
 
-__all__ = ['Calendar', 'Event', 'Todo', 'Journal', 'Timezone', 'TimezoneStandard', 'TimezoneDaylight', 'FreeBusy', 'Alarm',
-          'ComponentFactory', 'vBinary', 'vBoolean', 'vCalAddress', 'vDatetime', 'vDate', 'vDDDTypes', 'vDuration',
-          'vFloat', 'vInt', 'vPeriod','vWeekday', 'vFrequency', 'vRecur', 'vText', 'vTime', 'vUri', 'vGeo', 'vUTCOffset',
-          'vTypesFactory', 'Parameters', 'q_split', 'q_join', 'use_pytz', 'use_zoneinfo']
+__all__ = [
+    "Calendar",
+    "Event",
+    "Todo",
+    "Journal",
+    "Timezone",
+    "TimezoneStandard",
+    "TimezoneDaylight",
+    "FreeBusy",
+    "Alarm",
+    "ComponentFactory",
+    "vBinary",
+    "vBoolean",
+    "vCalAddress",
+    "vDatetime",
+    "vDate",
+    "vDDDTypes",
+    "vDuration",
+    "vFloat",
+    "vInt",
+    "vPeriod",
+    "vWeekday",
+    "vFrequency",
+    "vRecur",
+    "vText",
+    "vTime",
+    "vUri",
+    "vGeo",
+    "vUTCOffset",
+    "vTypesFactory",
+    "Parameters",
+    "q_split",
+    "q_join",
+    "use_pytz",
+    "use_zoneinfo",
+    "__version__",
+    "version",
+    "__version_tuple__",
+    "version_tuple",
+    "TypesFactory",
+    "Component",
+]

--- a/src/icalendar/tests/test_with_doctest.py
+++ b/src/icalendar/tests/test_with_doctest.py
@@ -75,7 +75,7 @@ def test_documentation_file(document, zoneinfo_only, env_for_doctest, tzp):
     functions are also replaced to work.
     """
     try:
-        test_result = doctest.testfile(document, module_relative=False, globs=env_for_doctest, raise_on_error=True)
+        test_result = doctest.testfile(document, module_relative=False, globs=env_for_doctest, raise_on_error=False)
     except doctest.UnexpectedException as e:
         ty, err, tb = e.exc_info
         if issubclass(ty, ModuleNotFoundError) and err.name == "pytz":

--- a/src/icalendar/tests/test_with_doctest.py
+++ b/src/icalendar/tests/test_with_doctest.py
@@ -75,7 +75,8 @@ def test_documentation_file(document, zoneinfo_only, env_for_doctest, tzp):
     functions are also replaced to work.
     """
     try:
-        test_result = doctest.testfile(document, module_relative=False, globs=env_for_doctest, raise_on_error=False)
+        # set raise_on_error to False if you wand to see the error for debug
+        test_result = doctest.testfile(document, module_relative=False, globs=env_for_doctest, raise_on_error=True)
     except doctest.UnexpectedException as e:
         ty, err, tb = e.exc_info
         if issubclass(ty, ModuleNotFoundError) and err.name == "pytz":

--- a/src/icalendar/version.py
+++ b/src/icalendar/version.py
@@ -1,4 +1,5 @@
 """Version file as a stable interface for the generated _version.py file."""
+
 try:
     from ._version import __version__, __version_tuple__, version, version_tuple
 except ModuleNotFoundError:


### PR DESCRIPTION
Following: https://icalendar.readthedocs.io/en/latest/maintenance.html#new-releases

- update release process
- ruff format some files
- use version variable from icalendar.version
- update aplha to stable

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--710.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->