### PR TITLE
Clarify to omit types in docstrings

### DIFF
--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -264,12 +264,16 @@ Description
     Separate the summary and description with a blank line.
 
 ``Attributes``
-    Each attribute should consist of its name and a brief description.
-    You must omit the attribute's type, allowing Sphinx extensions and the use of type hints to automatically render it for you.
+    Each attribute should consist of its name, type, and a brief description.
+    
+    .. note::
+
+        If you know how to avoid manually entering the type for an attribute, please see :issue:`1156`.
 
 ``Parameters``
     Each parameter should consist of its name and a brief description.
     You must omit the parameter's type, allowing Sphinx extensions and the use of type hints to automatically render it for you.
+    This is especially true in a class's ``__init__`` method.
 
     .. note::
 


### PR DESCRIPTION
Clarify docs to omit types in docstrings.

See https://github.com/collective/icalendar/pull/1078/changes#r2778988678

No change log entry needed for this trivial inconsequential change to the docs.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1155.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->