### PR TITLE
Add type hints to remaining prop value classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ Minor changes
 - Regroup dependencies in, and remove obsolete ones, from :file:`pyproject.toml`. :issue:`906`
 - Add type hints to internal helper functions. :issue:`938`
 - Add type hints to prop value classes (vBoolean, vFloat, vUri, vBinary, vInline). :issue:`938`
+- Add type hints to remaining prop value classes (vText, vCalAddress, vCategory, vGeo, vN, vOrg, vAdr, vBrokenProperty, vUid, Conference, Image). :issue:`938`
 - Added type hints and overloads to :meth:`Calendar.from_ical <icalendar.cal.calendar.Calendar.from_ical>` and :meth:`Component.from_ical <icalendar.cal.component.Component.from_ical>` to support ``multiple=True/False`` return types. :issue:`1129`
 - CI: Print a link to Vale documentation when the spell checker fails.
 

--- a/src/icalendar/prop/adr.py
+++ b/src/icalendar/prop/adr.py
@@ -115,11 +115,11 @@ class vAdr:
             )
         return AdrFields(*fields)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """self == other"""
         return isinstance(other, vAdr) and self.fields == other.fields
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """String representation."""
         return f"{self.__class__.__name__}({self.fields}, params={self.params})"
 

--- a/src/icalendar/prop/broken.py
+++ b/src/icalendar/prop/broken.py
@@ -21,14 +21,14 @@ class vBrokenProperty(vText):
 
     def __new__(
         cls,
-        value,
-        encoding=DEFAULT_ENCODING,
+        value: str | bytes,
+        encoding: str = DEFAULT_ENCODING,
         /,
         params: dict[str, Any] | None = None,
         expected_type: str | None = None,
         property_name: str | None = None,
         parse_error: str | None = None,
-    ):
+    ) -> Self:
         self = super().__new__(cls, value, encoding, params=params)
         object.__setattr__(self, "expected_type", expected_type)
         object.__setattr__(self, "property_name", property_name)
@@ -50,7 +50,7 @@ class vBrokenProperty(vText):
         property_name: str,
         expected_type: str,
         error: Exception,
-    ):
+    ) -> Self:
         """Create vBrokenProperty from parse failure."""
         return cls(
             raw_value,

--- a/src/icalendar/prop/cal_address.py
+++ b/src/icalendar/prop/cal_address.py
@@ -61,28 +61,28 @@ class vCalAddress(str):
 
     def __new__(
         cls,
-        value,
-        encoding=DEFAULT_ENCODING,
+        value: str | bytes,
+        encoding: str = DEFAULT_ENCODING,
         /,
         params: dict[str, Any] | None = None,
-    ):
+    ) -> Self:
         value = to_unicode(value, encoding=encoding)
         self = super().__new__(cls, value)
         self.params = Parameters(params)
         return self
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"vCalAddress('{self}')"
 
-    def to_ical(self):
+    def to_ical(self) -> bytes:
         return self.encode(DEFAULT_ENCODING)
 
     @classmethod
-    def from_ical(cls, ical) -> Self:
+    def from_ical(cls, ical: str | bytes) -> Self:
         return cls(ical)
 
     @property
-    def ical_value(self):
+    def ical_value(self) -> str:
         """The ``mailto:`` part of the address."""
         return str(self)
 
@@ -140,7 +140,7 @@ class vCalAddress(str):
         role: str | None = None,
         rsvp: bool | None = None,  # noqa: FBT001, RUF100
         sent_by: str | None = None,
-    ):
+    ) -> Self:
         """Create a new vCalAddress with RFC 5545 parameters.
 
         Creates a vCalAddress instance with automatic mailto: prefix handling

--- a/src/icalendar/prop/categories.py
+++ b/src/icalendar/prop/categories.py
@@ -1,5 +1,6 @@
 """CATEGORIES property values from :rfc:`5545`."""
 
+from collections.abc import Iterator
 from typing import Any, ClassVar
 
 from icalendar.compatibility import Self
@@ -21,10 +22,10 @@ class vCategory:
         self.cats: list[vText | str] = [vText(c) for c in c_list]
         self.params = Parameters(params)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[vText | str]:
         return iter(self.cats)
 
-    def to_ical(self):
+    def to_ical(self) -> bytes:
         return b",".join(
             [
                 c.to_ical() if hasattr(c, "to_ical") else vText(c).to_ical()
@@ -59,15 +60,15 @@ class vCategory:
         ical = to_unicode(ical)
         return ical.split(",")
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """self == other"""
         return isinstance(other, vCategory) and self.cats == other.cats
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Hash of the vCategory object."""
         return hash(tuple(self.cats))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """String representation."""
         return f"{self.__class__.__name__}({self.cats}, params={self.params})"
 

--- a/src/icalendar/prop/conference.py
+++ b/src/icalendar/prop/conference.py
@@ -72,7 +72,7 @@ class Conference:
     language: str | None = None
 
     @classmethod
