### PR TITLE
Document issues of re-tagging

### DIFF
--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -134,6 +134,12 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         git tag "v$VERSION"
         git push upstream "v$VERSION" # could be origin or whatever reference
 
+    .. warning::
+
+        Once a tag is pushed to the repository, it must not be re-tagged or deleted.
+        This creates issues for downstream repositories.
+        See `Issue 1033 <https://github.com/collective/icalendar/issues/1033>`_.
+
 #.  Once the tag is pushed and its `CI-tests`_ are passing, maintainers will get an e-mail:
 
     .. code-block:: text


### PR DESCRIPTION
## Closes issue

Contributes to #1033.

## Description

We should not re-tag during release

## Checklist

- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.



<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1034.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->