### PR TITLE
Add type hints to prop value classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ Minor changes
 - The :func:`icalendar.tools.is_pytz_dt` return value is now hinted as ``TypeGuard[datetime]``, not ``TypeIs[datetime]``, since returning ``False`` should not allow narrowing it as non-datetime.
 - Regroup dependencies in, and remove obsolete ones, from :file:`pyproject.toml`. :issue:`906`
 - Add type hints to internal helper functions. :issue:`938`
+- Add type hints to prop value classes (vBoolean, vFloat, vUri, vBinary, vInline). :issue:`938`
 - Added type hints and overloads to :meth:`Calendar.from_ical <icalendar.cal.calendar.Calendar.from_ical>` and :meth:`Component.from_ical <icalendar.cal.component.Component.from_ical>` to support ``multiple=True/False`` return types. :issue:`1129`
 - CI: Print a link to Vale documentation when the spell checker fails.
 

--- a/src/icalendar/prop/binary.py
+++ b/src/icalendar/prop/binary.py
@@ -17,30 +17,30 @@ class vBinary:
     params: Parameters
     obj: str
 
-    def __init__(self, obj, params: dict[str, str] | None = None):
+    def __init__(self, obj: str | bytes, params: dict[str, str] | None = None) -> None:
         self.obj = to_unicode(obj)
         self.params = Parameters(encoding="BASE64", value="BINARY")
         if params:
             self.params.update(params)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"vBinary({self.to_ical()})"
 
-    def to_ical(self):
+    def to_ical(self) -> bytes:
         return binascii.b2a_base64(self.obj.encode("utf-8"))[:-1]
 
     @staticmethod
-    def from_ical(ical):
+    def from_ical(ical: str | bytes) -> bytes:
         try:
             return base64.b64decode(ical)
         except ValueError as e:
             raise ValueError("Not valid base 64 encoding.") from e
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """self == other"""
         return isinstance(other, vBinary) and self.obj == other.obj
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Hash of the vBinary object."""
         return hash(self.obj)
 

--- a/src/icalendar/prop/boolean.py
+++ b/src/icalendar/prop/boolean.py
@@ -52,16 +52,18 @@ class vBoolean(int):
 
     BOOL_MAP = CaselessDict({"true": True, "false": False})
 
-    def __new__(cls, *args, params: dict[str, Any] | None = None, **kwargs):
+    def __new__(
+        cls, *args: Any, params: dict[str, Any] | None = None, **kwargs: Any
+    ) -> Self:
         self = super().__new__(cls, *args, **kwargs)
         self.params = Parameters(params)
         return self
 
-    def to_ical(self):
+    def to_ical(self) -> bytes:
         return b"TRUE" if self else b"FALSE"
 
     @classmethod
-    def from_ical(cls, ical):
+    def from_ical(cls, ical: str) -> bool:
         try:
             return cls.BOOL_MAP[ical]
         except Exception as e:

--- a/src/icalendar/prop/float.py
+++ b/src/icalendar/prop/float.py
@@ -56,16 +56,18 @@ class vFloat(float):
     default_value: ClassVar[str] = "FLOAT"
     params: Parameters
 
-    def __new__(cls, *args, params: dict[str, Any] | None = None, **kwargs):
+    def __new__(
+        cls, *args: Any, params: dict[str, Any] | None = None, **kwargs: Any
+    ) -> Self:
         self = super().__new__(cls, *args, **kwargs)
         self.params = Parameters(params)
         return self
 
-    def to_ical(self):
+    def to_ical(self) -> bytes:
         return str(self).encode("utf-8")
 
     @classmethod
-    def from_ical(cls, ical):
+    def from_ical(cls, ical: str | float) -> Self:
         try:
             return cls(ical)
         except Exception as e:

--- a/src/icalendar/prop/inline.py
+++ b/src/icalendar/prop/inline.py
@@ -1,7 +1,8 @@
 from typing import Any
 
+from icalendar.compatibility import Self
 from icalendar.parser import Parameters
-from icalendar.parser_tools import DEFAULT_ENCODING, to_unicode
+from icalendar.parser_tools import DEFAULT_ENCODING, ICAL_TYPE, to_unicode
 
 
 class vInline(str):
@@ -15,21 +16,22 @@ class vInline(str):
 
     def __new__(
         cls,
-        value,
-        encoding=DEFAULT_ENCODING,
+        value: ICAL_TYPE,
+        encoding: str = DEFAULT_ENCODING,
         /,
         params: dict[str, Any] | None = None,
-    ):
+    ) -> Self:
         value = to_unicode(value, encoding=encoding)
         self = super().__new__(cls, value)
         self.params = Parameters(params)
         return self
 
-    def to_ical(self):
+    def to_ical(self) -> bytes:
         return self.encode(DEFAULT_ENCODING)
 
     @classmethod
-    def from_ical(cls, ical):
+    def from_ical(cls, ical: ICAL_TYPE) -> Self:
         return cls(ical)
+
 
 __all__ = ["vInline"]

--- a/src/icalendar/prop/uri.py
+++ b/src/icalendar/prop/uri.py
@@ -1,6 +1,5 @@
 """URI values from :rfc:`5545`."""
 
-
 from typing import Any, ClassVar
 
 from icalendar.compatibility import Self
@@ -71,11 +70,11 @@ class vUri(str):
         self.params = Parameters(params)
         return self
 
-    def to_ical(self):
+    def to_ical(self) -> bytes:
         return self.encode(DEFAULT_ENCODING)
 
     @classmethod
-    def from_ical(cls, ical):
+    def from_ical(cls, ical: str | bytes) -> Self:
         try:
             return cls(ical)
         except Exception as e:
@@ -121,5 +120,6 @@ class vUri(str):
         return f"{self.__class__.__name__}({self.uri!r})"
 
     from icalendar.param import FMTTYPE, GAP, LABEL, LANGUAGE, LINKREL, RELTYPE, VALUE
+
 
 __all__ = ["vUri"]


### PR DESCRIPTION
## Closes issue

- [ ] Partially addresses #938

## Description

Adds type hints to five prop value classes: `vBoolean`, `vFloat`, `vUri`, `vBinary`, and `vInline`.

Methods annotated:
- `__new__` / `__init__` parameter types and return types
- `to_ical()` return types
- `from_ical()` parameter and return types
- `__repr__()`, `__eq__()`, `__hash__()` (vBinary only)

No behavioral changes — only type annotations were added.

## Checklist

- [x] I've added a change log entry to `CHANGES.rst`.
- [x] ~~I've added or updated tests if applicable.~~ [Not applicable — type hints only]
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests). [`tox -e py312`]
- [x] ~~I've added or edited documentation.~~ [Not applicable]

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1143.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->