### PR TITLE
docs(ci): print Vale docs link on spell-check failure

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -52,3 +52,10 @@ jobs:
 
       - name: Run vale
         run: make vale VALEOPTS="--minAlertLevel='warning'" PYTHONVERSION=${{ matrix.python-version }}
+      
+      - name: Spellchecker guidance on failure
+        if: failure()
+        run: |
+          echo "❌ Vale spell checker failed."
+          echo "📘 For how to fix messages and add new dictionary words, see:"
+          echo "👉 https://github.com/collective/icalendar/blob/main/docs/contribute/documentation/build-check.rst#spelling-grammar-and-style"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ Minor changes
 - Regroup dependencies in, and remove obsolete ones, from :file:`pyproject.toml`. :issue:`906`
 - Add type hints to internal helper functions. :issue:`938`
 - Added type hints and overloads to :meth:`Component.from_ical <icalendar.cal.component.Component.from_ical>` to support ``multiple=True/False`` return types. :issue:`1129`
+- CI: Print a link to Vale documentation when the spell checker fails.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Closes issue

- [ ] Closes #1132

## Description

When the Vale spell checker fails in CI, contributors previously received no guidance on how to resolve the error.
This change updates the documentation workflow to print a link to the project’s Vale documentation when the spell checker fails.

The linked documentation explains:

- which types of spell-check messages need fixing

- how to add new words to the Vale dictionary

This improves contributor experience by making CI failures actionable.

## Checklist

- [ ] I've added a change log entry to `CHANGES.rst`.
- [ ] I've added or updated tests if applicable.
- [ ] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

The documentation link points directly to the section describing Vale-based spelling checks and how to add accepted words to the dictionary:
https://github.com/collective/icalendar/blob/main/docs/contribute/documentation/build-check.rst#spelling-grammar-and-style