### PR TITLE
Fix docstring style in parser module

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -15,3 +15,19 @@ Microsoft.Units = suggestion
 # Ignore Sphinx Python object roles, such as ":class:" and ":meth:",
 # to prevent false positives from Microsoft.Spacing on dotted Python names.
 TokenIgnores = :[a-z]+:\x60.+\x60
+
+[*.rst]
+BasedOnStyles = Vale, Microsoft
+Microsoft.Contractions = suggestion
+Microsoft.GeneralURL = No
+Microsoft.Units = suggestion
+TokenIgnores = (.. *)
+
+[*.py]
+BasedOnStyles = Vale, Microsoft
+Microsoft.Contractions = suggestion
+Microsoft.GeneralURL = No
+Microsoft.Units = suggestion
+
+# Ignore Python comments and Sphinx roles
+TokenIgnores = (#.*),(:[a-z]+:\x60.+\x60)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ BUILDDIR        = ../_build
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
-VALEFILES       := $(shell find $(DOCS_DIR) -type f -name "*.rst" -print)  # Also add `src` for docstrings.
+VALEFILES       := $(shell find $(DOCS_DIR) -type f -name "*.rst" -print) $(shell find src/icalendar -type f -name "*.py" -not -path "*/tests/*" -not -path "*/fuzzing/*" -print)
 VALEOPTS        ?=
 PYTHONVERSION   = >=3.11,<3.15
 

--- a/PR_CHANGES.md
+++ b/PR_CHANGES.md
@@ -1,0 +1,29 @@
+# Configure Vale to Check Python Docstrings for Spelling and Style
+
+This PR configures Vale to run on Python docstrings, ensuring consistent style and spelling in the documentation. The changes exclude test code and comments as per the issue requirements.
+
+## Changes Made
+
+### 1. Updated `.vale.ini`
+- Added a `[*.py]` section to configure Vale for Python files.
+- Set `BasedOnStyles = Vale, Microsoft` for Python files.
+- Added `TokenIgnores` to ignore Python comments (starting with `#`) and Sphinx roles (e.g., `:class:`).
+- This ensures Vale checks docstrings but skips code comments and test files.
+
+### 2. Updated `Makefile`
+- Modified `VALEFILES` to include Python source files from `src/icalendar/` while excluding `*/tests/*` and `*/fuzzing/*` directories.
+- This targets only the main source code for docstring checking, avoiding test code and comments.
+
+### 3. Synced Vale Styles
+- Ran `uv run vale sync` to ensure all Vale styles and packages are up to date.
+
+## Next Steps
+- Run `make vale` to check for spelling and style issues in Python docstrings.
+- Fix any identified issues by correcting spelling mistakes or adjusting word lists in `docs/styles/config/vocabularies/`.
+- Potentially extend the accept and reject lists in `Base/accept.txt`, `Base/reject.txt`, and `icalendar/accept.txt`, `icalendar/reject.txt` based on findings.
+
+## Testing
+- The configuration has been set up to run Vale on Python files without affecting test code or comments.
+- Vale sync has been completed successfully.
+
+Closes #1007

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -361,7 +361,7 @@ To demonstrate icalendar's flexibility, the following example creates an event t
     END:VEVENT
 
 
-``zoneinfo`` Default Implementation
+``zoneinfo`` default implementation
 '''''''''''''''''''''''''''''''''''
 
 .. versionchanged:: 6.0.0
@@ -388,7 +388,7 @@ To continue to receive ``pytz`` timezones in parsed results, you can receive all
     <DstTzInfo 'Europe/Vienna' CET+1:00:00 STD>
 
 
-Complete Recurring Meeting
+Complete recurring meeting
 ''''''''''''''''''''''''''
 
 This section shows how create a complete and typical iCalendar file of a recurring meeting event, then add some properties to it, including a location, organizer, attendees, alarms, recurrence, and other properties.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -221,7 +221,7 @@ You can also add arbitrary property parameters by passing a parameters dictionar
 .. code-block:: pycon
 
     >>> event = Event()
-    >>> event.add("X-TEST-PROP", "tryout.",
+    >>> event.add("X-TEST-PROP", "tryout",
     ...           parameters={"prop1":"val1", "prop2":"val2"})
     >>> lines = event.to_ical().splitlines()
     >>> assert b'X-TEST-PROP;PROP1=val1;PROP2=val2:tryout.' in lines
@@ -334,7 +334,7 @@ Show journal entries.
     VJOURNAL({})
 
 
-timezone implementations
+Timezone Implementations
 ''''''''''''''''''''''''
 
 You can localize your events to take place in different timezones.
@@ -361,7 +361,7 @@ To demonstrate icalendar's flexibility, the following example creates an event t
     END:VEVENT
 
 
-``zoneinfo`` default implementation
+``zoneinfo`` Default Implementation
 '''''''''''''''''''''''''''''''''''
 
 .. versionchanged:: 6.0.0
@@ -388,7 +388,7 @@ To continue to receive ``pytz`` timezones in parsed results, you can receive all
     <DstTzInfo 'Europe/Vienna' CET+1:00:00 STD>
 
 
-Complete recurring meeting
+Complete Recurring Meeting
 ''''''''''''''''''''''''''
 
 This section shows how create a complete and typical iCalendar file of a recurring meeting event, then add some properties to it, including a location, organizer, attendees, alarms, recurrence, and other properties.

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -221,7 +221,7 @@ You can also add arbitrary property parameters by passing a parameters dictionar
 .. code-block:: pycon
 
     >>> event = Event()
-    >>> event.add("X-TEST-PROP", "tryout",
+    >>> event.add("X-TEST-PROP", "tryout.",
     ...           parameters={"prop1":"val1", "prop2":"val2"})
     >>> lines = event.to_ical().splitlines()
     >>> assert b'X-TEST-PROP;PROP1=val1;PROP2=val2:tryout.' in lines
@@ -334,7 +334,7 @@ Show journal entries.
     VJOURNAL({})
 
 
-Timezone Implementations
+Timezone implementations
 ''''''''''''''''''''''''
 
 You can localize your events to take place in different timezones.


### PR DESCRIPTION
## Closes issue

Replace `ISSUE_NUMBER` with the issue number that your pull request fixes. Then GitHub will link and automatically close the related issue.

- [ ] Closes #1007

## Description

Write a description of the fixes or improvements.

## Checklist

- [ ] I've added a change log entry to `CHANGES.rst`.
- [ ] I've added or updated tests if applicable.
- [ ] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

Upload screenshots, videos, links to documentation, or any other relevant information.


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1111.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->