### PR TITLE
Update link for running tests in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Write a description of the fixes or improvements.
 
 - [ ] I've added a change log entry to `CHANGES.rst`.
 - [ ] I've added or updated tests if applicable.
-- [ ] I've run and ensured all tests pass locally by following [Running Tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html).
+- [ ] I've run and ensured all tests pass locally by following [Running Tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
 - [ ] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.
 - [ ] I've added myself to `docs/credits.rst` as a contributor in this pull request or have done so previously.
 


### PR DESCRIPTION

## Description

The link got outdated.

## Checklist

- [ ] I've added a change log entry to `CHANGES.rst`.
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Running Tests](https://icalendar.readthedocs.io/en/latest/install.html#running-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.
- [x] I've added myself to `docs/credits.rst` as a contributor in this pull request or have done so previously.

