### PR TITLE
Add docs folder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ New features:
 Bug fixes:
 
 - Fix a few ``__all__`` variables.
-- Add missing ``docs`` folder to distribution packages, see `Issue 712 <https://github.com/collective/icalendar/issues/712>`_
+- Added missing ``docs`` folder to distribution packages. See `Issue 712 <https://github.com/collective/icalendar/issues/712>`_.
 
 6.0.0 (2024-09-28)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ New features:
 Bug fixes:
 
 - Fix a few ``__all__`` variables.
+- Add missing ``docs`` folder to distribution packages, see `Issue 712 <https://github.com/collective/icalendar/issues/712>`_
 
 6.0.0 (2024-09-28)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ exclude = [
   "/.*",
   "/*.*",
   "/src/icalendar/fuzzing",
-  "/docs",
   "/dist",
   "/build",
   "/htmlcov",

--- a/src/icalendar/tests/test_create_release.sh
+++ b/src/icalendar/tests/test_create_release.sh
@@ -24,7 +24,7 @@ if tar -tf "$archive" | grep -q 'fuzzing/'; then
 fi
 
 if ! tar -tf "$archive" | grep -q '/docs/'; then
-  echo "ERROR: The documentation is not included in the release."
+  echo "ERROR: The documentation is not included in the release, but should be."
   echo "       See https://github.com/collective/icalendar/issues/712"
   exit 1
 fi

--- a/src/icalendar/tests/test_create_release.sh
+++ b/src/icalendar/tests/test_create_release.sh
@@ -17,9 +17,15 @@ if ! [ -f "$archive" ]; then
   exit 1
 fi
 
-if tar -tf "$archive" | grep 'fuzzing/'; then
+if tar -tf "$archive" | grep -q 'fuzzing/'; then
   echo "ERROR: Fuzzing files are included in the release."
   echo "       See https://github.com/collective/icalendar/pull/569"
+  exit 1
+fi
+
+if ! tar -tf "$archive" | grep -q '/docs/'; then
+  echo "ERROR: The documentation is not included in the release."
+  echo "       See https://github.com/collective/icalendar/issues/712"
   exit 1
 fi
 


### PR DESCRIPTION
fixes #712

> To Reproduce -> These commands work now. The docs are added.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--720.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->