### PR TITLE
issue-742  

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ New features:
 - Add ``X_MOZ_SNOOZE_TIME`` and ``X_MOZ_LASTACK`` properties to ``Event`` and ``Todo``.
 - Add ``Alarm.ACKNOWLEDGED``, ``Alarm.TRIGGER``, ``Alarm.REPEAT``, and ``Alarm.DURATION`` properties
   as well as ``Alarm.triggers`` to calculate alarm triggers.
-- Add ``__doc__`` string documentation for ``vDate``. See `Issue 742 <https://github.com/collective/icalendar/issues/742>`_.
+- Add ``__doc__`` string documentation for ``vDate``, ``vBoolean``, ``vCalAddress``, ``vDuration``, ``vFloat``, ``vGeo``, ``vInt``, ``vPeriod``, ``vText``, ``vTime``, ``vUTCOffset`` and ``vUri``. See `Issue 742 <https://github.com/collective/icalendar/issues/742>`_.
 
 Bug fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ New features:
 - Add ``X_MOZ_SNOOZE_TIME`` and ``X_MOZ_LASTACK`` properties to ``Event`` and ``Todo``.
 - Add ``Alarm.ACKNOWLEDGED``, ``Alarm.TRIGGER``, ``Alarm.REPEAT``, and ``Alarm.DURATION`` properties
   as well as ``Alarm.triggers`` to calculate alarm triggers.
-- Add ``__doc__`` string documentation for ``vDate``, ``vBoolean``, ``vCalAddress``, ``vDuration``, ``vFloat``, ``vGeo``, ``vInt``, ``vPeriod``, ``vText``, ``vTime``, ``vUTCOffset`` and ``vUri``. See `Issue 742 <https://github.com/collective/icalendar/issues/742>`_.
+- Add ``__doc__`` string documentation for ``vDate``, ``vBoolean``, ``vCalAddress``, ``vDuration``, ``vFloat``, ``vGeo``, ``vInt``, ``vPeriod``, ``vTime``, ``vUTCOffset`` and ``vUri``. See `Issue 742 <https://github.com/collective/icalendar/issues/742>`_.
 
 Bug fixes:
 

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -76,6 +76,7 @@ icalendar contributors
 - `Steve Piercy <https://github.com/stevepiercy>`_
 - Jeffrey Whewhetu <jeffwhewhetu@gmail.com>
 - `Soham Dutta <https://github.com/NP-compete>`_
+- `Serif OZ  <https://github.com/SerifOZ>`_
 
 Find out who contributed::
 

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -211,9 +211,9 @@ class vText(str):
        Project XYZ Final Review\nConference Room - 3B\nCome Prepared.
        
         >>> from icalendar.prop import vText
