### PR TITLE
Fix import failure in Pyodide/WebAssembly environments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,7 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- Fixed import failure in Pyodide/WebAssembly environments by using lazy initialization for timezone data in the zoneinfo provider. The library can now be imported in environments without timezone data (e.g., Cloudflare Workers, PyScript, JupyterLite). See `Issue #1073 <https://github.com/collective/icalendar/issues/1073>`_.
 - Fixed :meth:`icalendar.caselessdict.CaselessDict.__eq__` to return ``NotImplemented`` when comparing with non-dict types instead of raising ``AttributeError``. See `Issue #1016 <https://github.com/collective/icalendar/issues/1016>`_.
 - Fixed decoding of categories. See `Issue 279 <https://github.com/collective/icalendar/issues/279>`_.
 - Link ``timedelta`` to :py:class:`datetime.timedelta` in the Python standard library documentation. See `Issue 951 <https://github.com/collective/icalendar/issues/951>`_.

--- a/src/icalendar/tests/test_issue_1073_pyodide_import.py
+++ b/src/icalendar/tests/test_issue_1073_pyodide_import.py
@@ -1,0 +1,109 @@
+"""Tests for issue #1073: Import failure in Pyodide/WebAssembly environments.
+
+The ZONEINFO class should use lazy initialization to avoid import-time
+failures in environments without timezone data.
+"""
+
+import threading
+from unittest import mock
+
+from icalendar.timezone.zoneinfo import ZONEINFO
+
+
+def test_zoneinfo_class_does_not_initialize_at_import_time():
+    """Test that ZONEINFO class attributes are not computed at class definition.
+
+    The class should have None placeholders for _utc and _available_timezones_cache
+    that are only populated when the properties are accessed.
+    """
+    # Verify that the class uses lazy initialization pattern
+    # The class attributes should exist and potentially be None initially
+    # (they may be populated from previous test runs, but that's OK)
+    assert hasattr(ZONEINFO, "_utc")
+    assert hasattr(ZONEINFO, "_available_timezones_cache")
+
+    # The class should have property accessors for utc and _available_timezones
+    # Check via __dict__ since they are instance properties
+    assert "utc" in ZONEINFO.__dict__
+    assert isinstance(ZONEINFO.__dict__["utc"], property)
+    assert "_available_timezones" in ZONEINFO.__dict__
+    assert isinstance(ZONEINFO.__dict__["_available_timezones"], property)
+
+
+def test_zoneinfo_utc_property_works():
+    """Test that UTC timezone property returns a valid ZoneInfo."""
+    z = ZONEINFO()
+
+    utc = z.utc
+    assert utc is not None
+    assert str(utc) == "UTC"
+
+    # Second access should return the same cached instance
+    assert z.utc is utc
+
+
+def test_zoneinfo_available_timezones_property_works():
+    """Test that available_timezones property returns a valid set."""
+    z = ZONEINFO()
+
+    timezones = z._available_timezones
+    assert timezones is not None
+    assert isinstance(timezones, set)
+    assert "UTC" in timezones
+
+    # Second access should return the same cached instance
+    assert z._available_timezones is timezones
+
+
+def test_zoneinfo_knows_timezone_id():
+    """Test that knows_timezone_id correctly uses the lazy _available_timezones."""
+    z = ZONEINFO()
+
+    assert z.knows_timezone_id("UTC") is True
+    assert z.knows_timezone_id("America/New_York") is True
+    assert z.knows_timezone_id("NonExistent/Timezone") is False
+
+
+def test_zoneinfo_can_be_instantiated_before_timezone_access():
+    """Test that ZONEINFO can be instantiated without triggering timezone lookups.
+
+    This is the key test for Pyodide compatibility - we need to be able to create
+    the provider instance without it immediately trying to access timezone data.
+    """
+    # Use mock.patch to temporarily set class attributes to None
+    # This is safer than directly modifying class state
+    with mock.patch.object(  # noqa: SIM117
+        ZONEINFO, "_utc", None
+    ):
+        with mock.patch.object(ZONEINFO, "_available_timezones_cache", None):
+            # This should NOT raise even if zoneinfo data is unavailable
+            z = ZONEINFO()
+
+            # Just accessing the name should work without triggering timezone lookups
+            assert z.name == "zoneinfo"
+
+
+def test_zoneinfo_thread_safe_initialization():
+    """Test that lazy initialization is thread-safe."""
+    z = ZONEINFO()
+    results = []
+    errors = []
+
+    def access_utc():
+        try:
+            utc = z.utc
+            results.append(utc)
+        except (ValueError, KeyError, OSError) as e:
+            errors.append(e)
+
+    # Create multiple threads that access utc simultaneously
+    threads = [threading.Thread(target=access_utc) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # All threads should get the same UTC timezone
+    assert len(errors) == 0, f"Errors occurred: {errors}"
+    assert len(results) == 10
+    assert all(r is results[0] for r in results), "All threads should get same UTC instance"

--- a/src/icalendar/timezone/zoneinfo.py
+++ b/src/icalendar/timezone/zoneinfo.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import copy
 import copyreg
 import functools
+import threading
 from datetime import datetime, tzinfo
 from io import StringIO
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from dateutil.rrule import rrule, rruleset
 from dateutil.tz import tzical
@@ -28,8 +29,33 @@ class ZONEINFO(TZProvider):
     """Provide icalendar with timezones from zoneinfo."""
 
     name = "zoneinfo"
-    utc = zoneinfo.ZoneInfo("UTC")
-    _available_timezones = zoneinfo.available_timezones()
+    # Use lazy initialization via properties to avoid import-time failures
+    # in environments without timezone data (e.g., Pyodide/WebAssembly).
+    # See https://github.com/collective/icalendar/issues/1073
+    _utc: zoneinfo.ZoneInfo | None = None
+    _available_timezones_cache: set | None = None
+    # Class-level lock is intentional: caches are shared by all instances.
+    _init_lock = threading.Lock()
+
+    @property
+    def utc(self) -> zoneinfo.ZoneInfo:
+        """Return the UTC timezone, initializing lazily on first access."""
+        if self._utc is None:
+            with self._init_lock:
+                # Double-check after acquiring lock
+                if self._utc is None:
+                    ZONEINFO._utc = zoneinfo.ZoneInfo("UTC")
+        return self._utc  # type: ignore[return-value]
+
+    @property
+    def _available_timezones(self) -> set:
+        """Return available timezones, initializing lazily on first access."""
+        if self._available_timezones_cache is None:
+            with self._init_lock:
+                # Double-check after acquiring lock
+                if self._available_timezones_cache is None:
+                    ZONEINFO._available_timezones_cache = zoneinfo.available_timezones()
+        return self._available_timezones_cache  # type: ignore[return-value]
 
     def localize(self, dt: datetime, tz: zoneinfo.ZoneInfo) -> datetime:
         """Localize a datetime to a timezone."""
@@ -41,7 +67,7 @@ class ZONEINFO(TZProvider):
             return dt.astimezone(self.utc)
         return self.localize(dt, self.utc)
 
-    def timezone(self, name: str) -> Optional[tzinfo]:
+    def timezone(self, name: str) -> tzinfo | None:
         """Return a timezone with a name or None if we cannot find it."""
         try:
             return zoneinfo.ZoneInfo(name)


### PR DESCRIPTION
## Summary

- Use lazy initialization for `ZONEINFO.utc` and `ZONEINFO._available_timezones` to avoid import-time `ZoneInfoNotFoundError` in environments without timezone data
- Add thread-safe double-checked locking for concurrent access

Fixes #1073

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1086.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->