### PR TITLE
Use license expression for project metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 Minor changes:
 
 - Use ``ruff`` to format the source code.
+- Update project metadata to use License-Expression.
 
 Breaking changes:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@
 #
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling>=1.27.0", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "icalendar"
-license = { file = "LICENSE.rst", name = "BSD-2-Clause" }
-#    name = "BSD-2-Clause", # TODO: is this the right short key
+license = "BSD-2-Clause"
+license-files = ["LICENSE.rst"]
 keywords = [
     "calendar",
     "calendaring",


### PR DESCRIPTION
Hatchling `1.27.0` added support for [PEP 639](https://peps.python.org/pep-0639/) license expressions. Update the project metadata for it.