### PR TITLE
Remove a confusing sentence from the Parameters docstring note

### DIFF
--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -274,7 +274,6 @@ Description
     .. note::
 
         Use "Parameters" instead of "Args" or "Arguments."
-        Although ``Args`` is common in Google style docstrings, :mod:`sphinx.ext.napoleon` supports both ``Parameters`` and ``Args``.
         The term "Parameters" is preferred for consistency with Python's official terminology.
         See `Python FAQ on arguments and parameters <https://docs.python.org/3/faq/programming.html#what-is-the-difference-between-arguments-and-parameters>`_ and :ref:`Napoleon's supported sections <sphinx:Sections>`.
 


### PR DESCRIPTION
No change log needed. Follow up to commit 2800942

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1139.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->