### PR TITLE
Make sure we do not loose information

### DIFF
--- a/src/icalendar/cal.py
+++ b/src/icalendar/cal.py
@@ -11,6 +11,14 @@ from collections import defaultdict
 from datetime import date, datetime, timedelta, tzinfo
 from typing import TYPE_CHECKING, List, NamedTuple, Optional, Tuple, Union
 
+try:
+    from typing import Self
+except ImportError:
+    try:
+        from typing_extensions import Self
+    except ImportError:
+        Self = "Self"
+
 import dateutil.rrule
 import dateutil.tz
 
@@ -357,7 +365,7 @@ class Component(CaselessDict):
         return properties
 
     @classmethod
-    def from_ical(cls, st, multiple=False):
+    def from_ical(cls, st, multiple=False) -> Self:
         """Populates the component recursively from a string."""
         stack = []  # a stack of components
         comps = []

--- a/src/icalendar/enums.py
+++ b/src/icalendar/enums.py
@@ -117,13 +117,51 @@ class ROLE(StrEnum):
     OPT_PARTICIPANT = "OPT-PARTICIPANT"
     NON_PARTICIPANT = "NON-PARTICIPANT"
 
+class VALUE(StrEnum):
+    """VALUE datatypes as defined in :rfc:`5545`.
+
+    Attributes: ``BOOLEAN``, ``CAL_ADDRESS``, ``DATE``, ``DATE_TIME``, ``DURATION``,
+    ``FLOAT``, ``INTEGER``, ``PERIOD``, ``RECUR``, ``TEXT``, ``TIME``, ``URI``,
+    ``UTC_OFFSET``
+
+    Description:
+        This parameter specifies the value type and format of
+        the property value.  The property values MUST be of a single value
+        type.  For example, a "RDATE" property cannot have a combination
+        of DATE-TIME and TIME value types.
+
+        If the property's value is the default value type, then this
+        parameter need not be specified.  However, if the property's
+        default value type is overridden by some other allowable value
+        type, then this parameter MUST be specified.
+
+        Applications MUST preserve the value data for x-name and iana-
+        token values that they don't recognize without attempting to
+        interpret or parse the value data.
+
+"""
+
+    BOOLEAN = "BOOLEAN"
+    CAL_ADDRESS = "CAL-ADDRESS"
+    DATE = "DATE"
+    DATE_TIME = "DATE-TIME"
+    DURATION = "DURATION"
+    FLOAT = "FLOAT"
+    INTEGER = "INTEGER"
+    PERIOD = "PERIOD"
+    RECUR = "RECUR"
+    TEXT = "TEXT"
+    TIME = "TIME"
+    URI = "URI"
+    UTC_OFFSET = "UTC-OFFSET"
 
 __all__ = [
-    "PARTSTAT",
-    "FBTYPE",
     "CUTYPE",
+    "FBTYPE",
+    "PARTSTAT",
     "RANGE",
     "RELATED",
-    "ROLE",
     "RELTYPE",
+    "ROLE",
+    "VALUE",
 ]

--- a/src/icalendar/parser.py
+++ b/src/icalendar/parser.py
@@ -7,8 +7,11 @@ conversion is attempted.
 """
 from __future__ import annotations
 
+import functools
 import os
+from typing import Optional
 from icalendar.caselessdict import CaselessDict
+from icalendar.enums import VALUE
 from icalendar.parser_tools import DEFAULT_ENCODING, ICAL_TYPE
 from icalendar.parser_tools import SEQUENCE_TYPES
 from icalendar.parser_tools import to_unicode
@@ -171,6 +174,29 @@ def q_join(lst, sep=",", always_quote=False):
     return sep.join(dquote(itm, always_quote=always_quote) for itm in lst)
 
 
+def single_string_parameter(func):
+    """Create a parameter getter/setter for a single string parameter."""
+
+    name = func.__name__
+
+    @functools.wraps(func)
+    def fget(self: Parameters):
+        """Get the value."""
+        return self.get(name)
+
+    def fset(self: Parameters, value: str|None):
+        """Set the value"""
+        if value is None:
+            fdel(self)
+        else:
+            self[name] = value
+
+    def fdel(self: Parameters):
+        """Delete the value."""
+        self.pop(name, None)
+
+    return property(fget, fset, fdel, doc=func.__doc__)
+
 class Parameters(CaselessDict):
     """Parser and generator of Property parameter strings. It knows nothing of
     datatypes. Its main concern is textual structure.
@@ -275,6 +301,26 @@ class Parameters(CaselessDict):
             except ValueError as exc:
                 raise ValueError(f"{param!r} is not a valid parameter string: {exc}")
         return result
+
+    @single_string_parameter
+    def value(self) -> VALUE | str | None:
+        """The VALUE parameter from :rfc:`5545`.
+
+        Description:
+            This parameter specifies the value type and format of
+            the property value.  The property values MUST be of a single value
+            type.  For example, a "RDATE" property cannot have a combination
+            of DATE-TIME and TIME value types.
+
+            If the property's value is the default value type, then this
+            parameter need not be specified.  However, if the property's
+            default value type is overridden by some other allowable value
+            type, then this parameter MUST be specified.
+
+            Applications MUST preserve the value data for x-name and iana-
+            token values that they don't recognize without attempting to
+            interpret or parse the value data.
+        """
 
 
 def escape_string(val):

