### PR TITLE
Print result of doctest failure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 Minor changes:
 
 - Add a ``weekday`` attribute to ``vWeekday`` components. See `Issue 749 <https://github.com/collective/icalendar/issues/749>`_.
+- Print failure of doctest to aid debugging.
 
 Breaking changes:
 

--- a/src/icalendar/tests/test_with_doctest.py
+++ b/src/icalendar/tests/test_with_doctest.py
@@ -86,14 +86,14 @@ def test_documentation_file(document, zoneinfo_only, env_for_doctest, tzp):
     functions are also replaced to work.
     """
     try:
+        import pytz
+    except ImportError:
+        pytest.skip("pytz not installed, skipping this file.")
+    try:
         # set raise_on_error to False if you wand to see the error for debug
         test_result = doctest.testfile(
-            document, module_relative=False, globs=env_for_doctest, raise_on_error=True
+            document, module_relative=False, globs=env_for_doctest, raise_on_error=False
         )
-    except doctest.UnexpectedException as e:
-        ty, err, tb = e.exc_info
-        if issubclass(ty, ModuleNotFoundError) and err.name == "pytz":
-            pytest.skip("pytz not installed, skipping this file.")
     finally:
         tzp.use_zoneinfo()
     assert (


### PR DESCRIPTION
When the documentation tests fail, this change will print the result of that.
Before, there was no hint, now you can see this for example:

```
**********************************************************************
File "/home/nicco/icalendar/src/icalendar/tests/../../../docs/usage.rst", line 408, in usage.rst
Failed example:
    f.write(cal.to_ical())
Expected:
    733
Got:
    775
**********************************************************************
File "/home/nicco/icalendar/src/icalendar/tests/../../../docs/usage.rst", line 416, in usage.rst
Failed example:
    print(cal.to_ical().decode('utf-8')) # doctest: +NORMALIZE_WHITESPACE
Expected:
    BEGIN:VCALENDAR
    VERSION:2.0
    PRODID:-//My calendar product//mxm.dk//
    BEGIN:VEVENT
    SUMMARY:Python meeting about calendaring
    DTSTART:20050404T080000Z
    DTEND:20050404T100000Z
    DTSTAMP:20050404T001000Z
    UID:20050115T101010/27346262376@mxm.dk
    RRULE:FREQ=DAILY
    ATTENDEE;CN="Max Rasmussen";ROLE=REQ-PARTICIPANT:MAILTO:maxm@example.com
    ATTENDEE;CN="The Dude";ROLE=REQ-PARTICIPANT:MAILTO:the-dude@example.com
    LOCATION:Odense\, Denmark
    ORGANIZER;CN="Max Rasmussen";ROLE=CHAIR:MAILTO:noone@example.com
    PRIORITY:5
    BEGIN:VALARM
    ACTION:DISPLAY
    DESCRIPTION:Reminder: Event in 1 hour
    TRIGGER:-PT1H
    END:VALARM
    BEGIN:VALARM
    ACTION:DISPLAY
    DESCRIPTION:Reminder: Event in 24 hours
    TRIGGER:-P1D
    END:VALARM
    END:VEVENT
    END:VCALENDAR
    <BLANKLINE>
Got:
    BEGIN:VCALENDAR
    VERSION:2.0
    PRODID:-//My calendar product//mxm.dk//
    BEGIN:VEVENT
    SUMMARY:Python meeting about calendaring
    DTSTART:20050404T080000Z
    DTEND:20050404T100000Z
    DTSTAMP:20050404T001000Z
    UID:20050115T101010/27346262376@mxm.dk
    RRULE:FREQ=DAILY;INTERVAL=10
    RRULE:FREQ=DAILY;INTERVAL=10
    ATTENDEE;CN="Max Rasmussen";ROLE=REQ-PARTICIPANT:MAILTO:maxm@example.com
    ATTENDEE;CN="The Dude";ROLE=REQ-PARTICIPANT:MAILTO:the-dude@example.com
    LOCATION:Odense\, Denmark
    ORGANIZER;CN="Max Rasmussen";ROLE=CHAIR:MAILTO:noone@example.com
    PRIORITY:5
    BEGIN:VALARM
    ACTION:DISPLAY
    DESCRIPTION:Reminder: Event in 1 hour
    TRIGGER:-PT1H
    END:VALARM
    BEGIN:VALARM
    ACTION:DISPLAY
    DESCRIPTION:Reminder: Event in 24 hours
    TRIGGER:-P1D
    END:VALARM
    END:VEVENT
    END:VCALENDAR
**********************************************************************
1 items had failures:
   2 of  89 in usage.rst
***Test Failed*** 2 failures.

```