### PR TITLE
link to vobject

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,6 +180,7 @@ Related projects
 * `x-wr-timezone <https://pypi.org/project/x-wr-timezone/>`_. Library and command line tool to make ``icalendar.Calendar`` objects and files from Google Calendar (using the non-standard ``X-WR-TIMEZONE`` property) compliant with the standard (:rfc:`5545`).
 * `ics-query <http://pypi.org/project/ics-query>`_. Command line tool to query iCalendar files for occurrences of events and other components.
 * `icalendar-compatibility <https://icalendar-compatibility.readthedocs.io/en/latest/>`_ - access to event data compatible with RFC5545 and different implementations
+* `caldav <https://caldav.readthedocs.io/>`_ is based on ``icalendar``.
 
 Further Reading
 ===============

--- a/README.rst
+++ b/README.rst
@@ -174,6 +174,7 @@ We expect the ``main`` branch with versions ``6+`` to receive the latest updates
 Related projects
 ================
 
+* `vobject <https://github.com/py-vobject/vobject>`_ is a different Python library for iCalendar.
 * `icalevents <https://github.com/irgangla/icalevents>`_. It is built on top of icalendar and allows you to query iCal files and get the events happening on specific dates. It manages recurrent events as well.
 * `recurring-ical-events <https://pypi.org/project/recurring-ical-events/>`_. Library to query an ``icalendar.Calendar`` object for events and other components happening at a certain date or within a certain time.
 * `x-wr-timezone <https://pypi.org/project/x-wr-timezone/>`_. Library and command line tool to make ``icalendar.Calendar`` objects and files from Google Calendar (using the non-standard ``X-WR-TIMEZONE`` property) compliant with the standard (:rfc:`5545`).


### PR DESCRIPTION
This creates a link in related projects to another project that does roughly the same.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--862.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->