### PR TITLE
Fix wording in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,7 @@
 Internet Calendaring and Scheduling (iCalendar) for Python
 ==========================================================
 
-The `icalendar`_ package is a :rfc:`5545` compatible parser/generator for iCalendar
-files.
+The `icalendar`_ package is an :rfc:`5545` compatible parser and generator of iCalendar files.
 
 ----
 


### PR DESCRIPTION
See https://github.com/collective/icalendar/pull/1048#discussion_r2644958659

This seems to be more English.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1053.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->