### PR TITLE
Exclude type checking block from test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+# Exclude type checking block
+# See https://github.com/nedbat/coveragepy/issues/831#issuecomment-517778185
+[report]
+exclude_lines = 
+    pragma: no cover
+    if TYPE_CHECKING:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ venv
 /src/icalendar/_version.py
 
 coverage.xml
+!.coveragerc

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ We use `Semantic Versioning <https://semver.org>`_.
 
 Minor changes:
 
-- Exclude type checking block from test coverage. 
+- Exclude type checking block from test coverage.
 
 Breaking changes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ We use `Semantic Versioning <https://semver.org>`_.
 
 Minor changes:
 
-- ...
+- Exclude type checking block from test coverage. 
 
 Breaking changes:
 


### PR DESCRIPTION
This excludes the type checking block from the test coverage report.

This is not covered any way because it is never run.

![grafik](https://github.com/user-attachments/assets/7574127c-52d5-4eef-9b36-ccc66e16b5ed)

Before:

```
Name                                                                                             Stmts   Miss Branch BrPart  Cover
src/icalendar/alarms.py                                                                            129      4     44      3    96%
```

after:

```
Name                                                                                             Stmts   Miss Branch BrPart  Cover
src/icalendar/alarms.py                                                                            126      2     42      2    98%
```

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--858.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->