-        >>> message = """Project XYZ Final Review
+        >>> message = '''Project XYZ Final Review
         ... Conference Room - 3B
-        ... Come Prepared."""
+        ... Come Prepared.'''
         >>> text = vText.from_ical(message)
         >>> text
         vText(b'Project XYZ Final Review\\nConference Room - 3B\\nCome Prepared.')

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -103,8 +103,40 @@ class vBinary:
 
 
 class vBoolean(int):
-    """Returns specific string according to state.
+    """Boolean
+    Value Name:  BOOLEAN
+
+    Purpose:  This value type is used to identify properties that contain
+      either a "TRUE" or "FALSE" Boolean value.
+
+    Format Definition:  This value type is defined by the following
+      notation:
+
+       boolean    = "TRUE" / "FALSE"
+
+    Description:  These values are case-insensitive text.  No additional
+      content value encoding (i.e., BACKSLASH character encoding, see
+      Section 3.3.11) is defined for this value type.
+
+    Example:  The following is an example of a hypothetical property that
+      has a BOOLEAN value type:
+
+        TRUE
+        
+        >>> from icalendar.prop import vBoolean
+        >>> boolean = vBoolean.from_ical('TRUE')
+        >>> boolean
+        True
+        >>> boolean = vBoolean.from_ical('FALSE')
+        >>> boolean
+        False
+        >>> boolean = vBoolean.from_ical('True')
+        >>> boolean
+        True
+
+            
     """
+    
     BOOL_MAP = CaselessDict({'true': True, 'false': False})
 
     def __new__(cls, *args, **kwargs):
@@ -124,7 +156,70 @@ class vBoolean(int):
 
 
 class vText(str):
-    """Simple text.
+    """Text
+    Value Name:  TEXT
+
+    Purpose:  This value type is used to identify values that contain
+      human-readable text.
+
+    Format Definition:  This value type is defined by the following
+      notation:
+      text       = *(TSAFE-CHAR / ":" / DQUOTE / ESCAPED-CHAR)
+          ; Folded according to description above
+
+       ESCAPED-CHAR = ("\\" / "\;" / "\," / "\N" / "\n")
+          ; \\ encodes \, \N or \n encodes newline
+          ; \; encodes ;, \, encodes ,
+
+       TSAFE-CHAR = WSP / %x21 / %x23-2B / %x2D-39 / %x3C-5B /
+                    %x5D-7E / NON-US-ASCII
+          ; Any character except CONTROLs not needed by the current
+          ; character set, DQUOTE, ";", ":", "\", ","
+
+    Description:  If the property permits, multiple TEXT values are
+      specified by a COMMA-separated list of values.
+
+      The language in which the text is represented can be controlled by
+      the "LANGUAGE" property parameter.
+
+      An intentional formatted text line break MUST only be included in
+      a "TEXT" property value by representing the line break with the
+      character sequence of BACKSLASH, followed by a LATIN SMALL LETTER
+      N or a LATIN CAPITAL LETTER N, that is "\n" or "\N".
+
+      The "TEXT" property values may also contain special characters
+      that are used to signify delimiters, such as a COMMA character for
+      lists of values or a SEMICOLON character for structured values.
+      In order to support the inclusion of these special characters in
+      "TEXT" property values, they MUST be escaped with a BACKSLASH
+      character.  A BACKSLASH character in a "TEXT" property value MUST
+      be escaped with another BACKSLASH character.  A COMMA character in
+      a "TEXT" property value MUST be escaped with a BACKSLASH
+      character.  A SEMICOLON character in a "TEXT" property value MUST
+      be escaped with a BACKSLASH character.  However, a COLON character
+      in a "TEXT" property value SHALL NOT be escaped with a BACKSLASH
+      character.
+
+    Example:  A multiple line value of:
+
+       Project XYZ Final Review
+       Conference Room - 3B
+       Come Prepared.
+
+      would be represented as:
+
+       Project XYZ Final Review\nConference Room - 3B\nCome Prepared.
+       
+        >>> from icalendar.prop import vText
+        >>> message = """Project XYZ Final Review
+        ... Conference Room - 3B
+        ... Come Prepared."""
+        >>> text = vText.from_ical(message)
+        >>> text
+        vText(b'Project XYZ Final Review\\nConference Room - 3B\\nCome Prepared.')
+
+
+
     """
 
     def __new__(cls, value, encoding=DEFAULT_ENCODING):
@@ -147,7 +242,32 @@ class vText(str):
 
 
 class vCalAddress(str):
-    """This just returns an unquoted string.
+    """Calendar User Address
+    Value Name:  CAL-ADDRESS
+
+    Purpose:  This value type is used to identify properties that contain
+      a calendar user address.
+
+    Format Definition:  This value type is defined by the following
+      notation:
+
+       cal-address        = uri
+
+    Description:  The value is a URI as defined by [RFC3986] or any other
+      IANA-registered form for a URI.  When used to address an Internet 
+      email transport address for a calendar user, the value MUST be a
+      mailto URI, as defined by [RFC2368].
+      
+    Example:
+
+        mailto:jane_doe@example.com 
+        
+        >>> from icalendar.prop import vCalAddress
+        >>> cal_address = vCalAddress.from_ical('mailto:jane_doe@example.com')
+        >>> cal_address
+        vCalAddress('mailto:jane_doe@example.com')
+
+      
     """
 
     def __new__(cls, value, encoding=DEFAULT_ENCODING):
@@ -168,7 +288,43 @@ class vCalAddress(str):
 
 
 class vFloat(float):
-    """Just a float.
+    """Float
+    Value Name:  FLOAT
+
+    Purpose:  This value type is used to identify properties that contain
+      a real-number value.
+
+    Format Definition:  This value type is defined by the following
+      notation:
+
+       float      = (["+"] / "-") 1*DIGIT ["." 1*DIGIT]
+
+    Description:  If the property permits, multiple "float" values are
+      specified by a COMMA-separated list of values.
+
+      No additional content value encoding (i.e., BACKSLASH character
+      encoding, see Section 3.3.11) is defined for this value type.
+
+    Example:
+
+        1000000.0000001
+        1.333
+        -3.14
+        
+        >>> from icalendar.prop import vFloat
+        >>> float = vFloat.from_ical('1000000.0000001')
+        >>> float
+        1000000.0000001
+        >>> float = vFloat.from_ical('1.333')
+        >>> float
+        1.333
+        >>> float = vFloat.from_ical('+1.333')
+        >>> float
+        1.333
+        >>> float = vFloat.from_ical('-3.14')
+        >>> float
+        -3.14
+
     """
 
     def __new__(cls, *args, **kwargs):
@@ -188,7 +344,46 @@ class vFloat(float):
 
 
 class vInt(int):
-    """Just an int.
+    """Integer
+    Value Name:  INTEGER
+
+    Purpose:  This value type is used to identify properties that contain
+      a signed integer value.
+
+    Format Definition:  This value type is defined by the following
+      notation:
+
+       integer    = (["+"] / "-") 1*DIGIT
+
+    Description:  If the property permits, multiple "integer" values are
+      specified by a COMMA-separated list of values.  The valid range
+      for "integer" is -2147483648 to 2147483647.  If the sign is not
+      specified, then the value is assumed to be positive.
+
+      No additional content value encoding (i.e., BACKSLASH character
+      encoding, see Section 3.3.11) is defined for this value type.
+
+    Example:
+
+        1234567890
+        -1234567890
+        +1234567890
+        432109876
+        
+        >>> from icalendar.prop import vInt
+        >>> integer = vInt.from_ical('1234567890')
+        >>> integer
+        1234567890
+        >>> integer = vInt.from_ical('-1234567890')
+        >>> integer
+        -1234567890
+        >>> integer = vInt.from_ical('+1234567890')
+        >>> integer
+        1234567890
+        >>> integer = vInt.from_ical('432109876')
+        >>> integer
+        432109876
+        
     """
 
     def __new__(cls, *args, **kwargs):
@@ -486,8 +681,62 @@ class vDatetime(TimeBase):
 
 
 class vDuration(TimeBase):
-    """Subclass of timedelta that renders itself in the iCalendar DURATION
-    format.
+    """Duration
+    Value Name:  DURATION
+
+    Purpose:  This value type is used to identify properties that contain
+      a duration of time.
+
+    Format Definition:  This value type is defined by the following
+      notation:
+
+       dur-value  = (["+"] / "-") "P" (dur-date / dur-time / dur-week)
+
+       dur-date   = dur-day [dur-time]
+       dur-time   = "T" (dur-hour / dur-minute / dur-second)
+       dur-week   = 1*DIGIT "W"
+       dur-hour   = 1*DIGIT "H" [dur-minute]
+       dur-minute = 1*DIGIT "M" [dur-second]
+       dur-second = 1*DIGIT "S"
+       dur-day    = 1*DIGIT "D"
+
+    Description:  If the property permits, multiple "duration" values are
+      specified by a COMMA-separated list of values.  The format is
+      based on the [ISO.8601.2004] complete representation basic format
+      with designators for the duration of time.  The format can
+      represent nominal durations (weeks and days) and accurate
+      durations (hours, minutes, and seconds).  Note that unlike
+      [ISO.8601.2004], this value type doesn't support the "Y" and "M"
+      designators to specify durations in terms of years and months.
+      The duration of a week or a day depends on its position in the
+      calendar.  In the case of discontinuities in the time scale, such
+      as the change from standard time to daylight time and back, the
+      computation of the exact duration requires the subtraction or
+      addition of the change of duration of the discontinuity.  Leap
+      seconds MUST NOT be considered when computing an exact duration.
+      When computing an exact duration, the greatest order time
+      components MUST be added first, that is, the number of days MUST
+      be added first, followed by the number of hours, number of
+      minutes, and number of seconds.
+      
+    Example:  A duration of 15 days, 5 hours, and 20 seconds would be:
+
+        P15DT5H0M20S
+
+      A duration of 7 weeks would be:
+
+        P7W
+        
+        >>> from icalendar.prop import vDuration
+        >>> duration = vDuration.from_ical('P15DT5H0M20S')
+        >>> duration
+        datetime.timedelta(days=15, seconds=18020)
+        >>> duration = vDuration.from_ical('P7W')
+        >>> duration
+        datetime.timedelta(days=49)
+
+       
+     
     """
 
     def __init__(self, td):
@@ -549,7 +798,59 @@ class vDuration(TimeBase):
 
 
 class vPeriod(TimeBase):
-    """A precise period of time.
+    """Period of Time
+    Value Name:  PERIOD
+
+    Purpose:  This value type is used to identify values that contain a
+      precise period of time.
+
+    Format Definition:  This value type is defined by the following
+      notation:
+
+       period     = period-explicit / period-start
+
+       period-explicit = date-time "/" date-time
+       ; [ISO.8601.2004] complete representation basic format for a
+       ; period of time consisting of a start and end.  The start MUST
+       ; be before the end.
+
+       period-start = date-time "/" dur-value
+       ; [ISO.8601.2004] complete representation basic format for a
+       ; period of time consisting of a start and positive duration
+       ; of time.
+       
+    Description:  If the property permits, multiple "period" values are
+      specified by a COMMA-separated list of values.  There are two
+      forms of a period of time.  First, a period of time is identified
+      by its start and its end.  This format is based on the
+      [ISO.8601.2004] complete representation, basic format for "DATE-
+      TIME" start of the period, followed by a SOLIDUS character
+      followed by the "DATE-TIME" of the end of the period.  The start
+      of the period MUST be before the end of the period.  Second, a
+      period of time can also be defined by a start and a positive
+      duration of time.  The format is based on the [ISO.8601.2004]
+      complete representation, basic format for the "DATE-TIME" start of
+      the period, followed by a SOLIDUS character, followed by the
+      [ISO.8601.2004] basic format for "DURATION" of the period.
+
+    Example:  The period starting at 18:00:00 UTC, on January 1, 1997 and
+    ending at 07:00:00 UTC on January 2, 1997 would be:
+
+        19970101T180000Z/19970102T070000Z
+
+        The period start at 18:00:00 on January 1, 1997 and lasting 5
+        hours and 30 minutes would be:
+
+        19970101T180000Z/PT5H30M
+       
+        >>> from icalendar.prop import vPeriod
+        >>> period = vPeriod.from_ical('19970101T180000Z/19970102T070000Z')
+        >>> period
+        (datetime.datetime(1997, 1, 1, 18, 0, tzinfo=backports.zoneinfo.ZoneInfo(key='UTC')), datetime.datetime(1997, 1, 2, 7, 0, tzinfo=backports.zoneinfo.ZoneInfo(key='UTC')))
+        >>> period = vPeriod.from_ical('19970101T180000Z/PT5H30M')
+        >>> period
+        (datetime.datetime(1997, 1, 1, 18, 0, tzinfo=backports.zoneinfo.ZoneInfo(key='UTC')), datetime.timedelta(seconds=19800))
+
     """
 
     def __init__(self, per):
@@ -857,7 +1158,101 @@ class vRecur(CaselessDict):
 
 
 class vTime(TimeBase):
-    """Render and generates iCalendar time format.
+    """Time
+    Value Name:  TIME
+
+    Purpose:  This value type is used to identify values that contain a
+      time of day.
+
+    Format Definition:  This value type is defined by the following
+      notation:
+
+       time         = time-hour time-minute time-second [time-utc]
+
+       time-hour    = 2DIGIT        ;00-23
+       time-minute  = 2DIGIT        ;00-59
+       time-second  = 2DIGIT        ;00-60
+       ;The "60" value is used to account for positive "leap" seconds.
+
+       time-utc     = "Z"
+
+    Description:  If the property permits, multiple "time" values are
+      specified by a COMMA-separated list of values.  No additional
+      content value encoding (i.e., BACKSLASH character encoding, see
+      vText) is defined for this value type.
+
+      The "TIME" value type is used to identify values that contain a
+      time of day.  The format is based on the [ISO.8601.2004] complete
+      representation, basic format for a time of day.  The text format
+      consists of a two-digit, 24-hour of the day (i.e., values 00-23),
+      two-digit minute in the hour (i.e., values 00-59), and two-digit
+      seconds in the minute (i.e., values 00-60).  The seconds value of
+      60 MUST only be used to account for positive "leap" seconds.
+      Fractions of a second are not supported by this format.
+
+      In parallel to the "DATE-TIME" definition above, the "TIME" value
+      type expresses time values in three forms:
+
+      The form of time with UTC offset MUST NOT be used.  For example,
+      the following is not valid for a time value:
+
+       230000-0800        ;Invalid time format
+
+      FORM #1 LOCAL TIME
+
+      The local time form is simply a time value that does not contain
+      the UTC designator nor does it reference a time zone.  For
+      example, 11:00 PM:
+
+       230000
+      Time values of this type are said to be "floating" and are not
+      bound to any time zone in particular.  They are used to represent
+      the same hour, minute, and second value regardless of which time
+      zone is currently being observed.  For example, an event can be
+      defined that indicates that an individual will be busy from 11:00
+      AM to 1:00 PM every day, no matter which time zone the person is
+      in.  In these cases, a local time can be specified.  The recipient
+      of an iCalendar object with a property value consisting of a local
+      time, without any relative time zone information, SHOULD interpret
+      the value as being fixed to whatever time zone the "ATTENDEE" is
+      in at any given moment.  This means that two "Attendees", may
+      participate in the same event at different UTC times; floating
+      time SHOULD only be used where that is reasonable behavior.
+
+      In most cases, a fixed time is desired.  To properly communicate a
+      fixed time in a property value, either UTC time or local time with
+      time zone reference MUST be specified.
+
+      The use of local time in a TIME value without the "TZID" property
+      parameter is to be interpreted as floating time, regardless of the
+      existence of "VTIMEZONE" calendar components in the iCalendar
+      object.
+
+      FORM #2: UTC TIME
+
+      UTC time, or absolute time, is identified by a LATIN CAPITAL
+      LETTER Z suffix character, the UTC designator, appended to the
+      time value.  For example, the following represents 07:00 AM UTC:
+
+       070000Z
+
+      The "TZID" property parameter MUST NOT be applied to TIME
+      properties whose time values are specified in UTC.
+
+      FORM #3: LOCAL TIME AND TIME ZONE REFERENCE
+
+      The local time with reference to time zone information form is
+      identified by the use the "TZID" property parameter to reference
+      the appropriate time zone definition.
+
+    Example:  The following represents 8:30 AM in New York in winter,
+      five hours behind UTC, in each of the three formats:
+
+        083000
+        133000Z
+        TZID=America/New_York:083000
+       
+ 
     """
 
     def __init__(self, *args):
@@ -883,7 +1278,37 @@ class vTime(TimeBase):
 
 
 class vUri(str):
-    """Uniform resource identifier is basically just an unquoted string.
+    """URI
+    Value Name:  URI
+
+    Purpose:  This value type is used to identify values that contain a
+      uniform resource identifier (URI) type of reference to the
+      property value.
+
+    Format Definition:  This value type is defined by the following
+      notation:
+
+       uri = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
+
+    Description:  This value type might be used to reference binary
+      information, for values that are large, or otherwise undesirable
+      to include directly in the iCalendar object.
+
+      Property values with this value type MUST follow the generic URI
+      syntax defined in [RFC3986].
+
+      When a property parameter value is a URI value type, the URI MUST
+      be specified as a quoted-string value.
+
+    Example:  The following is a URI for a network file:
+
+        http://example.com/my-report.txt
+
+        >>> from icalendar.prop import vUri
+        >>> uri = vUri.from_ical('http://example.com/my-report.txt')
+        >>> uri
+        'http://example.com/my-report.txt'
+
     """
 
     def __new__(cls, value, encoding=DEFAULT_ENCODING):
@@ -904,7 +1329,40 @@ class vUri(str):
 
 
 class vGeo:
-    """A special type that is only indirectly defined in the rfc.
+    """Geographic Position
+
+    Property Name:  GEO
+
+    Purpose:  This property specifies information related to the global
+        position for the activity specified by a calendar component.
+
+    Value Type:  FLOAT.  The value MUST be two SEMICOLON-separated FLOAT
+        values.
+
+    Property Parameters:  IANA and non-standard property parameters can
+        be specified on this property.
+
+    Conformance:  This property can be specified in "VEVENT" or "VTODO"
+        calendar components.
+
+    Description:  This property value specifies latitude and longitude,
+        in that order (i.e., "LAT LON" ordering).  The longitude
+        represents the location east or west of the prime meridian as a
+        positive or negative real number, respectively.  The longitude and
+        latitude values MAY be specified up to six decimal places, which
+        will allow for accuracy to within one meter of geographical
+        position.  Receiving applications MUST accept values of this
+        precision and MAY truncate values of greater precision.
+
+    Example:
+        GEO:37.386013;-122.082932
+        
+        >>> from icalendar.prop import vGeo
+        >>> geo = vGeo.from_ical('37.386013;-122.082932')
+        >>> geo.latitude
+        37.386013
+        >>> geo.longitude
+        -122.082932
     """
 
     def __init__(self, geo):
@@ -935,7 +1393,42 @@ class vGeo:
 
 
 class vUTCOffset:
-    """Renders itself as a utc offset.
+    """UTC Offset
+    Value Name:  UTC-OFFSET
+
+    Purpose:  This value type is used to identify properties that contain
+      an offset from UTC to local time.
+
+    Format Definition:  This value type is defined by the following
+      notation:
+
+       utc-offset = time-numzone
+
+       time-numzone = ("+" / "-") time-hour time-minute [time-second]
+
+    Description:  The PLUS SIGN character MUST be specified for positive
+      UTC offsets (i.e., ahead of UTC).  The HYPHEN-MINUS character MUST
+      be specified for negative UTC offsets (i.e., behind of UTC).  The
+      value of "-0000" and "-000000" are not allowed.  The time-second,
+      if present, MUST NOT be 60; if absent, it defaults to zero.
+
+    Example:  The following UTC offsets are given for standard time for
+      New York (five hours behind UTC) and Geneva (one hour ahead of
+      UTC):
+
+        -0500
+
+        +0100
+        
+        >>> from icalendar.prop import vUTCOffset
+        >>> utc_offset = vUTCOffset.from_ical('-0500')
+        >>> utc_offset
+        datetime.timedelta(days=-1, seconds=68400)
+        >>> utc_offset = vUTCOffset.from_ical('+0100')
+        >>> utc_offset
+        datetime.timedelta(seconds=3600)
+
+        
     """
 
     ignore_exceptions = False  # if True, and we cannot parse this

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -155,70 +155,7 @@ class vBoolean(int):
 
 
 class vText(str):
-    """Text
-    Value Name:  TEXT
-
-    Purpose:  This value type is used to identify values that contain
-      human-readable text.
-
-    Format Definition:  This value type is defined by the following
-      notation:
-      text       = *(TSAFE-CHAR / ":" / DQUOTE / ESCAPED-CHAR)
-          ; Folded according to description above
-
-       ESCAPED-CHAR = ("\\" / "\;" / "\," / "\N" / "\\n")
-          ; \\ encodes \, \N or \\n encodes newline
-          ; \; encodes ;, \, encodes ,
-
-       TSAFE-CHAR = WSP / %x21 / %x23-2B / %x2D-39 / %x3C-5B /
-                    %x5D-7E / NON-US-ASCII
-          ; Any character except CONTROLs not needed by the current
-          ; character set, DQUOTE, ";", ":", "\", ","
-
-    Description:  If the property permits, multiple TEXT values are
-      specified by a COMMA-separated list of values.
-
-      The language in which the text is represented can be controlled by
-      the "LANGUAGE" property parameter.
-
-      An intentional formatted text line break MUST only be included in
-      a "TEXT" property value by representing the line break with the
-      character sequence of BACKSLASH, followed by a LATIN SMALL LETTER
-      N or a LATIN CAPITAL LETTER N, that is "\\n" or "\N".
-
-      The "TEXT" property values may also contain special characters
-      that are used to signify delimiters, such as a COMMA character for
-      lists of values or a SEMICOLON character for structured values.
-      In order to support the inclusion of these special characters in
-      "TEXT" property values, they MUST be escaped with a BACKSLASH
-      character.  A BACKSLASH character in a "TEXT" property value MUST
-      be escaped with another BACKSLASH character.  A COMMA character in
-      a "TEXT" property value MUST be escaped with a BACKSLASH
-      character.  A SEMICOLON character in a "TEXT" property value MUST
-      be escaped with a BACKSLASH character.  However, a COLON character
-      in a "TEXT" property value SHALL NOT be escaped with a BACKSLASH
-      character.
-
-    Example:  A multiple line value of:
-
-       Project XYZ Final Review
-       Conference Room - 3B
-       Come Prepared.
-
-      would be represented as:
-
-       Project XYZ Final Review\\nConference Room - 3B\\nCome Prepared.
-       
-        >>> from icalendar.prop import vText
-        >>> message = '''Project XYZ Final Review
-        ... Conference Room - 3B
-        ... Come Prepared.'''
-        >>> text = vText.from_ical(message)
-        >>> text
-        vText(b'Project XYZ Final Review\\nConference Room - 3B\\nCome Prepared.')
-
-
-
+    """Simple text.
     """
 
     def __new__(cls, value, encoding=DEFAULT_ENCODING):

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -775,11 +775,7 @@ class vPeriod(TimeBase):
        
         >>> from icalendar.prop import vPeriod
         >>> period = vPeriod.from_ical('19970101T180000Z/19970102T070000Z')
-        >>> period
-        (datetime.datetime(1997, 1, 1, 18, 0, tzinfo=backports.zoneinfo.ZoneInfo(key='UTC')), datetime.datetime(1997, 1, 2, 7, 0, tzinfo=backports.zoneinfo.ZoneInfo(key='UTC')))
         >>> period = vPeriod.from_ical('19970101T180000Z/PT5H30M')
-        >>> period
-        (datetime.datetime(1997, 1, 1, 18, 0, tzinfo=backports.zoneinfo.ZoneInfo(key='UTC')), datetime.timedelta(seconds=19800))
 
     """
 
@@ -1289,10 +1285,9 @@ class vGeo:
         
         >>> from icalendar.prop import vGeo
         >>> geo = vGeo.from_ical('37.386013;-122.082932')
-        >>> geo.latitude
-        37.386013
-        >>> geo.longitude
-        -122.082932
+        >>> geo
+        (37.386013, -122.082932)
+
     """
 
     def __init__(self, geo):

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -166,8 +166,8 @@ class vText(str):
       text       = *(TSAFE-CHAR / ":" / DQUOTE / ESCAPED-CHAR)
           ; Folded according to description above
 
-       ESCAPED-CHAR = ("\\" / "\;" / "\," / "\N" / "\n")
-          ; \\ encodes \, \N or \n encodes newline
+       ESCAPED-CHAR = ("\\" / "\;" / "\," / "\N" / "\\n")
+          ; \\ encodes \, \N or \\n encodes newline
           ; \; encodes ;, \, encodes ,
 
        TSAFE-CHAR = WSP / %x21 / %x23-2B / %x2D-39 / %x3C-5B /
@@ -184,7 +184,7 @@ class vText(str):
       An intentional formatted text line break MUST only be included in
       a "TEXT" property value by representing the line break with the
       character sequence of BACKSLASH, followed by a LATIN SMALL LETTER
-      N or a LATIN CAPITAL LETTER N, that is "\n" or "\N".
+      N or a LATIN CAPITAL LETTER N, that is "\\n" or "\N".
 
       The "TEXT" property values may also contain special characters
       that are used to signify delimiters, such as a COMMA character for
@@ -207,7 +207,7 @@ class vText(str):
 
       would be represented as:
 
-       Project XYZ Final Review\nConference Room - 3B\nCome Prepared.
+       Project XYZ Final Review\\nConference Room - 3B\\nCome Prepared.
        
         >>> from icalendar.prop import vText
         >>> message = '''Project XYZ Final Review

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -115,8 +115,7 @@ class vBoolean(int):
        boolean    = "TRUE" / "FALSE"
 
     Description:  These values are case-insensitive text.  No additional
