### PR TITLE
Update version to '6.x' in version-switcher.json

### DIFF
--- a/docs/_static/version-switcher.json
+++ b/docs/_static/version-switcher.json
@@ -5,7 +5,7 @@
     },
     {
         "name": "6.x (stable)",
-        "version": "v6.3.2",
+        "version": "6.x",
         "url": "https://icalendar.readthedocs.io/en/stable/",
         "preferred": "true"
     },


### PR DESCRIPTION
This is to see if a general version in the version switcher would work.

## Closes issue

I would like changes to the version switcher to be minimal.

## Description

This tries out a 6.x version like for the others.

## Checklist

- [ ] I've added a change log entry to `CHANGES.rst`.
- [ ] I've added or updated tests if applicable.
- [ ] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.
- [ ] I've added myself to `docs/credits.rst` as a contributor in this pull request or have done so previously.



<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1039.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->