### PR TITLE
Add UID property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Breaking changes:
 
 New features:
 
-- ...
+- Add the ``uid`` property to ``Alarm``, ``Event``, ``Calendar``, ``Todo``, and ``Journal`` components. See `Issue 740 <https://github.com/collective/icalendar/issues/740>`_.
 
 Bug fixes:
 

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -633,8 +633,13 @@ Description:
     values in the middle of a UTF-8 multi-octet sequence.
 
 Conformance:
-    The "UID" property can be specified on "VEVENT", "VTODO", and
-    "VJOURNAL" calendar components.
+    :rfc:`5545` states that the "UID" property can be specified on "VEVENT", "VTODO",
+    and "VJOURNAL" calendar components.
+    :rfc:`7986` modifies the definition of the "UID" property to
+    allow it to be defined in an iCalendar object.
+    :rfc:`9074`  adds a "UID" property to "VALARM" components to allow a unique
+    identifier to be specified. The value of this property can then be used
+    to refer uniquely to the "VALARM" component.
 
 Purpose:
     :rfc:`5545` states that this property specifies the persistent, globally unique

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -602,14 +602,84 @@ Example:
 """
 )
 
+uid_property = single_string_property(
+    "UID", """UID specifies the persistent, globally unique identifier for a component.
+
+We recommend using :py:`uuid.uuid4` to generate new values.
+
+Description:
+    The "UID" itself MUST be a globally unique identifier.
+    The generator of the identifier MUST guarantee that the identifier
+    is unique.
+
+    This is the method for correlating scheduling messages with the
+    referenced "VEVENT", "VTODO", or "VJOURNAL" calendar component.
+    The full range of calendar components specified by a recurrence
+    set is referenced by referring to just the "UID" property value
+    corresponding to the calendar component.  The "RECURRENCE-ID"
+    property allows the reference to an individual instance within the
+    recurrence set.
+
+    This property is an important method for group-scheduling
+    applications to match requests with later replies, modifications,
+    or deletion requests.  Calendaring and scheduling applications
+    MUST generate this property in "VEVENT", "VTODO", and "VJOURNAL"
+    calendar components to assure interoperability with other group-
+    scheduling applications.  This identifier is created by the
+    calendar system that generates an iCalendar object.
+
+    Implementations MUST be able to receive and persist values of at
+    least 255 octets for this property, but they MUST NOT truncate
+    values in the middle of a UTF-8 multi-octet sequence.
+
+Conformance:
+    The "UID" property can be specified on "VEVENT", "VTODO", and
+    "VJOURNAL" calendar components.
+
+Purpose:
+    :rfc:`5545` states that this property specifies the persistent, globally unique
+    identifier for the iCalendar object.  This can be used, for
+    example, to identify duplicate calendar streams that a client may
+    have been given access to.  It can be used in conjunction with the
+    "LAST-MODIFIED" property also specified on the "VCALENDAR" object
+    to identify the most recent version of a calendar.
+
+    :rfc:`7986` states that UID can be used, for
+    example, to identify duplicate calendar streams that a client may
+    have been given access to.  It can be used in conjunction with the
+    "LAST-MODIFIED" property also specified on the "VCALENDAR" object
+    to identify the most recent version of a calendar.
+
+Security:
+    :rfc:`7986` states that UID values MUST NOT include any data that
+    might identify a user, host, domain, or any other security- or
+    privacy-sensitive information.  It is RECOMMENDED that calendar user
+    agents now generate "UID" values that are hex-encoded random
+    Universally Unique Identifier (UUID) values as defined in
+    Sections 4.4 and 4.5 of :rfc:`4122`.
+
+Conformance:
+    This property can be specified once in an iCalendar object.
+
+Examples:
+    The following is an example of such a property value:
+    ``5FC53010-1267-4F8E-BC28-1D7AE55A7C99``.
+
+
+"""
+)
+
+
+
 __all__ = [
-    "single_utc_property",
-    "color_property",
-    "multi_language_text_property",
-    "single_int_property",
-    "sequence_property",
     "categories_property",
-    "rdates_property",
+    "color_property",
     "exdates_property",
+    "multi_language_text_property",
+    "rdates_property",
     "rrules_property",
+    "sequence_property",
+    "single_int_property",
+    "single_utc_property",
+    "uid_property",
 ]

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -661,6 +661,9 @@ Security:
     Sections 4.4 and 4.5 of :rfc:`4122`.
     You can use the :mod:`uuid` module to generate new UUIDs.
 
+Compatibility:
+    For Alarms, ``X-ALARMUID`` is also considered.
+
 Examples:
     The following is an example of such a property value:
     ``5FC53010-1267-4F8E-BC28-1D7AE55A7C99``.

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -605,7 +605,10 @@ Example:
 uid_property = single_string_property(
     "UID", """UID specifies the persistent, globally unique identifier for a component.
 
