### PR TITLE
Add ical2jcal project link to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,8 @@ Related projects
 `icalendar-anonymizer <https://pypi.org/project/icalendar-anonymizer/>`_
     Anonymize iCalendar files by stripping personal data while preserving technical properties for bug reproduction.
 
+`ical2jcal <https://pypi.org/project/ical2jcal>`_
+    Convert between iCalendar and jCalendar.
 
 Change log
 ==========


### PR DESCRIPTION
## Description

This links to a related project. I think that this does not need a changelog entry.

## Checklist

- [ ] I've added a change log entry to `CHANGES.rst`.
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1145.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->