### PR TITLE
Add developer certificate of origin to pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+<!--
+  1. Please mention issues.
+  2. Agree to be the original author, see below.
+--->
+
+
+
+<details><summary>
+
+- [ ] I agree to the Developer Certificate of Origin Version 1.1
+
+</summary>
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+**Developer's Certificate of Origin 1.1**
+
+By making a contribution to this project, I certify that:
+
+1. The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+2. The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+3. The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+4. I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+</details>


### PR DESCRIPTION
This adds a Developer Certificate of Origin to all the pull requests.

See this example:

https://github.com/niccokunzmann/developer-certificate-of-origin-pr/pull/1

You can open and close it and agree to the certificate.

Fixes #778.