-    def from_uri(cls, uri: vUri | str):
+    def from_uri(cls, uri: vUri | str) -> Conference:
         """Create a Conference from a URI."""
         params = uri.params if isinstance(uri, vUri) else {}
         return cls(

--- a/src/icalendar/prop/geo.py
+++ b/src/icalendar/prop/geo.py
@@ -92,25 +92,25 @@ class vGeo:
         self.longitude = longitude
         self.params = Parameters(params)
 
-    def to_ical(self):
+    def to_ical(self) -> str:
         return f"{self.latitude};{self.longitude}"
 
     @staticmethod
-    def from_ical(ical):
+    def from_ical(ical: str) -> tuple[float, float]:
         try:
             latitude, longitude = ical.split(";")
             return (float(latitude), float(longitude))
         except Exception as e:
             raise ValueError(f"Expected 'float;float' , got: {ical}") from e
 
-    def __eq__(self, other):
-        return self.to_ical() == other.to_ical()
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, vGeo) and self.to_ical() == other.to_ical()
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Hash of the vGeo object."""
         return hash((self.latitude, self.longitude))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """repr(self)"""
         return f"{self.__class__.__name__}(({self.latitude}, {self.longitude}))"
 

--- a/src/icalendar/prop/image.py
+++ b/src/icalendar/prop/image.py
@@ -44,7 +44,7 @@ class Image:
     """
 
     @classmethod
-    def from_property_value(cls, value: vUri | vBinary | vText):
+    def from_property_value(cls, value: vUri | vBinary | vText) -> Image:
         """Create an Image from a property value."""
         params: dict[str, str] = {}
         if not hasattr(value, "params"):
@@ -79,7 +79,7 @@ class Image:
         fmttype: str | None = None,
         altrep: str | None = None,
         display: str | None = None,
-    ):
+    ) -> None:
         """Create a new image according to :rfc:`7986`."""
         if uri is not None and b64data is not None:
             raise ValueError("Image cannot have both URI and binary data (RFC 7986)")

--- a/src/icalendar/prop/n.py
+++ b/src/icalendar/prop/n.py
@@ -108,11 +108,11 @@ class vN:
             raise ValueError(f"N must have exactly 5 fields, got {len(fields)}: {ical}")
         return NFields(*fields)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """self == other"""
         return isinstance(other, vN) and self.fields == other.fields
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """String representation."""
         return f"{self.__class__.__name__}({self.fields}, params={self.params})"
 

--- a/src/icalendar/prop/org.py
+++ b/src/icalendar/prop/org.py
@@ -92,11 +92,11 @@ class vOrg:
             raise ValueError(f"ORG must have at least 1 field: {ical}")
         return tuple(fields)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """self == other"""
         return isinstance(other, vOrg) and self.fields == other.fields
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """String representation."""
         return f"{self.__class__.__name__}({self.fields}, params={self.params})"
 

--- a/src/icalendar/prop/text.py
+++ b/src/icalendar/prop/text.py
@@ -17,11 +17,11 @@ class vText(str):
 
     def __new__(
         cls,
-        value,
-        encoding=DEFAULT_ENCODING,
+        value: ICAL_TYPE,
+        encoding: str = DEFAULT_ENCODING,
         /,
         params: dict[str, Any] | None = None,
-    ):
+    ) -> Self:
         value = to_unicode(value, encoding=encoding)
         self = super().__new__(cls, value)
         self.encoding = encoding
@@ -35,7 +35,7 @@ class vText(str):
         return escape_char(self).encode(self.encoding)
 
     @classmethod
-    def from_ical(cls, ical: ICAL_TYPE):
+    def from_ical(cls, ical: ICAL_TYPE) -> Self:
         return cls(ical)
 
     @property
@@ -52,7 +52,7 @@ class vText(str):
         return [name, self.params.to_jcal(), self.VALUE.lower(), str(self)]
 
     @classmethod
-    def examples(cls):
+    def examples(cls) -> list[Self]:
         """Examples of vText."""
         return [cls("Hello World!")]
 

--- a/src/icalendar/prop/uid.py
+++ b/src/icalendar/prop/uid.py
@@ -18,7 +18,7 @@ class vUid(vText):
     default_value: ClassVar[str] = "UID"
 
     @classmethod
-    def new(cls):
+    def new(cls) -> Self:
         """Create a new UID for convenience.
 
         .. code-block:: pycon

--- a/src/icalendar/prop/uri.py
+++ b/src/icalendar/prop/uri.py
@@ -64,7 +64,7 @@ class vUri(str):
         encoding: str = DEFAULT_ENCODING,
         /,
         params: dict[str, Any] | None = None,
-    ):
+    ) -> Self:
         value = to_unicode(value, encoding=encoding)
         self = super().__new__(cls, value)
         self.params = Parameters(params)


### PR DESCRIPTION
## Closes issue

- [ ] Partially addresses #938

## Description

Adds type hints to the remaining prop value classes: `vText`, `vCalAddress`, `vCategory`, `vGeo`, `vN`, `vOrg`, `vAdr`, `vBrokenProperty`, `vUid`, `Conference`, and `Image`. Also adds the missing `-> Self` return type on `vUri.__new__`.

Methods annotated:
- `__new__` / `__init__` parameter types and return types
- `to_ical()` return types
- `from_ical()` parameter and return types
- `__repr__()`, `__eq__()`, `__hash__()` where present
- `__iter__()` (vCategory)
- Factory methods (`new()`, `from_uri()`, `from_property_value()`, `from_parse_error()`)
- Property accessors (`ical_value`, etc.)

No behavioral changes — only type annotations were added.

## Checklist

- [x] I've added a change log entry to `CHANGES.rst`.
- [x] ~~I've added or updated tests if applicable.~~ [Not applicable — type hints only]
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests). [`tox -e py312`]
- [x] ~~I've added or edited documentation.~~ [Not applicable]

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1146.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->