-We recommend using :py:`uuid.uuid4` to generate new values.
+We recommend using :func:`uuid.uuid4` to generate new values.
+
+Returns:
+    The value of the UID property as a string or ``""`` if no value is set.
 
 Description:
     The "UID" itself MUST be a globally unique identifier.
@@ -632,6 +635,12 @@ Description:
     least 255 octets for this property, but they MUST NOT truncate
     values in the middle of a UTF-8 multi-octet sequence.
 
+    :rfc:`7986` states that UID can be used, for
+    example, to identify duplicate calendar streams that a client may
+    have been given access to.  It can be used in conjunction with the
+    "LAST-MODIFIED" property also specified on the "VCALENDAR" object
+    to identify the most recent version of a calendar.
+
 Conformance:
     :rfc:`5545` states that the "UID" property can be specified on "VEVENT", "VTODO",
     and "VJOURNAL" calendar components.
@@ -641,19 +650,7 @@ Conformance:
     identifier to be specified. The value of this property can then be used
     to refer uniquely to the "VALARM" component.
 
-Purpose:
-    :rfc:`5545` states that this property specifies the persistent, globally unique
-    identifier for the iCalendar object.  This can be used, for
-    example, to identify duplicate calendar streams that a client may
-    have been given access to.  It can be used in conjunction with the
-    "LAST-MODIFIED" property also specified on the "VCALENDAR" object
-    to identify the most recent version of a calendar.
-
-    :rfc:`7986` states that UID can be used, for
-    example, to identify duplicate calendar streams that a client may
-    have been given access to.  It can be used in conjunction with the
-    "LAST-MODIFIED" property also specified on the "VCALENDAR" object
-    to identify the most recent version of a calendar.
+    This property can be specified once only.
 
 Security:
     :rfc:`7986` states that UID values MUST NOT include any data that
@@ -662,9 +659,7 @@ Security:
     agents now generate "UID" values that are hex-encoded random
     Universally Unique Identifier (UUID) values as defined in
     Sections 4.4 and 4.5 of :rfc:`4122`.
-
-Conformance:
-    This property can be specified once in an iCalendar object.
+    You can use the :mod:`uuid` module to generate new UUIDs.
 
 Examples:
     The following is an example of such a property value:

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -665,6 +665,18 @@ Examples:
     The following is an example of such a property value:
     ``5FC53010-1267-4F8E-BC28-1D7AE55A7C99``.
 
