### PR TITLE
Release v6.3.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,13 @@ We use `Semantic Versioning <https://semver.org>`_.
 - New features increase the **minor** version number.
 - Minor changes and bug fixes increase the **patch** version number.
 
+6.3.2 (2025-11-03)
+------------------
+
+Minor changes:
+
+- Add PyData Theme version switcher to documentation. See `Issue 825 <https://github.com/collective/icalendar/issues/825>`_.
+
 6.3.1 (2025-05-20)
 ------------------
 


### PR DESCRIPTION
This adds the changes to release v6.3.2. See https://github.com/collective/icalendar/pull/966

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--972.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->