### PR TITLE
Add comprehensive tests for Conference parameter normalization edge cases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Minor changes:
 - Fix duplicate blank issue template by adding config.yml to disable GitHub's default blank option. See `Issue 777 <https://github.com/collective/icalendar/issues/777>`_.
 - Add PEP 561 py.typed marker to enable type checking support. The package now distributes inline type annotations for mypy and other type checkers. See `Issue 395 <https://github.com/collective/icalendar/issues/395>`_.
 - Bump ``github/codeql-action`` from 3 to 4 in CI fuzzing workflow.
+- Add comprehensive tests for Conference parameter normalization edge cases to prevent regressions. Tests cover string passthrough, empty list filtering, None values, and falsy values for feature, label, and language parameters. See `Issue 908 <https://github.com/collective/icalendar/issues/908>`_.
 
 Breaking changes:
 

--- a/src/icalendar/tests/test_conference.py
+++ b/src/icalendar/tests/test_conference.py
@@ -151,3 +151,123 @@ def test_conference_from_string():
     assert conference.feature is None
     assert conference.label is None
     assert conference.language is None
+
+
+def test_conference_string_passthrough():
+    """Test that string parameters are kept as strings, not converted to lists."""
+    # Test feature parameter
+    conference = Conference(uri="https://example.com", feature="AUDIO")
+    assert conference.feature == "AUDIO"
+    assert isinstance(conference.feature, str)
+    
+    # Test label parameter
+    conference = Conference(uri="https://example.com", label="Test Label")
+    assert conference.label == "Test Label"
+    assert isinstance(conference.label, str)
+    
+    # Test language parameter
+    conference = Conference(uri="https://example.com", language="EN")
+    assert conference.language == "EN"
+    assert isinstance(conference.language, str)
+
+
+def test_conference_empty_list_filtering():
+    """Test that empty lists are filtered out and don't produce empty parameters."""
+    # Test feature parameter with empty list
+    conference = Conference(uri="https://example.com", feature=[])
+    assert conference.feature == []
+    uri = conference.to_uri()
+    assert "FEATURE" not in uri.params
+    
+    # Test label parameter with empty list
+    conference = Conference(uri="https://example.com", label=[])
+    assert conference.label == []
+    uri = conference.to_uri()
+    assert "LABEL" not in uri.params
+    
+    # Test language parameter with empty list
+    conference = Conference(uri="https://example.com", language=[])
+    assert conference.language == []
+    uri = conference.to_uri()
+    assert "LANGUAGE" not in uri.params
+
+
+def test_conference_none_values():
+    """Test that None values don't add parameters to the URI."""
+    # Test with only URI, no other parameters
+    conference = Conference(uri="https://example.com")
+    assert conference.feature is None
+    assert conference.label is None
+    assert conference.language is None
+    
+    uri = conference.to_uri()
+    assert "FEATURE" not in uri.params
+    assert "LABEL" not in uri.params
+    assert "LANGUAGE" not in uri.params
+    
+    # Test with explicit None values
+    conference = Conference(uri="https://example.com", feature=None, label=None, language=None)
+    uri = conference.to_uri()
+    assert "FEATURE" not in uri.params
+    assert "LABEL" not in uri.params
+    assert "LANGUAGE" not in uri.params
+
+
+def test_conference_list_params_serialization():
+    """Test serialization of list parameters."""
+    # Test feature parameter with list
+    conference = Conference(uri="https://example.com", feature=["AUDIO", "VIDEO"])
+    assert conference.feature == ["AUDIO", "VIDEO"]
+    uri = conference.to_uri()
+    assert "FEATURE" in uri.params
+    assert uri.params["FEATURE"] == ["AUDIO", "VIDEO"]
+    
+    # Test label parameter with list
+    conference = Conference(uri="https://example.com", label=["Label1", "Label2"])
+    assert conference.label == ["Label1", "Label2"]
+    uri = conference.to_uri()
+    assert "LABEL" in uri.params
+    assert uri.params["LABEL"] == ["Label1", "Label2"]
+    
+    # Test language parameter with list
+    conference = Conference(uri="https://example.com", language=["EN", "DE"])
+    assert conference.language == ["EN", "DE"]
+    uri = conference.to_uri()
+    assert "LANGUAGE" in uri.params
+    assert uri.params["LANGUAGE"] == ["EN", "DE"]
+
+
+def test_conference_mixed_parameter_types():
+    """Test Conference with mixed parameter types (some strings, some lists, some None)."""
+    conference = Conference(
+        uri="https://example.com",
+        feature="AUDIO",  # string
+        label=["Label1", "Label2"],  # list
+        language=None  # None
+    )
+    
+    uri = conference.to_uri()
+    assert "FEATURE" in uri.params
+    assert "LABEL" in uri.params
+    assert "LANGUAGE" not in uri.params
+    
+    assert uri.params["FEATURE"] == "AUDIO"
+    assert uri.params["LABEL"] == ["Label1", "Label2"]
+
+
+def test_conference_falsy_values_filtering():
+    """Test that falsy values (empty string, 0, False) are filtered out."""
+    # Test empty string
+    conference = Conference(uri="https://example.com", feature="")
+    uri = conference.to_uri()
+    assert "FEATURE" not in uri.params
+    
+    # Test zero
+    conference = Conference(uri="https://example.com", feature=0)
+    uri = conference.to_uri()
+    assert "FEATURE" not in uri.params
+    
+    # Test False
+    conference = Conference(uri="https://example.com", feature=False)
+    uri = conference.to_uri()
+    assert "FEATURE" not in uri.params


### PR DESCRIPTION
## Description

This PR adds comprehensive tests for Conference parameter normalization edge cases to prevent regressions. The tests cover the scenarios mentioned in issue #925:

1. **String passthrough**: `Conference(uri="https://example.com", feature="AUDIO")` - keeps as string, not convert to list
2. **Empty list filtering**: `Conference(uri="https://example.com", feature=[])` - filters out, not produce `FEATURE: ''`
3. **None values**: `Conference(uri="https://example.com")` - should not add FEATURE to params at all

The tests cover all three parameters (`feature`, `label`, `language`) since they all use the same normalize() function.

## Checklist

- [x] I've added a change log entry to `CHANGES.rst`.
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Running Tests](https://icalendar.readthedocs.io/en/latest/install.html#running-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.
- [ ] I've added myself to `docs/credits.rst` as a contributor in this pull request or have done so previously.

## Additional information

This addresses the edge cases mentioned in issue 925 and ensures that future refactoring won't break the Conference parameter normalization behavior. All 24 tests in the conference module pass, including the 6 new edge case tests.

### Tests Added:
- `test_conference_string_passthrough()` - Tests string parameters remain as strings
- `test_conference_empty_list_filtering()` - Tests empty lists are filtered out  
- `test_conference_none_values()` - Tests None values don't add parameters
- `test_conference_list_params_serialization()` - Tests list parameter serialization
- `test_conference_mixed_parameter_types()` - Tests mixed parameter types
- `test_conference_falsy_values_filtering()` - Tests falsy values are filtered out

### Test Coverage:
The tests comprehensively verify that:
- String parameters remain as strings (not converted to lists)
- Empty lists are filtered out (don't appear in URI params)
- None values don't add parameters to the URI
- List parameters are properly serialized
- Mixed parameter types work correctly
- Falsy values are filtered out

This will help prevent regressions if someone refactors the Conference class parameter handling logic in the future.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--926.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->