### PR TITLE
docs: add changelog entry and credits for changelog subheadings work

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ We still recommend checking out the new features and giving feedback in the repo
 Minor changes
 ~~~~~~~~~~~~~
 
+- Convert changelog section labels to reStructuredText subheadings for improved ReadTheDocs navigation. See `Issue 982 <https://github.com/collective/icalendar/issues/982>`_.
 - Move sections in Table of Content of Reference guide.
 - Improve :py:class:`icalendar.prop.vDatetime` documentation. See `Issue #946 <https://github.com/collective/icalendar/issues/946>`_.
 

--- a/docs/contribute/credits.rst
+++ b/docs/contribute/credits.rst
@@ -38,6 +38,7 @@ Contributors
 - Andrey Nikolaev <nikolaeff@gmail.com>
 - Barak Michener <me@barakmich.com>
 - Bastian Wegge <wegge@crossbow.de>
+- `Chase Naples <https://github.com/cnaples79>`_
 - Christian Geier <contact@lostpackets.de>
 - Christophe de Vienne <cdevienne@gmail.com>
 - cillianderoiste <cillian.deroiste@gmail.com>


### PR DESCRIPTION
## Summary

This PR adds the missing documentation items requested in PR #983 review:
- Adds Chase Naples to contributors list in `docs/contribute/credits.rst`
- Adds changelog entry for the subheading improvements in `CHANGES.rst`

## Context

PR #983 by @cnaples79 successfully converted changelog section labels to reStructuredText subheadings, improving ReadTheDocs navigation. Reviewers @stevepiercy and @niccokunzmann requested these additional documentation items be added.

Since @cnaples79 has not responded to the review feedback, I'm opening this follow-up PR to complete the documentation requirements.

## Recommendation

1. Merge PR #983 first (core work is complete and approved)
2. Then merge this PR immediately after to complete the documentation

Fixes #982

cc @niccokunzmann @stevepiercy

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1000.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->