### PR TITLE
Document semver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+We use `Semantic Versioning <https://semver.org>`_.
+
+- Breaking changes increase the **major** version number.
+- New features increase the **minor** version number.
+- Minor changes and bug fixes increase the **patch** version number.
+
 6.2.1 (unreleased)
 ------------------
 


### PR DESCRIPTION
We use semantic versioning on the project. This is now also written into the changelog.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--827.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->