--- a/src/icalendar/prop.py
+++ b/src/icalendar/prop.py
@@ -51,7 +51,7 @@ from datetime import date, datetime, time, timedelta
 from typing import Union
 
 from icalendar.caselessdict import CaselessDict
-from icalendar.enums import Enum
+from icalendar.enums import VALUE, Enum
 from icalendar.parser import Parameters, escape_char, unescape_char
 from icalendar.parser_tools import (
     DEFAULT_ENCODING,
@@ -60,6 +60,7 @@ from icalendar.parser_tools import (
     from_unicode,
     to_unicode,
 )
+from icalendar.tools import to_datetime
 
 from .timezone import tzid_from_dt, tzid_from_tzinfo, tzp
 
@@ -571,12 +572,15 @@ class vDDDTypes(TimeBase):
 
         if len(ical) in (15, 16):
             return vDatetime.from_ical(ical, timezone=timezone)
-        elif len(ical) == 8:
+        if len(ical) == 8:
+            if timezone:
+                tzinfo = tzp.timezone(timezone)
+                if tzinfo is not None:
+                    return to_datetime(vDate.from_ical(ical)).replace(tzinfo=tzinfo)
             return vDate.from_ical(ical)
-        elif len(ical) in (6, 7):
+        if len(ical) in (6, 7):
             return vTime.from_ical(ical)
-        else:
-            raise ValueError(f"Expected datetime, date, or time, got: '{ical}'")
+        raise ValueError(f"Expected datetime, date, or time, got: '{ical}'")
 
 
 class vDate(TimeBase):

--- a/src/icalendar/tests/test_issue_187_type_and_value_do_not_match.py
+++ b/src/icalendar/tests/test_issue_187_type_and_value_do_not_match.py
@@ -1,0 +1,46 @@
+"""We can get time information that is actually of the WRONG value.
+
+We can still parse it and correct the value parameter.
+"""
+from datetime import date, datetime
+
+import pytest
+
+from icalendar import Event
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo
+
+
+@pytest.mark.parametrize(
+    ("string", "expected_params", "expected_property_value"),
+    [
+        (":20150217", {}, date(2015, 2, 17)),
+        (";VALUE=DATETIME:20150217", {"VALUE": "DATETIME"}, date(2015, 2, 17)),
+        (";VALUE=DATE:20150217T095800", {"VALUE": "DATE"}, datetime(2015, 2, 17, 9, 58, 0)),
+        (";VALUE=DATE:20150217T095800Z", {"VALUE": "DATE"}, datetime(2015, 2, 17, 9, 58, 0, tzinfo=ZoneInfo("UTC"))),
+        (";TZID=Europe/Berlin:20150217", { "TZID": "Europe/Berlin"}, datetime(2015, 2, 17, tzinfo=ZoneInfo("Europe/Berlin"))),
+        (";TZID=Europe/Berlin:20150217T095800Z", {"TZID": "Europe/Berlin"}, datetime(2015, 2, 17, 9, 58, 0, tzinfo=ZoneInfo("Europe/Berlin"))),
+    ]
+)
+def test_wrong_dates_are_converted(string, expected_params, expected_property_value):
+    """We convert these dates to the correct value if they turn up.
+
+    We want to make sure that these are working, have values and do not throw exceptions.
+    Information should not get lost except if it is contradictory.
+    So, the tests can be changed if a different resolution is needed.
+
+    The problem: The VALUE parameter might not correspond to the actual value.
+    However, we correctly parse the value and do not loose information.
+    """
+    event = Event.from_ical(f"""
+BEGIN:VEVENT
+DTSTART{string}
+END:VEVENT
+""")
+    dt = event.get("dtstart")
+    test = f"{dt} should be {expected_property_value} with {expected_params}"
+    assert dt.params == expected_params, test
+    assert dt.dt == expected_property_value, test

--- a/src/icalendar/tests/test_parameter_access.py
+++ b/src/icalendar/tests/test_parameter_access.py
@@ -1,0 +1,47 @@
+"""Test the access to parameters via getter/setter properties."""
+
+import pytest
+from icalendar import Parameters
+from icalendar.enums import VALUE
+
+
+@pytest.fixture()
+def p():
+    """Empty test property."""
+    return Parameters()
+
+def test_value_parameter_default(p):
+    """Test default value."""
+    assert p.value is None
+
+def test_set_value(p):
+    """Set the value."""
+    p.value = "test"
+    assert p.value == "test"
+    assert p["VALUE"] == "test"
+
+def test_conversion(p):
+    """Converted to enum."""
+    p.value = "DATE-TIME"
+    assert p.value == VALUE.DATE_TIME
+
+
+def test_delete_value(p):
+    """Delete the value."""
+    p.value = "test"
+    del p.value
+    assert p.value is None
+    assert "VALUE" not in p
+    del p.value
+    assert p.value is None
+    assert "VALUE" not in p
+
+def test_delete_value_None(p):
+    """Delete the value."""
+    p.value = "test"
+    p.value = None
+    assert p.value is None
+    assert "VALUE" not in p
+    p.value = None
+    assert p.value is None
+    assert "VALUE" not in p


### PR DESCRIPTION
Make sure we do not loose information because the VALUE parameter has a wrong type for datetime values

This attempts to fix #187.

Also:

- add proper type to from_ical
- add VALUE enum
- add value getter for Parameters
- convert date to tzinfo if we would loose the TZID information in the value

To merge after #845 