### PR TITLE
Fix issue #821 to read file from stdin & removed pathlib

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,7 @@ New features:
 
 Bug fixes:
 
+- Fix read from stdin issue - See `Issue 821 <https://github.com/collective/icalendar/issues/821>`_.
 - Fix invalid calendar: Parsing a date with TZID results in a datetime to not loose the timezone. See `Issue 187 <https://github.com/collective/icalendar/issues/187>`_.
 - Fix timezone placement in ``add_missing_timezones()``: ``VTIMEZONE`` components now appear before ``VEVENT`` and other components that reference them. See `Issue 844 <https://github.com/collective/icalendar/issues/844>`_.
 - Fixed ``Todo.duration`` and ``Event.duration`` to return ``DURATION`` property when set, even without ``DTSTART``. See `Issue 867 <https://github.com/collective/icalendar/issues/867>`_.

--- a/src/icalendar/cli.py
+++ b/src/icalendar/cli.py
@@ -2,7 +2,6 @@
 """utility program that allows user to preview calendar's events"""
 
 import argparse
-import pathlib
 import sys
 from datetime import datetime
 
@@ -77,7 +76,11 @@ def view(event):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("calendar_files", nargs="+", type=pathlib.Path)
+    parser.add_argument(
+        "calendar_files", nargs="+", 
+        type=argparse.FileType("r", encoding="utf-8-sig"),
+        help="one or more .ics files (use '-' for stdin)"
+    )
     parser.add_argument(
         "--output",
         "-o",
@@ -93,11 +96,10 @@ def main():
     )
     argv = parser.parse_args()
 
-    for calendar_file in argv.calendar_files:
-        with open(calendar_file, encoding="utf-8-sig") as f:
-            calendar = Calendar.from_ical(f.read())
-            for event in calendar.walk("vevent"):
-                argv.output.write(view(event) + "\n\n")
+    for f in argv.calendar_files:
+        calendar = Calendar.from_ical(f.read())
+        for event in calendar.walk("vevent"):
+            argv.output.write(view(event) + "\n\n")
 
 
 __all__ = ["main", "view"]

