### PR TITLE
Moved the "Edit this page" link above the page table of contents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -87,6 +87,7 @@ Documentation
 - Documented how to install and use pre-commit. :issue:`996`
 - Added a new rule to our docstring style guide to escape docstrings, and added a new section for type hints in the code conventions section. :issue:`1080`
 - Documented ``__init__`` methods. :issue:`1079`
+- Moved "Edit this page" link to above the page table of contents. :issue:`1106`
 
 
 7.0.0a3 (2025-12-19)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,7 @@ html_theme_options = {
     "navbar_start": ["navbar-logo", "version-switcher"],
     "navigation_with_keys": True,
     "search_bar_text": "Search",
+    "secondary_sidebar_items": ["edit-this-page", "page-toc", "sourcelink"],
     "show_nav_level": 2,
     "show_toc_level": 2,
     "show_version_warning_banner": True,


### PR DESCRIPTION
- Closes #1106

## Checklist

- [X] I've added a change log entry to `CHANGES.rst`.
- [ ] I've added or updated tests if applicable.
- [X] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [X] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1117.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->