+    Set the UID of a calendar:
+
+    .. code-block:: pycon
+
+        >>> from icalendar import Calendar
+        >>> from uuid import uuid4
+        >>> calendar = Calendar()
+        >>> calendar.uid = uuid4()
+        >>> print(calendar.to_ical())
+        BEGIN:VCALENDAR
+        UID:d755cef5-2311-46ed-a0e1-6733c9e15c63
+        END:VCALENDAR
 
 """
 )

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -1863,7 +1863,11 @@ class Alarm(Component):
             start=tuple(start), end=tuple(end), absolute=tuple(absolute)
         )
 
-    uid = uid_property
+    uid = single_string_property(
+        "UID",
+        uid_property.__doc__,
+        "X-ALARMUID",
+    )
 
 
 class Calendar(Component):

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -25,6 +25,7 @@ from icalendar.attr import (
     single_int_property,
     single_string_property,
     single_utc_property,
+    uid_property,
 )
 from icalendar.caselessdict import CaselessDict
 from icalendar.error import IncompleteComponent, InvalidCalendar
@@ -906,6 +907,7 @@ class Event(Component):
     rdates = rdates_property
     exdates = exdates_property
     rrules = rrules_property
+    uid = uid_property
 
 
 class Todo(Component):
@@ -1101,6 +1103,7 @@ class Todo(Component):
     rdates = rdates_property
     exdates = exdates_property
     rrules = rrules_property
+    uid = uid_property
 
 
 class Journal(Component):
@@ -1192,6 +1195,7 @@ class Journal(Component):
     rdates = rdates_property
     exdates = exdates_property
     rrules = rrules_property
+    uid = uid_property
 
 
 class FreeBusy(Component):
@@ -1223,6 +1227,7 @@ class FreeBusy(Component):
         "FREEBUSY",
         "RSTATUS",
     )
+    uid = uid_property
 
 
 class Timezone(Component):
@@ -2165,19 +2170,21 @@ class Calendar(Component):
     "X-APPLE-CALENDAR-COLOR",
     )
     categories = categories_property
+    uid = uid_property
 
 # These are read only singleton, so one instance is enough for the module
 types_factory = TypesFactory()
 component_factory = ComponentFactory()
 
 __all__ = [
+    "INLINE",
     "Alarm",
     "Calendar",
     "Component",
     "ComponentFactory",
     "Event",
     "FreeBusy",
-    "INLINE",
+    "IncompleteComponent",
     "Journal",
     "Timezone",
     "TimezoneDaylight",
@@ -2185,5 +2192,4 @@ __all__ = [
     "Todo",
     "component_factory",
     "get_example",
-    "IncompleteComponent",
 ]

--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -1863,6 +1863,8 @@ class Alarm(Component):
             start=tuple(start), end=tuple(end), absolute=tuple(absolute)
         )
 
+    uid = uid_property
+
 
 class Calendar(Component):
     """

--- a/src/icalendar/tests/conftest.py
+++ b/src/icalendar/tests/conftest.py
@@ -16,6 +16,7 @@ except ImportError:
     pytz = None
 import itertools
 import sys
+import uuid
 from pathlib import Path
 
 from dateutil import tz
@@ -341,6 +342,8 @@ def env_for_doctest(monkeypatch):
     monkeypatch.setitem(sys.modules, "zoneinfo", zoneinfo)
     monkeypatch.setattr(zoneinfo, "ZoneInfo", DoctestZoneInfo)
     from icalendar.timezone.zoneinfo import ZONEINFO
+    uid = uuid.UUID("d755cef5-2311-46ed-a0e1-6733c9e15c63", version=4)
+    monkeypatch.setattr(uuid, "uuid4", lambda: uid)
 
     monkeypatch.setattr(ZONEINFO, "utc", zoneinfo.ZoneInfo("UTC"))
     return {"print": doctest_print}

--- a/src/icalendar/tests/test_issue_720_uid_property.py
+++ b/src/icalendar/tests/test_issue_720_uid_property.py
@@ -1,0 +1,12 @@
+"""This tests the UID property.
+
+See https://github.com/collective/icalendar/issues/740
+"""
+
+from icalendar import Alarm
+
+
+def test_alarm_uses_x_property_too():
+    alarm = Alarm()
+    alarm["X-ALARMUID"] = "1234"
+    assert alarm.uid == "1234"


### PR DESCRIPTION
This adds unified access to UID.
Fix #740 

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--835.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->