### PR TITLE
Add intersphinx

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ Breaking changes:
 
 New features:
 
-- ...
+- Types in documentation now link to their documentation pages using ``intersphinx``
 
 Bug fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ Breaking changes:
 
 New features:
 
-- Types in documentation now link to their documentation pages using ``intersphinx``
+- Python types in documentation now link to their documentation pages using ``intersphinx``.
 
 Bug fixes:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
-    'sphinx_copybutton'
+    'sphinx_copybutton',
+    'sphinx.ext.intersphinx',
 ]
 source_suffix = '.rst'
 master_doc = 'index'
@@ -41,3 +42,10 @@ man_pages = [
     ('index', 'icalendar', 'icalendar Documentation',
      ['Plone Foundation'], 1)
 ]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "dateutil": ("https://dateutil.readthedocs.io/en/stable/", None),
+    "tzdata": ("https://tzdata.readthedocs.io/en/latest/", None),
+    "pytz": ("https://pythonhosted.org/pytz/", None),
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,4 @@ man_pages = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "dateutil": ("https://dateutil.readthedocs.io/en/stable/", None),
-    "tzdata": ("https://tzdata.readthedocs.io/en/latest/", None),
-    "pytz": ("https://pythonhosted.org/pytz/", None),
 }


### PR DESCRIPTION
This adds intersphinx mapping of Python objects and our dependencies.

Before:
![Screenshot 2025-01-17 at 17-40-19 API Reference — icalendar 6 1 1 dev35 documentation](https://github.com/user-attachments/assets/6c990e8b-4d67-4546-ad89-2ae76c3b91e9)

Now, bool and date are a link:

![Screenshot 2025-01-17 at 17-40-36 API Reference — icalendar 6 1 1 dev35 documentation](https://github.com/user-attachments/assets/81ab8f94-4848-4f7d-ad8d-a05f0dced3f2)


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--770.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->