### PR TITLE
test python 3.13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
 #        - ["3.10",  "docs"]  # disable as readthedocs builds it
         - ["3.11",  "py311"]
         - ["3.12",  "py312"]
+        - ["3.13",  "py313"]
 
     runs-on: ubuntu-latest
     name: ${{ matrix.config[1] }}
@@ -79,7 +80,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -111,7 +112,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Breaking changes:
 New features:
 
 - Added ``Event.end``, ``Event.start``, ``Event.dtstart``, and ``Event.dtend`` attributes. See `Issue 662 <https://github.com/collective/icalendar/issues/662>`_.
+- Test compatibility with Python 3.13
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ you can receive all the latest updates, and switch back to earlier behavior:
     <DstTzInfo 'Europe/Vienna' CET+1:00:00 STD>
 
 Version 6 is on `branch main <https://github.com/collective/icalendar/>`_.
-It is compatible with Python versions 3.8 - 3.12, and PyPy3.
+It is compatible with Python versions 3.8 - 3.13, and PyPy3.
 We expect the ``main`` branch with versions ``6+`` to receive the latest updates and features.
 
 Related projects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # to run for a specific environment, use ``tox -e ENVNAME``
 [tox]
-envlist = py38,py39,py310,py311,312,pypy3,docs,nopytz
+envlist = py38,py39,py310,py311,py312,py313,pypy3,docs,nopytz
 # Note: the 'docs' env creates a 'build' directory which may interfere in strange ways
 # with the other environments.  You might see this when you run the tests in parallel.
 # See https://github.com/collective/icalendar/pull/359#issuecomment-1214150269


### PR DESCRIPTION
Closes #723 

 - add python 3.13 support
 - all tests passed with new python version - no need to update files

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--728.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->