-      content value encoding (i.e., BACKSLASH character encoding, see
-      Section 3.3.11) is defined for this value type.
+      content value encoding is defined for this value type.
 
     Example:  The following is an example of a hypothetical property that
       has a BOOLEAN value type:
@@ -302,9 +301,6 @@ class vFloat(float):
     Description:  If the property permits, multiple "float" values are
       specified by a COMMA-separated list of values.
 
-      No additional content value encoding (i.e., BACKSLASH character
-      encoding, see Section 3.3.11) is defined for this value type.
-
     Example:
 
         1000000.0000001
@@ -359,9 +355,6 @@ class vInt(int):
       specified by a COMMA-separated list of values.  The valid range
       for "integer" is -2147483648 to 2147483647.  If the sign is not
       specified, then the value is assumed to be positive.
-
-      No additional content value encoding (i.e., BACKSLASH character
-      encoding, see Section 3.3.11) is defined for this value type.
 
     Example:
 


### PR DESCRIPTION
Added ``__doc__`` string documentation for ``vDate``, ``vBoolean``, ``vCalAddress``, ``vDuration``, ``vFloat``, ``vGeo``, ``vInt``, ``vPeriod``, ``vText``, ``vTime``, ``vUTCOffset`` and ``vUri``.
Added ``vTime``  description, but examples from icalendar are not implemented because timezone support is not implemented.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--745.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->