### PR TITLE
Add type to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,10 @@
 ---
 name: Bug report
 about: Create a bug report to help us improve icalendar
-title: "[BUG] "
+title: '[Bug] '
 labels: ''
 assignees: ''
-
+type: 'Bug'
 ---
 
 <!-- This template is here to guide you and help us. If you can't complete everything here, that is fine. -->


### PR DESCRIPTION
The type is `Bug` and is added to the template.
The title is kept so that we can still have the knowledge of it being a bug even if github.com/collective remove the type.
