### PR TITLE
Reapply "Create stability around timezone identification"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ New features:
 
 Bug fixes:
 
-- ...
+- Stabelize timezone id lookup, see `Issue 780 <https://github.com/collective/icalendar/issues/780>`_.
 
 6.1.2 (2025-03-19)
 ------------------


### PR DESCRIPTION
I accidentally worked on the `main` branch. Here is the pull request.

- use existing lookup table only to identify equivalent timezones
- return a tuple of possible timezone ids
- first in this tuple is the timezoneid passed
- test dateutil, pytz, zoneinfo
- add support for dateutil.tz.tzutc

This fixes #780 