### PR TITLE
Make coveralls optional

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,7 @@ jobs:
         parallel: true
         file: coverage.xml
         allow-empty: true
+        fail-on-error: false
 
   coverage:
     # parallel test coverage upload


### PR DESCRIPTION
Coverage reports are nice to have. At the moment, they fail at times.

This allows the the submission of the reports to fail and the CI still is green.

```
HTTP error:
---
Error: Service Unavailable (503)
Message: <h2>This website is under heavy load (queue full)</h2><p>We're sorry, too many people are accessing this website at the same time. We're working on this problem. Please try again later.</p>
---
```