### PR TITLE
issue-742

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ New features:
 - Add ``X_MOZ_SNOOZE_TIME`` and ``X_MOZ_LASTACK`` properties to ``Event`` and ``Todo``.
 - Add ``Alarm.ACKNOWLEDGED``, ``Alarm.TRIGGER``, ``Alarm.REPEAT``, and ``Alarm.DURATION`` properties
   as well as ``Alarm.triggers`` to calculate alarm triggers.
+- Add ``__doc__`` string documentation for ``vDate``. See `Issue 742 <https://github.com/collective/icalendar/issues/742>`_.
 
 Bug fixes:
 

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -350,7 +350,42 @@ class vDDDTypes(TimeBase):
 
 
 class vDate(TimeBase):
-    """Render and generates iCalendar date format.
+    """Date
+    Value Name:  DATE
+    
+    Purpose:  This value type is used to identify values that contain a
+      calendar date.
+      
+    Format Definition:  This value type is defined by the following
+      notation:
+
+       date               = date-value
+
+       date-value         = date-fullyear date-month date-mday
+       date-fullyear      = 4DIGIT
+       date-month         = 2DIGIT        ;01-12
+       date-mday          = 2DIGIT        ;01-28, 01-29, 01-30, 01-31
+                                          ;based on month/year
+                                          
+    Description:  If the property permits, multiple "date" values are
+      specified as a COMMA-separated list of values.  The format for the
+      value type is based on the [ISO.8601.2004] complete
+      representation, basic format for a calendar date.  The textual
+      format specifies a four-digit year, two-digit month, and two-digit
+      day of the month.  There are no separator characters between the
+      year, month, and day component text.
+    
+    Example:  The following represents July 14, 1997:
+
+       19970714
+       
+       >>> date = vDate.from_ical('19970714')
+       >>> date.year
+       1997
+       >>> date.month
+       7
+       >>> date.day
+       14
     """
 
     def __init__(self, dt):

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -379,6 +379,7 @@ class vDate(TimeBase):
 
        19970714
        
+       >>> from icalendar.prop impoer vDate
        >>> date = vDate.from_ical('19970714')
        >>> date.year
        1997

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -379,7 +379,7 @@ class vDate(TimeBase):
 
        19970714
        
-       >>> from icalendar.prop impoer vDate
+       >>> from icalendar.prop import vDate
        >>> date = vDate.from_ical('19970714')
        >>> date.year
        1997


### PR DESCRIPTION
Example added: vDate
If this is true, I will continue with the others. 

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--744.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->