### PR TITLE
fix: auto-generate UID in Calendar.new() when not provided

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,7 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- Fixed :meth:`Calendar.new <icalendar.cal.calendar.Calendar.new>` to automatically generate a UID when not provided, matching the documented behavior. Previously, the documentation stated that ``uid`` would be set to a new :func:`uuid.uuid4` if ``None``, but the implementation did not generate it. See `Issue #1066 <https://github.com/collective/icalendar/issues/1066>`_.
 - Fixed import failure in Pyodide/WebAssembly environments by using lazy initialization for timezone data in the zoneinfo provider. The library can now be imported in environments without timezone data (e.g., Cloudflare Workers, PyScript, JupyterLite). See `Issue #1073 <https://github.com/collective/icalendar/issues/1073>`_.
 - Fixed :meth:`icalendar.caselessdict.CaselessDict.__eq__` to return ``NotImplemented`` when comparing with non-dict types instead of raising ``AttributeError``. See `Issue #1016 <https://github.com/collective/icalendar/issues/1016>`_.
 - Fixed decoding of categories. See `Issue 279 <https://github.com/collective/icalendar/issues/279>`_.

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from datetime import timedelta
 from typing import TYPE_CHECKING, Sequence
 
@@ -609,7 +610,7 @@ Description:
         calendar.method = method
         calendar.calscale = calscale
         calendar.categories = categories
-        calendar.uid = uid
+        calendar.uid = uid if uid is not None else uuid.uuid4()
         calendar.url = url
         calendar.refresh_interval = refresh_interval
         calendar.source = source

--- a/src/icalendar/tests/test_issue_1066_calendar_uid.py
+++ b/src/icalendar/tests/test_issue_1066_calendar_uid.py
@@ -1,0 +1,56 @@
+"""Tests for issue #1066: Calendar.new() should auto-generate UID.
+
+See https://github.com/collective/icalendar/issues/1066
+"""
+
+import uuid
+
+import pytest
+
+from icalendar import Calendar
+
+
+def test_calendar_new_auto_generates_uid(test_uid):
+    """Test that Calendar.new() automatically generates a UID when not provided."""
+    calendar = Calendar.new()
+
+    # UID should not be None
+    assert calendar.uid is not None
+
+    # UID should match the test fixture default
+    assert str(calendar.uid) == test_uid
+
+
+def test_calendar_new_respects_explicit_uid():
+    """Test that Calendar.new() respects explicitly provided UID."""
+    custom_uid = "test-calendar-uid"
+    calendar = Calendar.new(uid=custom_uid)
+
+    assert calendar.uid == custom_uid
+
+
+def test_calendar_new_accepts_uuid_object():
+    """Test that Calendar.new() accepts UUID objects as uid parameter."""
+    custom_uuid = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    calendar = Calendar.new(uid=custom_uuid)
+
+    # The uid property returns a string representation
+    assert str(calendar.uid) == str(custom_uuid)
+
+
+def test_calendar_new_uid_appears_in_ical_output():
+    """Test that the auto-generated UID appears in the iCalendar output."""
+    calendar = Calendar.new(name="Test Calendar")
+
+    ical_output = calendar.to_ical()
+
+    # UID should be present in the output
+    assert b"UID:" in ical_output
+    # The UID value should match what we set
+    assert str(calendar.uid).encode() in ical_output
+
+
+def test_issue_1066_original_assertion():
+    """Test the exact assertion from issue #1066."""
+    # This was failing before the fix
+    assert Calendar.new().uid is not None

--- a/src/icalendar/tests/test_issue_843_new_method_for_components.py
+++ b/src/icalendar/tests/test_issue_843_new_method_for_components.py
@@ -56,7 +56,7 @@ COMPONENTS_DTSTAMP = {
     Availability,
 }
 COMPONENTS_DTSTAMP_AUTOMATIC = {Event, Journal, Todo, FreeBusy, Available, Availability}
-COMPONENTS_UID_AUTOMATIC = {Event, Todo, Journal, Available, Availability}
+COMPONENTS_UID_AUTOMATIC = {Event, Todo, Journal, Available, Availability, Calendar}
 COMPONENTS_UID = {Event, Todo, Journal, Alarm, Calendar, Available, Availability}
 COMPONENTS_SEQUENCE = {Event, Todo, Journal, Availability}
 COMPONENTS_CATEGORIES = {Event, Journal, Todo, Calendar, Availability, Available}


### PR DESCRIPTION
## Closes issue

- [x] Closes #1066

## Description

Fixed `Calendar.new()` to automatically generate a UID when not provided, matching the documented behavior. The docstring states that `uid` will be set to a new `uuid.uuid4()` if `None`, but the implementation was not generating it.

This fix applies the same pattern already used in `Event.new()` (line 510):

```python
calendar.uid = uid if uid is not None else uuid.uuid4()
```

**Changes:**

**1. Core Implementation** (`src/icalendar/cal/calendar.py`)
- Added `import uuid`
- Updated `Calendar.new()` to auto-generate UID when `uid=None`

**2. Test Framework Update** (`src/icalendar/tests/test_issue_843_new_method_for_components.py`)         
  - Added `Calendar` to `COMPONENTS_UID_AUTOMATIC` set 

**3. New Tests** (`src/icalendar/tests/test_issue_1066_calendar_uid.py`)
- Added 5 tests specific to this fix

**4. Changelog** (`CHANGES.rst`)
- Added entry in "Bug fixes" section

## Checklist

- [x] I've added a change log entry to `CHANGES.rst`.
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1099.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->