--- a/src/icalendar/tests/test_issue_821_stdin_parse.py
+++ b/src/icalendar/tests/test_issue_821_stdin_parse.py
@@ -1,0 +1,159 @@
+# tests/test_cli_stdin_argparse.py
+import io
+import os
+import sys
+import unittest
+import tempfile
+import contextlib
+from datetime import datetime
+from unittest import mock
+
+from icalendar import Calendar, cli
+from icalendar.compatibility import ZoneInfo
+
+
+INPUT = """
+BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+SUMMARY:Test Summary
+ORGANIZER:organizer@test.test
+ATTENDEE:attendee1@example.com
+ATTENDEE:attendee2@test.test
+COMMENT:Comment
+DTSTART;TZID=Europe/Warsaw:20220820T103400
+DTEND;TZID=Europe/Warsaw:20220820T113400
+LOCATION:New Amsterdam, 1000 Sunrise Test Street
+DESCRIPTION: Test Description
+END:VEVENT
+BEGIN:VEVENT
+ORGANIZER:organizer@test.test
+ATTENDEE:attendee1@example.com
+SUMMARY:Test summary
+DTSTART;TZID=Europe/Warsaw:20220820T200000
+DTEND;TZID=Europe/Warsaw:20220820T203000
+LOCATION:New Amsterdam, 1010 Test Street
+DESCRIPTION:Test Description\\nThis one is multiline
+END:VEVENT
+BEGIN:VEVENT
+UID:1
+SUMMARY:TEST
+DTSTART:20220511
+DURATION:P5D
+END:VEVENT
+END:VCALENDAR
+""".lstrip()
+
+
+def _local_datetime(dt: str) -> str:
+    """
+    Match the CLI's behavior: display datetimes in the *local* timezone.
+    The source times are Europe/Warsaw; convert to local tz for comparison.
+    """
+    return (
+        datetime.strptime(dt, "%Y%m%dT%H%M%S")
+        .replace(tzinfo=ZoneInfo("Europe/Warsaw"))
+        .astimezone()
+        .strftime("%c")
+    )
+
+
+# datetimes are displayed in the local timezone, so build expected strings at runtime
+_firststart = _local_datetime("20220820T103400")
+_firstend = _local_datetime("20220820T113400")
+_secondstart = _local_datetime("20220820T200000")
+_secondend = _local_datetime("20220820T203000")
+
+PROPER_OUTPUT = f"""    Organizer: organizer <organizer@test.test>
+    Attendees:
+     attendee1 <attendee1@example.com>
+     attendee2 <attendee2@test.test>
+    Summary    : Test Summary
+    Starts     : {_firststart}
+    End        : {_firstend}
+    Duration   : 1:00:00
+    Location   : New Amsterdam, 1000 Sunrise Test Street
+    Comment    : Comment
+    Description:
+      Test Description
+
+    Organizer: organizer <organizer@test.test>
+    Attendees:
+     attendee1 <attendee1@example.com>
+    Summary    : Test summary
+    Starts     : {_secondstart}
+    End        : {_secondend}
+    Duration   : 0:30:00
+    Location   : New Amsterdam, 1010 Test Street
+    Comment    : 
+    Description:
+     Test Description
+     This one is multiline
+
+    Organizer: 
+    Attendees:
+
+    Summary    : TEST
+    Starts     : Wed May 11 00:00:00 2022
+    End        : Mon May 16 00:00:00 2022
+    Duration   : 5 days, 0:00:00
+    Location   : 
+    Comment    : 
+    Description:
+     
+
+""".replace("\r\n", "\n")  # normalize newlines just in case
+
+
+class TestIcalendarCLIArgparseStdin(unittest.TestCase):
+    def test_cli_with_stdin_dash(self):
+        """
+        Validate that `type=argparse.FileType("r", ...)` maps '-' to sys.stdin
+        and the CLI prints the expected, fully formatted output.
+        """
+        # Provide INPUT via stdin
+        fake_stdin = io.StringIO(INPUT)
+        captured = io.StringIO()
+
+        with mock.patch.object(sys, "stdin", fake_stdin), \
+             mock.patch.object(sys, "argv", ["icalendar", "-"]), \
+             contextlib.redirect_stdout(captured):
+            cli.main()
+
+        self.assertEqual(captured.getvalue(), PROPER_OUTPUT)
+
+    def test_cli_with_file_path(self):
+        """
+        Validate that passing a real file path also yields the same output.
+        """
+        with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as tf:
+            tf.write(INPUT)
+            tmpname = tf.name
+
+        try:
+            captured = io.StringIO()
+            with mock.patch.object(sys, "argv", ["icalendar", tmpname]), \
+                 contextlib.redirect_stdout(captured):
+                cli.main()
+            self.assertEqual(captured.getvalue(), PROPER_OUTPUT)
+        finally:
+            os.unlink(tmpname)
+
+    def test_view_direct_matches_cli(self):
+        """
+        Optional: sanity check that the lower-level view(event) path
+        still matches what the CLI emits, to guard against formatting drift.
+        """
+        cal = Calendar.from_ical(INPUT)
+        manual = []
+        for evt in cal.walk("vevent"):
+            manual.append(cli.view(evt))
+            manual.append("")  # the CLI prints a blank line after each event
+        manual_output = "\n".join(manual) + "\n"  # trailing newline
+
+        self.assertEqual(manual_output, PROPER_OUTPUT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Closes issue

Replace `ISSUE_NUMBER` with the issue number that your pull request fixes. Then GitHub will link and automatically close the related issue.

- [ ] Closes #821 

## Description

Removed the usage of Pathlib which might not be great but the code fix now works 

## Checklist

- [DONE ] I've added a change log entry to `CHANGES.rst`.
- [ DONE] I've added or updated tests if applicable.
- [ DONE] I've run and ensured all tests pass locally by following [Running Tests](https://icalendar.readthedocs.io/en/latest/install.html#running-tests).
- [ NOT REQ'D ] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.
- [ NOT REQ'D ] I've added myself to `docs/credits.rst` as a contributor in this pull request or have done so previously.

## Additional information

(.venv) srikarkc@Srikars-MacBook-Air icalendar % pytest -v | grep 821
src/icalendar/tests/test_issue_821_stdin_parse.py::TestIcalendarCLIArgparseStdin::test_cli_with_file_path PASSED [ 43%]
src/icalendar/tests/test_issue_821_stdin_parse.py::TestIcalendarCLIArgparseStdin::test_cli_with_stdin_dash PASSED [ 43%]
src/icalendar/tests/test_issue_821_stdin_parse.py::TestIcalendarCLIArgparseStdin::test_view_direct_matches_cli PASSED [ 43%]
src/icalendar/tests/test_with_doctest.py::test_docstring_of_python_file[icalendar.tests.test_issue_821_stdin_parse] PASSED [ 98%]



<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--912.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->