### PR TITLE
Add example() to Available and Availability

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ New features:
 - Add ``new()`` to ``icalendar.Calendar`` to set required attributes. See `Issue 569 <https://github.com/collective/icalendar/issues/569>`_.
 - Add ``new()`` to ``Alarm``, ``Event``, ``Todo``, ``FreeBusy``, ``Component``, and ``Journal`` components. See `Issue 843 <https://github.com/collective/icalendar/issues/843>`_.
 - Add ``value`` to ``Parameters`` to access the ``VALUE`` parameter.
-- Add ``Availability`` and ``Available`` components from :rfc:`7953`. See `Issue 654 <https://github.com/collective/icalendar/issues/654>`_.
+- Add ``Availability`` and ``Available`` components from :rfc:`7953`. See `Issue 654 <https://github.com/collective/icalendar/issues/654>`_ and `Issue 864 <https://github.com/collective/icalendar/issues/864>`_.
 - Add ``stamp``, ``last_modified``, ``created``, ``CREATED``, ``busy_type``, ``class``, ``comments``, ``contacts``, ``location``, ``organizer``, ``priority``, and ``url`` properties to components that use them.
 - Add ``availabilities`` attribtue to ``Calendar``.
 - Add ``status``, ``transparency``, and ``attendees`` properties. See `Issue 841 <https://github.com/collective/icalendar/issues/841>`_.

--- a/src/icalendar/cal/availability.py
+++ b/src/icalendar/cal/availability.py
@@ -27,6 +27,7 @@ from icalendar.attr import (
     summary_property,
     url_property,
 )
+from icalendar.cal.examples import get_example
 from icalendar.error import InvalidCalendar
 
 from .component import Component
@@ -110,6 +111,15 @@ class Availability(Component):
             RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR
             END:AVAILABLE
             END:VAVAILABILITY
+
+        You can get the same example from :meth:`example`:
+
+        .. code-block: pycon
+
+            >>> from icalendar import Availability
+            >>> a = Availability.example()
+            >>> a.organizer
+            vCalAddress('mailto:bernard@example.com')
 
         The following is an example of a "VAVAILABILITY" calendar
         component used to represent the availability of a user available
@@ -312,6 +322,11 @@ class Availability(Component):
         availability.start = start
         availability.end = end
         return availability
+
+    @classmethod
+    def example(cls, name: str = "rfc_7953_1") -> Availability:
+        """Return the calendar example with the given name."""
+        return cls.from_ical(get_example("availabilities", name))
 
 
 __all__ = ["Availability"]

--- a/src/icalendar/cal/available.py
+++ b/src/icalendar/cal/available.py
@@ -26,6 +26,7 @@ from icalendar.attr import (
     summary_property,
     uid_property,
 )
+from icalendar.cal.examples import get_example
 from icalendar.error import InvalidCalendar
 
 from .component import Component
@@ -58,6 +59,16 @@ class Available(Component):
             RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR
             LOCATION:Denver
             END:AVAILABLE
+
+        You can get the same example from :meth:`example`:
+
+        .. code-block: pycon
+
+            >>> from icalendar import Available
+            >>> a = Available.example()
+            >>> str(a.summary)
+            'Monday to Friday from 9:00 to 17:00'
+
     """
 
     name = "VAVAILABLE"
@@ -153,6 +164,11 @@ class Available(Component):
         available.start = start
         available.end = end
         return available
+
+    @classmethod
+    def example(cls, name: str = "rfc_7953_1") -> Available:
+        """Return the calendar example with the given name."""
+        return cls.from_ical(get_example("availabilities", name)).available[0]
 
 
 __all__ = ["Available"]

--- a/src/icalendar/tests/test_examples.py
+++ b/src/icalendar/tests/test_examples.py
@@ -4,9 +4,7 @@ import datetime
 
 import pytest
 
-from icalendar.cal.calendar import Calendar
-from icalendar.cal.event import Event
-from icalendar.cal.timezone import Timezone
+from icalendar import Availability, Available, Calendar, Event, Timezone
 
 
 def test_creating_calendar_with_unicode_fields(calendars, utc):
@@ -67,7 +65,9 @@ def test_invalid_examples_lists_the_others():
     assert "example.ics" in str(e.value)
 
 
-@pytest.mark.parametrize("component", [Calendar, Event, Timezone])
+@pytest.mark.parametrize(
+    "component", [Calendar, Event, Timezone, Available, Availability]
+)
 def test_default_example(component):
     """Check that we have a default example."""
     example = component.example()

--- a/src/icalendar/tests/test_issue_864_examples.py
+++ b/src/icalendar/tests/test_issue_864_examples.py
@@ -1,0 +1,13 @@
+"""Test that we have good examples."""
+
+from icalendar import Event
+
+SUMMARY = "This is a unicode summary. Das müssen wir dekodieren. Русский. ↧"
+
+
+def test_summary_is_text():
+    """The summary should be a text."""
+    event = Event.new(summary=SUMMARY)
+    assert event.summary == SUMMARY
+    event = Event.from_ical(event.to_ical())
+    assert event.summary == SUMMARY

--- a/src/icalendar/tests/test_issue_864_examples.py
+++ b/src/icalendar/tests/test_issue_864_examples.py
@@ -2,7 +2,7 @@
 
 from icalendar import Event
 
-SUMMARY = "This is a unicode summary. Das müssen wir dekodieren. Русский. ↧"
+SUMMARY = "This is a Unicode summary. Das müssen wir dekodieren. Русский. ↧"
 
 
 def test_summary_is_text():


### PR DESCRIPTION
This fixes #864.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--875.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->