### PR TITLE
Added a new rule to our docstring style guide to escape docstrings.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,7 @@ Documentation
 - Replaced "Arguments" and "Args" with "Parameters". :issue:`1076`
 - Added documentation of how to set up a development environment with git. :issue:`906`
 - Documented how to install and use pre-commit. :issue:`996`
+- Added a new rule to our docstring style guide to escape docstrings, and added a new section for type hints in the code conventions section. :issue:`1080`
 
 
 7.0.0a3 (2025-12-19)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,6 +140,7 @@ issues_github_path = "collective/icalendar"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
+    "typing": ("https://typing.python.org/en/latest/", None),
 }
 
 

--- a/docs/contribute/development.rst
+++ b/docs/contribute/development.rst
@@ -180,6 +180,37 @@ In addition, "internal use only" objects are not displayed in the documentation.
 Their docstrings, of course, remain in the Python source code.
 
 
+Type hints
+''''''''''
+
+Type hints in Python help developers catch errors early, improve code documentation, and enhance the functionality of IDEs and linters.
+icalendar uses type hints, and supports rendering them in its :doc:`reference API documentation </reference/api/icalendar>`.
+
+icalendar was originally written before the existence of type hints in Python.
+As such, there are many Python objects in the code base that lack type hints.
+The icalendar team welcomes contributions to add type hints.
+
+When the type hints in the standard library are not sufficient, you can use subtyping through :doc:`protocols <typing:spec/protocol>`.
+The following example demonstrates subtyping through the usage of a protocol and a method using a literal :ref:`ellipsis <bltin-ellipsis-object>` ``...`` to indicate that the method signature exists, but the implementation details aren't necessary.
+
+.. code-block:: python
+
+    class HasToIcal(Protocol):
+        """Protocol for objects with a to_ical method."""
+
+        def to_ical(self) -> bytes:
+            """Convert to iCalendar format."""
+            ...
+
+.. seealso::
+
+    - GitHub issue :issue:`Add type hints <938>`
+    - :ref:`markup-and-formatting`
+    - :doc:`typing:index`
+    - Python standard library :mod:`typing`
+    - :ref:`annotating-callables`
+
+
 Activate a tox environment
 --------------------------
 

--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -50,6 +50,8 @@ Instead, what you want to achieve matters.
 By keeping each page focused on one category, readers can focus on getting work done, understanding, or experimenting.
 
 
+.. _markup-and-formatting:
+
 Markup and formatting
 ---------------------
 
@@ -284,6 +286,19 @@ Description
     :ref:`sphinx:Sections`
 
 
+Escape docstrings
+-----------------
+
+Avoid double-escaping in docstrings.
+Use the raw ``r`` indicator immediately before the leading docstring delimiter ``"""``.
+Thus the docstring and the rendered content will have the same level of escapes.
+It will also be less confusing for readers of the source code.
+
+.. seealso::
+
+    :ref:`parser-split_on_unescaped_semicolon` example.
+
+
 Docstring examples
 ------------------
 
@@ -306,6 +321,8 @@ See the rendered view of this class method at :meth:`Component.register <icalend
 .. literalinclude:: ../../../src/icalendar/cal/component.py
     :pyobject: Component.register
 
+
+.. _parser-split_on_unescaped_semicolon:
 
 ``parser.split_on_unescaped_semicolon``
 '''''''''''''''''''''''''''''''''''''''

--- a/docs/styles/config/vocabularies/icalendar/accept.txt
+++ b/docs/styles/config/vocabularies/icalendar/accept.txt
@@ -22,6 +22,7 @@ sphinx_reredirects
 src
 (?i)subcomponents?
 (?i)subpackages?
+subtyping
 (?i)Traceback
 (?i)unescaped
 uv


### PR DESCRIPTION
Closes #1080

## Description

- Added a new rule to our docstring style guide to escape docstrings.
- Added a new section for type hints in the code conventions section.
- Added subtyping to icalendar spelling dictionary.
- Added the Python Typing documentation to Intersphinx configuration.

## Checklist

- [x] I've added a change log entry to `CHANGES.rst`.
- [ ] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1108.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->