### PR TITLE
Add type hints to date/time and remaining prop value classes in __init__.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,7 @@ Minor changes
 - Add type hints to internal helper functions. :issue:`938`
 - Add type hints to prop value classes (vBoolean, vFloat, vUri, vBinary, vInline). :issue:`938`
 - Add type hints to remaining prop value classes (vText, vCalAddress, vCategory, vGeo, vN, vOrg, vAdr, vBrokenProperty, vUid, Conference, Image). :issue:`938`
+- Add type hints to date/time and remaining prop value classes in ``__init__.py``. Fix incorrect return type annotation on ``vDate.parse_jcal_value``. :issue:`938`
 - Added type hints and overloads to :meth:`Calendar.from_ical <icalendar.cal.calendar.Calendar.from_ical>` and :meth:`Component.from_ical <icalendar.cal.component.Component.from_ical>` to support ``multiple=True/False`` return types. :issue:`1129`
 - CI: Print a link to Vale documentation when the spell checker fails.
 


### PR DESCRIPTION
## Summary
- Add type annotations to 16 classes (~37 methods) in `prop/__init__.py`: `vInt`, `vDDDLists`, `TimeBase`, `vDDDTypes`, `vDate`, `vDatetime`, `vDuration`, `vPeriod`, `vWeekday`, `vFrequency`, `vMonth`, `vSkip`, `vRecur`, `vTime`, `vUTCOffset`, and `TypesFactory`.
- Fix incorrect return type annotation on `vDate.parse_jcal_value` (`-> datetime` → `-> date`, since the method calls `.date()`).
- Update `CHANGES.rst`.

Continues #938. Follows up on #1143 and #1146.

## Test plan
- [x] `tox -e py312` — all tests pass (8023 passed)
- [x] `tox -e ruff` — no new lint errors introduced (all existing errors match upstream main)
- [x] Annotation-only changes + 1 annotation bug fix; no runtime behavior change

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1153.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->