### PR TITLE
get tags and set version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,6 @@ build:
     python: "3.11"
   commands:
     - git fetch --tags
-    - git tag v7.0.0
     - pip install build
     - python -m build
     # Cancel building pull requests when there aren't changes in the docs directory or YAML file.

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,9 @@ build:
   tools:
     python: "3.11"
   commands:
+    - get fetch tags
+    - pip install build
+    - python -m build
     # Cancel building pull requests when there aren't changes in the docs directory or YAML file.
     # You can add any other files or directories that you'd like here as well,
     # like your docs requirements file, or other files that will change your docs build.

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,7 @@ build:
   tools:
     python: "3.11"
   commands:
-    - git fetch tags
+    - git fetch --tags
     - pip install build
     - python -m build
     # Cancel building pull requests when there aren't changes in the docs directory or YAML file.

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,7 @@ build:
   tools:
     python: "3.11"
   commands:
-    - get fetch tags
+    - git fetch tags
     - pip install build
     - python -m build
     # Cancel building pull requests when there aren't changes in the docs directory or YAML file.

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,7 @@ build:
     python: "3.11"
   commands:
     - git fetch --tags
+    - git tag v7.0.0
     - pip install build
     - python -m build
     # Cancel building pull requests when there aren't changes in the docs directory or YAML file.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ Bug fixes:
 
 - Test that we can add an RRULE as a string. See `Issue 301 <https://github.com/collective/icalendar/issues/301>`_.
 - Test that we support dateutil timezones as outlined in `Issue 336 <https://github.com/collective/icalendar/issues/336>`_.
-- Build documentation on readthedocs with the version identifier. See `Issue 826 <https://github.com/collective/icalendar/issues/826>`_.
+- Build documentation on Read the Docs with the version identifier. See `Issue 826 <https://github.com/collective/icalendar/issues/826>`_.
 
 
 6.2.0 (2025-05-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Bug fixes:
 
 - Test that we can add an RRULE as a string. See `Issue 301 <https://github.com/collective/icalendar/issues/301>`_.
 - Test that we support dateutil timezones as outlined in `Issue 336 <https://github.com/collective/icalendar/issues/336>`_.
+- Build documentation on readthedocs with the version identifier. See `Issue 826 <https://github.com/collective/icalendar/issues/826>`_.
 
 
 6.2.0 (2025-05-07)


### PR DESCRIPTION
By building the package and pulling the tags, we should be able to build the documentation so it shows the version of the package.

@stevepiercy What are your thoughts on the commands? Would it be better to put them into make?

Contributes to #826 