### PR TITLE
Start calculating event start and end

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Breaking changes:
 
 New features:
 
-- ...
+- Add ``Event.end``, ``Event.start``, ``Event.dtstart`` and ``Event.dtend`` attributes, see `Issue 662 <https://github.com/collective/icalendar/issues/662>`_
 
 Bug fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Breaking changes:
 
 New features:
 
-- Add ``Event.end``, ``Event.start``, ``Event.dtstart`` and ``Event.dtend`` attributes, see `Issue 662 <https://github.com/collective/icalendar/issues/662>`_
+- Added ``Event.end``, ``Event.start``, ``Event.dtstart``, and ``Event.dtend`` attributes. See `Issue 662 <https://github.com/collective/icalendar/issues/662>`_.
 
 Bug fixes:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ ignore = [
     "PERF401", # Use a list comprehension to create a transformed list
     "ARG002",  # Unused method argument: ...
     "ARG001",  # Unused function argument: ...
+    "UP007",   # Optional -> X | None remove when migrated to py39+
 ]
 extend-safe-fixes = [
     "PT006", # Wrong type passed to first argument of @pytest.mark.parametrize; expected {expected_string}

--- a/src/icalendar/__init__.py
+++ b/src/icalendar/__init__.py
@@ -5,13 +5,13 @@ from icalendar.cal import (
     ComponentFactory,
     Event,
     FreeBusy,
+    IncompleteComponent,
+    InvalidCalendar,
     Journal,
     Timezone,
     TimezoneDaylight,
     TimezoneStandard,
     Todo,
-    InvalidCalendar,
-    IncompleteComponent
 )
 
 # Parameters and helper methods for splitting and joining string with escaped
@@ -36,6 +36,7 @@ from icalendar.prop import (
     vFrequency,
     vGeo,
     vInt,
+    vMonth,
     vPeriod,
     vRecur,
     vText,
@@ -90,4 +91,7 @@ __all__ = [
     "version_tuple",
     "TypesFactory",
     "Component",
+    "vMonth",
+    "IncompleteComponent",
+    "InvalidCalendar",
 ]

--- a/src/icalendar/__init__.py
+++ b/src/icalendar/__init__.py
@@ -10,6 +10,8 @@ from icalendar.cal import (
     TimezoneDaylight,
     TimezoneStandard,
     Todo,
+    InvalidCalendar,
+    IncompleteComponent
 )
 
 # Parameters and helper methods for splitting and joining string with escaped

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -587,7 +587,7 @@ class Event(Component):
         end = self.DTEND
         duration = self.DURATION
         if duration is not None and end is not None:
-            raise InvalidCalendar("DTEND and DURATION cannot be there at the same time.")
+            raise InvalidCalendar("Only one of DTEND and DURATION may be in a VEVENT, not both.")
         if isinstance(start, date) and not isinstance(start, datetime) and duration is not None and duration.seconds != 0:
             raise InvalidCalendar("When DTSTART is a date, DURATION must be of days or weeks.")
         if start is not None and end is not None and is_date(start) != is_date(end):

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -711,6 +711,19 @@ class Todo(Component):
 
 
 class Journal(Component):
+    """A describtive text at a certain time or associated with a component.
+
+    A "VJOURNAL" calendar component is a grouping of
+    component properties that represent one or more descriptive text
+    notes associated with a particular calendar date.  The "DTSTART"
+    property is used to specify the calendar date with which the
+    journal entry is associated.  Generally, it will have a DATE value
+    data type, but it can also be used to specify a DATE-TIME value
+    data type.  Examples of a journal entry include a daily record of
+    a legislative body or a journal entry of individual telephone
+    contacts for the day or an ordered list of accomplishments for the
+    day.
+    """
 
     name = 'VJOURNAL'
 
@@ -724,6 +737,34 @@ class Journal(Component):
         'RELATED', 'RDATE', 'RRULE', 'RSTATUS', 'DESCRIPTION',
     )
 
+    DTSTART = create_single_property(
+        "DTSTART", "dt", (datetime, date), date,
+        'The "DTSTART" property for a "VJOURNAL" that specifies the exact date at which the journal entry was made.')
+
+    @property
+    def start(self) -> date:
+        """The start of the Journal.
+        
+        The "DTSTART"
+        property is used to specify the calendar date with which the
+        journal entry is associated.
+        """
+        start = self.DTSTART
+        if start is None:
+            raise IncompleteComponent("No DTSTART given.")
+        return start
+    
+    @start.setter
+    def start(self, value: datetime|date) -> None:
+        """Set the start of the journal."""
+        self.DTSTART = value
+
+    end = start
+    
+    @property
+    def duration(self) -> timedelta:
+        """The journal does not last any time."""
+        return timedelta(0)
 
 class FreeBusy(Component):
 

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -711,7 +711,7 @@ class Todo(Component):
 
 
 class Journal(Component):
-    """A describtive text at a certain time or associated with a component.
+    """A descriptive text at a certain time or associated with a component.
 
     A "VJOURNAL" calendar component is a grouping of
     component properties that represent one or more descriptive text

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -591,7 +591,7 @@ class Event(Component):
         if isinstance(start, date) and not isinstance(start, datetime) and duration is not None and duration.seconds != 0:
             raise InvalidCalendar("When DTSTART is a date, DURATION must be of days or weeks.")
         if start is not None and end is not None and is_date(start) != is_date(end):
-            raise InvalidCalendar("DTSTART and DTEND must have the same type.")
+            raise InvalidCalendar("DTSTART and DTEND must be of the same type, either date or datetime.")
         return start, end, duration
 
     @property

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import os
 from datetime import date, datetime, timedelta
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import dateutil.rrule
 import dateutil.tz
@@ -511,7 +511,6 @@ def create_single_property(prop:str, value_attr:str, value_type:tuple[type], typ
         if not isinstance(value, value_type):
             raise InvalidCalendar(f"{prop} must be either a date or a datetime, not {value}.")
         return value
-    
 
     def p_set(self:Component, value) -> None:
         if value is None:
@@ -524,13 +523,13 @@ def create_single_property(prop:str, value_attr:str, value_type:tuple[type], typ
             for other_prop in self.exclusive:
                 if other_prop != prop:
                     self.pop(other_prop, None)
-    p_set.__annotations__["value"] = p_get.__annotations__["return"] = type_def | None
+    p_set.__annotations__["value"] = p_get.__annotations__["return"] = Optional[type_def]
 
     def p_del(self:Component):
         self.pop(prop)
-    
+
     p_doc = f"""The {prop} property.
-    
+
     {doc}
 
     Accepted values: {', '.join(t.__name__ for t in value_type)}.
@@ -595,7 +594,7 @@ class Event(Component):
         return start, end, duration
 
     @property
-    def DURATION(self) -> timedelta | None:  # noqa: N802
+    def DURATION(self) -> Optional[timedelta]:  # noqa: N802
         """The DURATION of the component.
 
         The "DTSTART" property for a "VEVENT" specifies the inclusive start of the event.
@@ -617,7 +616,7 @@ class Event(Component):
         return None
     
     @DURATION.setter
-    def DURATION(self, value: timedelta | None):  # noqa: N802
+    def DURATION(self, value: Optional[timedelta]):  # noqa: N802
         if value is None:
             self.pop("duration", None)
             return
@@ -663,7 +662,7 @@ class Event(Component):
         return start
 
     @start.setter
-    def start(self, start: date | datetime| None):
+    def start(self, start: Optional[date | datetime]):
         """Set the start."""
         self.DTSTART = start
 

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -500,7 +500,7 @@ class Component(CaselessDict):
 def create_single_property(prop:str, value_attr:str, value_type:tuple[type], type_def:type, doc:str):
     """Create a single property getter and setter."""
 
-    def p_get(self : Component) -> type_def | None:
+    def p_get(self : Component):
         default = object()
         result = self.get(prop, default)
         if result is default:
@@ -511,8 +511,9 @@ def create_single_property(prop:str, value_attr:str, value_type:tuple[type], typ
         if not isinstance(value, value_type):
             raise InvalidCalendar(f"{prop} must be either a date or a datetime, not {value}.")
         return value
+    
 
-    def p_set(self:Component, value: type_def | None) -> None:
+    def p_set(self:Component, value) -> None:
         if value is None:
             p_del(self)
             return
@@ -523,6 +524,7 @@ def create_single_property(prop:str, value_attr:str, value_type:tuple[type], typ
             for other_prop in self.exclusive:
                 if other_prop != prop:
                     self.pop(other_prop, None)
+    p_set.__annotations__["value"] = p_get.__annotations__["return"] = type_def | None
 
     def p_del(self:Component):
         self.pop(prop)
@@ -531,9 +533,10 @@ def create_single_property(prop:str, value_attr:str, value_type:tuple[type], typ
     
     {doc}
 
+    Accepted values: {', '.join(t.__name__ for t in value_type)}.
     If the attribute has invalid values, we raise InvalidCalendar.
     If the value is absent, we return None.
-    You can also delete the value with del.
+    You can also delete the value with del or by setting it to None.
     """
     return property(p_get, p_set, p_del, p_doc)
 
@@ -571,7 +574,7 @@ class Event(Component):
     ignore_exceptions = True
 
     @classmethod
-    def example(cls, name) -> Event:
+    def example(cls, name:str) -> Event:
         """Return the calendar example with the given name."""
         return cls.from_ical(get_example("events", name))
 
@@ -741,7 +744,7 @@ class Timezone(Component):
     singletons = ('TZID', 'LAST-MODIFIED', 'TZURL',)
 
     @classmethod
-    def example(cls, name) -> Calendar:
+    def example(cls, name: str) -> Calendar:
         """Return the calendar example with the given name."""
         return cls.from_ical(get_example("timezones", name))
 
@@ -930,7 +933,7 @@ class Calendar(Component):
     singletons = ('PRODID', 'VERSION', 'CALSCALE', 'METHOD')
 
     @classmethod
-    def example(cls, name) -> Calendar:
+    def example(cls, name: str) -> Calendar:
         """Return the calendar example with the given name."""
         return cls.from_ical(get_example("calendars", name))
 

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -763,7 +763,7 @@ class Journal(Component):
     
     @property
     def duration(self) -> timedelta:
-        """The journal does not last any time."""
+        """The journal has no duration."""
         return timedelta(0)
 
 class FreeBusy(Component):

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -604,6 +604,7 @@ class Event(Component):
         of the event.
 
         If you would like to calculate the duration of an event do not use this.
+        Instead use the difference between DTSTART and DTEND.
         """
         default = object()
         duration = self.get("duration", default)

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -688,7 +688,7 @@ class Event(Component):
 
     @end.setter
     def end(self, end: date | datetime | None):
-        """Set the start."""
+        """Set the end."""
         self.DTEND = end
 
 

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -642,6 +642,7 @@ class vMonth(int):
     In :rfc:`5545`, this is just an int.
     In :rfc:`7529`, this can be followed by `L` to indicate a leap month.
 
+        >>> from icalendar import vMonth
         >>> vMonth(1) # first month January
         vMonth('1')
         >>> vMonth("5L") # leap month in Hebrew calendar

--- a/src/icalendar/tests/test_issue_662_component_properties.py
+++ b/src/icalendar/tests/test_issue_662_component_properties.py
@@ -2,7 +2,11 @@
 from datetime import date, datetime, timedelta
 
 import pytest
-from zoneinfo import ZoneInfo
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo  # type: ignore
 
 from icalendar import (
     Event,
@@ -201,9 +205,9 @@ invalid_event_end_4.add("DURATION", timedelta(hours=1))
 @pytest.mark.parametrize(
     ("invalid_event", "message"),
     [
-        (invalid_event_end_1, "DTSTART and DTEND must have the same type."),
-        (invalid_event_end_2, "DTSTART and DTEND must have the same type."),
-        (invalid_event_end_3, "DTEND and DURATION cannot be there at the same time."),
+        (invalid_event_end_1, "DTSTART and DTEND must be of the same type, either date or datetime."),
+        (invalid_event_end_2, "DTSTART and DTEND must be of the same type, either date or datetime."),
+        (invalid_event_end_3, "Only one of DTEND and DURATION may be in a VEVENT, not both."),
         (invalid_event_end_4, "When DTSTART is a date, DURATION must be of days or weeks."),
     ]
 )

--- a/src/icalendar/tests/test_issue_662_component_properties.py
+++ b/src/icalendar/tests/test_issue_662_component_properties.py
@@ -13,7 +13,7 @@ from icalendar import (
 from icalendar.prop import vDuration
 
 
-@pytest.fixture
+@pytest.fixture()
 def event():
     """The event to test."""
     return Event()
@@ -38,7 +38,7 @@ def _set_event_start_init(event, start):
 
 def _set_event_dtstart(event, start):
     """Create the event with the dtstart property."""
-    event.dtstart = start
+    event.DTSTART = start
 
 def _set_event_start_attr(event, start):
     """Create the event with the dtstart property."""
@@ -59,7 +59,7 @@ def set_event_start(request):
 
 def test_event_dtstart(dtstart, event):
     """Test the start of events."""
-    assert event.dtstart == dtstart
+    assert event.DTSTART == dtstart
 
 
 def test_event_start(dtstart, event):
@@ -80,7 +80,7 @@ def test_multiple_dtstart(invalid_event):
     with pytest.raises(InvalidCalendar):
         invalid_event.start  # noqa: B018
     with pytest.raises(InvalidCalendar):
-        invalid_event.dtstart  # noqa: B018
+        invalid_event.DTSTART  # noqa: B018
 
 def test_no_dtstart():
     """DTSTART is optional.
@@ -91,7 +91,7 @@ def test_no_dtstart():
     is OPTIONAL; in any case, it MUST NOT occur
     more than once.
     """
-    assert Event().dtstart is None
+    assert Event().DTSTART is None
     with pytest.raises(IncompleteComponent):
         Event().start  # noqa: B018
 
@@ -116,7 +116,7 @@ def _set_event_end_init(event, end):
 
 def _set_event_dtend(event, end):
     """Create the event with the dtend property."""
-    event.dtend = end
+    event.DTEND = end
 
 def _set_event_end_attr(event, end):
     """Create the event with the dtend property."""
@@ -137,7 +137,7 @@ def set_event_end(request):
 
 def test_event_dtend(dtend, event):
     """Test the end of events."""
-    assert event.dtend == dtend
+    assert event.DTEND == dtend
 
 
 def test_event_end(dtend, event):
@@ -145,7 +145,7 @@ def test_event_end(dtend, event):
     assert event.end == dtend
 
 
-@pytest.mark.parametrize("attr", ["dtstart", "dtend"])
+@pytest.mark.parametrize("attr", ["DTSTART", "DTEND"])
 def test_delete_attr(event, dtstart, dtend, attr):
     delattr(event, attr)
     assert getattr(event, attr) is None
@@ -178,6 +178,7 @@ def test_start_and_duration(event, dtstart, duration):
     """Check calculation of end with duration."""
     dur = event.end - event.start
     assert dur == duration
+    assert event.duration == duration
 
 def test_default_duration(event, dtstart):
     """Check that the end can be computed if a start is given."""
@@ -201,19 +202,19 @@ invalid_event_end_4 = Event()
 invalid_event_end_4.add("DTSTART", date(2024, 1, 1))
 invalid_event_end_4.add("DURATION", timedelta(hours=1))
 @pytest.mark.parametrize(
-    ("incomplete_event_end", "message"),
+    ("invalid_event", "message"),
     [
         (invalid_event_end_1, "DTSTART and DTEND must have the same type."),
         (invalid_event_end_2, "DTSTART and DTEND must have the same type."),
-        (invalid_event_end_3, "DURATION and DTEND cannot be there at the same time."),
+        (invalid_event_end_3, "DTEND and DURATION cannot be there at the same time."),
         (invalid_event_end_4, "When DTSTART is a date, DURATION must be of days or weeks."),
     ]
 )
 @pytest.mark.parametrize("attr", ["start", "end"])
-def test_invalid_event(incomplete_event_end, message, attr):
+def test_invalid_event(invalid_event, message, attr):
     """Test that the end and start throuw the right error."""
     with pytest.raises(InvalidCalendar) as e:
-        getattr(incomplete_event_end, attr)
+        getattr(invalid_event, attr)
     assert e.value.args[0] == message
 
 def test_duration_one_day():
@@ -224,7 +225,7 @@ def test_duration_one_day():
     "DTEND" nor "DURATION" property, the event's duration is taken to
     be one day
     """
-    
+    # TODO: Test duration and end
 
 incomplete_event_1 = Event()
 incomplete_event_2 = Event()
@@ -235,3 +236,19 @@ def test_incomplete_event(incomplete_event_end):
     """Test that the end throuws the right error."""
     with pytest.raises(IncompleteComponent):
         incomplete_event_end.end  # noqa: B018
+
+
+def test_set_invalid_start():
+    """Check that we get the right error.
+    
+    - other types that vDDDTypes accepts
+    - object
+    - None
+    - timezone + no timezone
+    - duration or end do not math
+    """
+
+
+def test_check_invalid_duration():
+    """Check that we get the right error."""
+    # TODO

--- a/src/icalendar/tests/test_issue_662_component_properties.py
+++ b/src/icalendar/tests/test_issue_662_component_properties.py
@@ -1,0 +1,237 @@
+"""This tests the properties of components and their types."""
+from datetime import date, datetime, timedelta
+
+import pytest
+from zoneinfo import ZoneInfo
+
+from icalendar import (
+    Event,
+    IncompleteComponent,
+    InvalidCalendar,
+    vDDDTypes,
+)
+from icalendar.prop import vDuration
+
+
+@pytest.fixture
+def event():
+    """The event to test."""
+    return Event()
+
+@pytest.fixture(params=[
+        datetime(2022, 7, 22, 12, 7),
+        date(2022, 7, 22),
+        datetime(2022, 7, 22, 13, 7, tzinfo=ZoneInfo("Europe/Paris")),
+    ])
+def dtstart(request, set_event_start, event):
+    """Start of the event."""
+    set_event_start(event, request.param)
+    return request.param
+
+
+def _set_event_start_init(event, start):
+    """Create the event with the __init__ method."""
+    d = dict(event)
+    d["dtstart"] = vDDDTypes(start)
+    event.clear()
+    event.update(Event(d))
+
+def _set_event_dtstart(event, start):
+    """Create the event with the dtstart property."""
+    event.dtstart = start
+
+def _set_event_start_attr(event, start):
+    """Create the event with the dtstart property."""
+    event.start = start
+
+def _set_event_start_ics(event, start):
+    """Create the event with the start property."""
+    event.add("dtstart", start)
+    ics = event.to_ical().decode()
+    print(ics)
+    event.clear()
+    event.update(Event.from_ical(ics))
+
+@pytest.fixture(params=[_set_event_start_init, _set_event_start_ics, _set_event_dtstart, _set_event_start_attr])
+def set_event_start(request):
+    """Create a new event."""
+    return request.param
+
+def test_event_dtstart(dtstart, event):
+    """Test the start of events."""
+    assert event.dtstart == dtstart
+
+
+def test_event_start(dtstart, event):
+    """Test the start of events."""
+    assert event.start == dtstart
+
+
+invalid_start_event_1 = Event()
+invalid_start_event_1.add("dtstart", datetime(2022, 7, 22, 12, 7))
+invalid_start_event_1.add("dtstart", datetime(2022, 7, 22, 12, 8))
+invalid_start_event_2 = Event.from_ical(invalid_start_event_1.to_ical())
+invalid_start_event_3 = Event()
+invalid_start_event_3.add("DTSTART", (date(2018, 1, 1), date(2018, 2, 1)))
+
+@pytest.mark.parametrize("invalid_event", [invalid_start_event_1, invalid_start_event_2, invalid_start_event_3])
+def test_multiple_dtstart(invalid_event):
+    """Check that we get the right error."""
+    with pytest.raises(InvalidCalendar):
+        invalid_event.start  # noqa: B018
+    with pytest.raises(InvalidCalendar):
+        invalid_event.dtstart  # noqa: B018
+
+def test_no_dtstart():
+    """DTSTART is optional.
+
+    The following is REQUIRED if the component
+    appears in an iCalendar object that doesn't
+    specify the "METHOD" property; otherwise, it
+    is OPTIONAL; in any case, it MUST NOT occur
+    more than once.
+    """
+    assert Event().dtstart is None
+    with pytest.raises(IncompleteComponent):
+        Event().start  # noqa: B018
+
+
+@pytest.fixture(params=[
+        datetime(2022, 7, 22, 12, 8),
+        date(2022, 7, 23),
+        datetime(2022, 7, 22, 14, 7, tzinfo=ZoneInfo("Europe/Paris")),
+    ])
+def dtend(request, set_event_end, event):
+    """end of the event."""
+    set_event_end(event, request.param)
+    return request.param
+
+
+def _set_event_end_init(event, end):
+    """Create the event with the __init__ method."""
+    d = dict(event)
+    d["dtend"] = vDDDTypes(end)
+    event.clear()
+    event.update(Event(d))
+
+def _set_event_dtend(event, end):
+    """Create the event with the dtend property."""
+    event.dtend = end
+
+def _set_event_end_attr(event, end):
+    """Create the event with the dtend property."""
+    event.end = end
+
+def _set_event_end_ics(event, end):
+    """Create the event with the end property."""
+    event.add("dtend", end)
+    ics = event.to_ical().decode()
+    print(ics)
+    event.clear()
+    event.update(Event.from_ical(ics))
+
+@pytest.fixture(params=[_set_event_end_init, _set_event_end_ics, _set_event_dtend, _set_event_end_attr])
+def set_event_end(request):
+    """Create a new event."""
+    return request.param
+
+def test_event_dtend(dtend, event):
+    """Test the end of events."""
+    assert event.dtend == dtend
+
+
+def test_event_end(dtend, event):
+    """Test the end of events."""
+    assert event.end == dtend
+
+
+@pytest.mark.parametrize("attr", ["dtstart", "dtend"])
+def test_delete_attr(event, dtstart, dtend, attr):
+    delattr(event, attr)
+    assert getattr(event, attr) is None
+    delattr(event, attr)
+
+
+def _set_duration_vdddtypes(event:Event, duration:timedelta):
+    """Set the vDDDTypes value"""
+    event["DURATION"] = vDDDTypes(duration)
+
+def _set_duration_add(event:Event, duration:timedelta):
+    """Set the vDDDTypes value"""
+    event.add("DURATION", duration)
+
+def _set_duration_vduration(event:Event, duration:timedelta):
+    """Set the vDDDTypes value"""
+    event["DURATION"] = vDuration(duration)
+
+@pytest.fixture(params=[_set_duration_vdddtypes, _set_duration_add, _set_duration_vduration])
+def duration(event, dtstart, request):
+    """... events have a DATE value type for the "DTSTART" property ...
+    If such a "VEVENT" has a "DURATION"
+    property, it MUST be specified as a "dur-day" or "dur-week" value.
+    """
+    duration = timedelta(hours=1) if isinstance(dtstart, datetime) else timedelta(days=2)
+    request.param(event, duration)
+    return duration
+
+def test_start_and_duration(event, dtstart, duration):
+    """Check calculation of end with duration."""
+    dur = event.end - event.start
+    assert dur == duration
+
+def test_default_duration(event, dtstart):
+    """Check that the end can be computed if a start is given."""
+
+# The "VEVENT" is also the calendar component used to specify an
+# anniversary or daily reminder within a calendar.  These events
+# have a DATE value type for the "DTSTART" property instead of the
+# default value type of DATE-TIME.  If such a "VEVENT" has a "DTEND"
+# property, it MUST be specified as a DATE value also.
+invalid_event_end_1 = Event()
+invalid_event_end_1.add("DTSTART", datetime(2024, 1, 1, 10, 20))
+invalid_event_end_1.add("DTEND", date(2024, 1, 1))
+invalid_event_end_2 = Event()
+invalid_event_end_2.add("DTEND", datetime(2024, 1, 1, 10, 20))
+invalid_event_end_2.add("DTSTART", date(2024, 1, 1))
+invalid_event_end_3 = Event()
+invalid_event_end_3.add("DTEND", datetime(2024, 1, 1, 10, 20))
+invalid_event_end_3.add("DTSTART", datetime(2024, 1, 1, 10, 20))
+invalid_event_end_3.add("DURATION", timedelta(days=1))
+invalid_event_end_4 = Event()
+invalid_event_end_4.add("DTSTART", date(2024, 1, 1))
+invalid_event_end_4.add("DURATION", timedelta(hours=1))
+@pytest.mark.parametrize(
+    ("incomplete_event_end", "message"),
+    [
+        (invalid_event_end_1, "DTSTART and DTEND must have the same type."),
+        (invalid_event_end_2, "DTSTART and DTEND must have the same type."),
+        (invalid_event_end_3, "DURATION and DTEND cannot be there at the same time."),
+        (invalid_event_end_4, "When DTSTART is a date, DURATION must be of days or weeks."),
+    ]
+)
+@pytest.mark.parametrize("attr", ["start", "end"])
+def test_invalid_event(incomplete_event_end, message, attr):
+    """Test that the end and start throuw the right error."""
+    with pytest.raises(InvalidCalendar) as e:
+        getattr(incomplete_event_end, attr)
+    assert e.value.args[0] == message
+
+def test_duration_one_day():
+    """
+
+    For cases where a "VEVENT" calendar component
+    specifies a "DTSTART" property with a DATE value type but no
+    "DTEND" nor "DURATION" property, the event's duration is taken to
+    be one day
+    """
+    
+
+incomplete_event_1 = Event()
+incomplete_event_2 = Event()
+incomplete_event_2.add("DURATION", timedelta(hours=1))
+
+@pytest.mark.parametrize("incomplete_event_end", [incomplete_event_1, incomplete_event_2])
+def test_incomplete_event(incomplete_event_end):
+    """Test that the end throuws the right error."""
+    with pytest.raises(IncompleteComponent):
+        incomplete_event_end.end  # noqa: B018

--- a/src/icalendar/tests/test_issue_662_component_properties.py
+++ b/src/icalendar/tests/test_issue_662_component_properties.py
@@ -180,9 +180,6 @@ def test_start_and_duration(event, dtstart, duration):
     assert dur == duration
     assert event.duration == duration
 
-def test_default_duration(event, dtstart):
-    """Check that the end can be computed if a start is given."""
-
 # The "VEVENT" is also the calendar component used to specify an
 # anniversary or daily reminder within a calendar.  These events
 # have a DATE value type for the "DTSTART" property instead of the

--- a/src/icalendar/tests/test_with_doctest.py
+++ b/src/icalendar/tests/test_with_doctest.py
@@ -35,7 +35,7 @@ def test_this_module_is_among_them():
     assert __name__ in MODULE_NAMES
 
 @pytest.mark.parametrize("module_name", MODULE_NAMES)
-def test_docstring_of_python_file(module_name):
+def test_docstring_of_python_file(module_name, env_for_doctest):
     """This test runs doctest on the Python module."""
     try:
         module = importlib.import_module(module_name)
@@ -43,7 +43,7 @@ def test_docstring_of_python_file(module_name):
         if e.name == "pytz":
             pytest.skip("pytz is not installed, skipping this module.")
         raise
-    test_result = doctest.testmod(module, name=module_name)
+    test_result = doctest.testmod(module, name=module_name, globs=env_for_doctest)
     assert test_result.failed == 0, f"{test_result.failed} errors in {module_name}"
 
 


### PR DESCRIPTION
This is a contribution to #662. 

Calculation of event start and end are actually quite complex.

This also contributes to #716 because the calculation of start and end are way easier then.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--721.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->