### PR TITLE
Link to issue tracker and discussions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,9 @@ files.
 ----
 
 :Homepage: https://icalendar.readthedocs.io
+:Community Discussions: https://github.com/collective/icalendar/discussions
+:Issue Tracker: https://github.com/collective/icalendar/issues
 :Code: https://github.com/collective/icalendar
-:Mailing list: https://github.com/collective/icalendar/issues
 :Dependencies: `python-dateutil`_ and `tzdata`_.
 :License: `BSD`_
 


### PR DESCRIPTION
We do not have a mailing list any more.
This updates the links.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--761.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->