### PR TITLE
Fix casing and spacing for the proper name of "Read the Docs"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ We still recommend checking out the new features and giving feedback in the repo
 Minor changes
 ~~~~~~~~~~~~~
 
-- Convert changelog section labels to reStructuredText subheadings for improved ReadTheDocs navigation. See `Issue 982 <https://github.com/collective/icalendar/issues/982>`_.
+- Convert changelog section labels to reStructuredText subheadings for improved Read the Docs navigation. See `Issue 982 <https://github.com/collective/icalendar/issues/982>`_.
 - Move sections in Table of Content of Reference guide.
 - Improve :py:class:`icalendar.prop.vDatetime` documentation. See `Issue #946 <https://github.com/collective/icalendar/issues/946>`_.
 


### PR DESCRIPTION
Fixes a premature merge.

No change log entry is necessary because it's merely an update from an itchy trigger finger.