### PR TITLE
Add `sign` and `weekday` attributes to `vWeekday` components

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,11 +6,11 @@ Changelog
 
 Minor changes:
 
-- Add ``sign`` and ``weekday`` attributes to ``vWeekday`` components. See `Issue 749 <https://github.com/collective/icalendar/issues/749>`_.
+- Add a ``weekday`` attribute to ``vWeekday`` components. See `Issue 749 <https://github.com/collective/icalendar/issues/749>`_.
 
 Breaking changes:
 
-- ...
+- The ``relative`` attribute of ``vWeekday`` components has the correct sign now. See `Issue 749 <https://github.com/collective/icalendar/issues/749>`_.
 
 New features:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 Minor changes:
 
-- ...
+- Add ``sign`` and ``weekday`` attributes to ``vWeekday`` components. See `Issue 749 <https://github.com/collective/icalendar/issues/749>`_.
 
 Breaking changes:
 

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -77,6 +77,7 @@ icalendar contributors
 - Jeffrey Whewhetu <jeffwhewhetu@gmail.com>
 - `Soham Dutta <https://github.com/NP-compete>`_
 - `Serif OZ  <https://github.com/SerifOZ>`_
+- David Venhoff <https://github.com/david-venhoff>
 
 Find out who contributed::
 

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -931,6 +931,8 @@ class vWeekday(str):
         relative = match['relative']
         if weekday not in vWeekday.week_days or sign not in '+-':
             raise ValueError(f'Expected weekday abbrevation, got: {self}')
+        self.sign = sign or None
+        self.weekday = weekday or None
         self.relative = relative and int(relative) or None
         self.params = Parameters()
         return self

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -913,7 +913,32 @@ class vPeriod(TimeBase):
 
 
 class vWeekday(str):
-    """This returns an unquoted weekday abbrevation.
+    """Either a ``weekday`` or a ``weekdaynum``
+
+    .. code-block:: pycon
+
+        >>> from icalendar import vWeekday
+        >>> vWeekday("MO") # Simple weekday
+        'MO'
+        >>> vWeekday("2FR").relative # Second friday
+        2
+        >>> vWeekday("2FR").weekday
+        'FR'
+        >>> vWeekday("-1SU").relative # Last Sunday
+        -1
+
+    Definition from RFC:
+
+    .. code-block:: text
+
+        weekdaynum = [[plus / minus] ordwk] weekday
+        plus        = "+"
+        minus       = "-"
+        ordwk       = 1*2DIGIT       ;1 to 53
+        weekday     = "SU" / "MO" / "TU" / "WE" / "TH" / "FR" / "SA"
+        ;Corresponding to SUNDAY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY,
+        ;FRIDAY, and SATURDAY days of the week.
+
     """
     week_days = CaselessDict({
         "SU": 0, "MO": 1, "TU": 2, "WE": 3, "TH": 4, "FR": 5, "SA": 6,

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -931,9 +931,10 @@ class vWeekday(str):
         relative = match['relative']
         if weekday not in vWeekday.week_days or sign not in '+-':
             raise ValueError(f'Expected weekday abbrevation, got: {self}')
-        self.sign = sign or None
         self.weekday = weekday or None
         self.relative = relative and int(relative) or None
+        if sign == '-' and self.relative:
+            self.relative *= -1
         self.params = Parameters()
         return self
 

--- a/src/icalendar/tests/prop/test_vWeekday.py
+++ b/src/icalendar/tests/prop/test_vWeekday.py
@@ -6,7 +6,6 @@ from icalendar.prop import vWeekday
 def test_simple():
     weekday = vWeekday("SU")
     assert weekday.to_ical() == b"SU"
-    assert weekday.sign is None
     assert weekday.weekday == "SU"
     assert weekday.relative is None
 
@@ -14,9 +13,8 @@ def test_simple():
 def test_relative():
     weekday = vWeekday("-1MO")
     assert weekday.to_ical() == b"-1MO"
-    assert weekday.sign == "-"
     assert weekday.weekday == "MO"
-    assert weekday.relative == 1
+    assert weekday.relative == -1
 
 
 def test_roundtrip():

--- a/src/icalendar/tests/prop/test_vWeekday.py
+++ b/src/icalendar/tests/prop/test_vWeekday.py
@@ -1,0 +1,29 @@
+import pytest
+
+from icalendar.prop import vWeekday
+
+
+def test_simple():
+    weekday = vWeekday("SU")
+    assert weekday.to_ical() == b"SU"
+    assert weekday.sign is None
+    assert weekday.weekday == "SU"
+    assert weekday.relative is None
+
+
+def test_relative():
+    weekday = vWeekday("-1MO")
+    assert weekday.to_ical() == b"-1MO"
+    assert weekday.sign == "-"
+    assert weekday.weekday == "MO"
+    assert weekday.relative == 1
+
+
+def test_roundtrip():
+    assert vWeekday.from_ical(vWeekday("+2TH").to_ical()) == "+2TH"
+
+
+def test_error():
+    """Error: Expected weekday abbrevation, got: \"-100MO\" """
+    with pytest.raises(ValueError):
+        vWeekday.from_ical("-100MO")


### PR DESCRIPTION
This pr adds the `sign` and `weekday` properties to `vWeekday` components, so that users of this library don't have to manually parse these. 

I decided to just make the existing variables available, but I could also combine `sign` and `relative` into one variable, if that is wanted.

Fixes: #749 

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--750.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->