### PR TITLE
Complete API documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ New features:
 
 Bug fixes:
 
-- ...
+- Add ``icalendar.timezone`` to the documentation.
 
 6.0.1 (2024-10-13)
 ------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,3 +42,18 @@ icalendar.tools
 
 .. automodule:: icalendar.tools
    :members:
+
+icalendar.timezone
+++++++++++++++++++
+
+.. automodule:: icalendar.timezone
+   :members:
+
+.. automodule:: icalendar.timezone.tzp
+   :members:
+
+icalendar.version
++++++++++++++++++
+
+.. automodule:: icalendar.version
+   :members:


### PR DESCRIPTION
icalendar.timezone was absent from the API docs.