### PR TITLE
Add type hints in icalendar/tools.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,7 @@ Minor changes:
 - Update LICENSE file heading formatting.
 - Document ``icalendar.version`` module.
 - Use ``CONTRIBUTING.md`` in favour of ``.rst`` file.
+- Add type hints to ``icalendar.tools`` module.
 
 Breaking changes:
 

--- a/docs/contribute/credits.rst
+++ b/docs/contribute/credits.rst
@@ -61,6 +61,7 @@ Contributors
 - Jochen Sprickerhof <icalendar@jochen.sprickerhof.de>
 - Johannes Raggam <johannes@raggam.co.at>
 - Jordan Kiang <jordan@cozi.com>
+- `Jouni K. Seppänen <https://github.com/jkseppan>`_
 - Kamil Mańkowski <kam193@wp.pl>
 - Klaus Klein <kleink+github@kleink.org>
 - Laurent Lasudry <lasudry@gmail.com>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,9 @@ dependencies = [
     "backports.zoneinfo; python_version < '3.9'",
     # tzdata: IANA timezone database fallback for zoneinfo (required on Windows,
     # provides current timezone data on all platforms)
-    "tzdata"
+    "tzdata",
+    # typing.TypeIs was added in Python 3.13
+    "typing-extensions~=4.10; python_version < '3.13'",
 ]
 
 [project.optional-dependencies]

--- a/src/icalendar/tools.py
+++ b/src/icalendar/tools.py
@@ -3,43 +3,49 @@
 from __future__ import annotations
 
 from datetime import date, datetime, tzinfo
+from typing import Union, cast
+
+try:
+    from typing import TypeIs
+except ImportError:
+    from typing_extensions import TypeIs
 
 
-def is_date(dt: date) -> bool:
+def is_date(dt: Union[date, datetime]) -> bool:
     """Whether this is a date and not a datetime."""
     return isinstance(dt, date) and not isinstance(dt, datetime)
 
 
-def is_datetime(dt: date) -> bool:
-    """Whether this is a date and not a datetime."""
+def is_datetime(dt: Union[date, datetime]) -> TypeIs[datetime]:
+    """Whether this is a datetime and not just a date."""
     return isinstance(dt, datetime)
 
 
-def to_datetime(dt: date) -> datetime:
+def to_datetime(dt: Union[date, datetime]) -> datetime:
     """Make sure we have a datetime, not a date."""
     if is_date(dt):
         return datetime(dt.year, dt.month, dt.day)  # noqa: DTZ001
-    return dt
+    return cast("datetime", dt)
 
 
-def is_pytz(tz: tzinfo):
+def is_pytz(tz: tzinfo) -> bool:
     """Whether the timezone requires localize() and normalize()."""
     return hasattr(tz, "localize")
 
 
-def is_pytz_dt(dt: date):
+def is_pytz_dt(dt: Union[date, datetime]) -> TypeIs[datetime]:
     """Whether the time requires localize() and normalize()."""
-    return is_datetime(dt) and is_pytz(dt.tzinfo)
+    return is_datetime(dt) and (tzinfo := dt.tzinfo) is not None and is_pytz(tzinfo)
 
 
-def normalize_pytz(dt: date):
+def normalize_pytz(dt: Union[date, datetime]) -> Union[date, datetime]:
     """We have to normalize the time after a calculation if we use pytz.
 
     pytz requires this function to be used in order to correctly calculate the
     timezone's offset after calculations.
     """
     if is_pytz_dt(dt):
-        return dt.tzinfo.normalize(dt)
+        return dt.tzinfo.normalize(dt)  # type: ignore[attr-defined]
     return dt
 
 

--- a/styles/config/vocabularies/icalendar/accept.txt
+++ b/styles/config/vocabularies/icalendar/accept.txt
@@ -31,6 +31,7 @@ iCal
 (?i)Jannis
 (?i)Jeroen
 (?i)Jochen
+Jouni
 (?i)Kamil
 (?i)Kolab
 (?i)Kunzmann
@@ -69,6 +70,7 @@ RFCs?
 src
 (?i)Sashank
 (?i)Schwarzer
+Seppänen
 (?i)Sidnei
 (?i)Simmler
 (?i)Soham


### PR DESCRIPTION
## Closes issue

See #938 (doesn't close it as there are many more type hints to add)


## Description

The union of date and datetime is actually date, since datetime inherits from date, but I think the type hints are still useful documentation. Annotating the return value of is_datetime as TypeIs[datetime] should help type checkers.

## Checklist

- [x] I've added a change log entry to `CHANGES.rst`.
- [N/A] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Running Tests](https://icalendar.readthedocs.io/en/latest/install.html#running-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.
- [x] I've added myself to `docs/credits.rst` as a contributor in this pull request or have done so previously.

## Additional information

https://docs.python.org/3/library/typing.html#typing.TypeIs


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--940.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->