### PR TITLE
Ruff: fix lint warnings and format src/icalendar/cal/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,18 @@ extend-safe-fixes = [
     "T201",   # print found
     "T203",   # `pprint` found
 ]
+"src/icalendar/cal/**" = [
+    "A002",    # argument shadowing builtin (sorted)
+    "DTZ001",  # datetime() called without tzinfo
+    "E501",    # line too long (docstrings with RFC references)
+    "FBT001",  # boolean positional argument
+    "N802",    # function name should be lowercase (TRIGGER_RELATED etc.)
+    "PERF203", # try-except in loop (parsing loop)
+    "PLC0415", # import outside top-level (circular import avoidance)
+    "PLW1641", # eq without hash (Component intentionally unhashable)
+    "PLW2901", # loop variable overwritten
+    "SLF001",  # private member access
+]
 "src/icalendar/prop/*.py" = [
     "N801",    # Class name should use CamelCase
     "PLC0415", # Import property within class

--- a/src/icalendar/cal/alarm.py
+++ b/src/icalendar/cal/alarm.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
-from typing import TYPE_CHECKING, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, NamedTuple
 
 from icalendar.attr import (
     CONCEPTS_TYPE_SETTER,
@@ -39,8 +39,9 @@ class Alarm(Component):
 
     Example:
 
-        The following example creates an alarm which uses an audio file from an FTP server.        
-        
+        The following example creates an alarm which uses an audio file
+        from an FTP server.
+
         .. code-block:: pycon
 
             >>> from icalendar import Alarm
@@ -141,14 +142,14 @@ class Alarm(Component):
     changed in the alarm component. If the value of any "ACKNOWLEDGED" property
     in the alarm changes and is greater than or equal to the trigger time of the alarm,
     then clients SHOULD dismiss or cancel any "alert" presented to the calendar user.
-    """,  # noqa: E501
+    """,
     )
 
     TRIGGER = create_single_property(
         "TRIGGER",
         "dt",
         (datetime, timedelta),
-        Optional[Union[timedelta, datetime]],
+        timedelta | datetime | None,
         """Purpose:  This property specifies when an alarm will trigger.
 
     Value Type:  The default value type is DURATION.  The value type can
@@ -163,7 +164,7 @@ class Alarm(Component):
     )
 
     @property
-    def TRIGGER_RELATED(self) -> str:  # noqa: N802
+    def TRIGGER_RELATED(self) -> str:
         """The RELATED parameter of the TRIGGER property.
 
         Values are either "START" (default) or "END".
@@ -187,7 +188,7 @@ class Alarm(Component):
         return trigger.params.get("RELATED", "START")
 
     @TRIGGER_RELATED.setter
-    def TRIGGER_RELATED(self, value: str):  # noqa: N802
+    def TRIGGER_RELATED(self, value: str):
         """Set "START" or "END"."""
         trigger = self.get("TRIGGER")
         if trigger is None:
@@ -231,7 +232,7 @@ class Alarm(Component):
         ()
         >>> alarm.triggers.absolute
         ()
-        """  # noqa: E501
+        """
         start = []
         end = []
         absolute = []
@@ -267,14 +268,14 @@ class Alarm(Component):
     def new(
         cls,
         /,
-        attendees: Optional[list[vCalAddress]] = None,
+        attendees: list[vCalAddress] | None = None,
         concepts: CONCEPTS_TYPE_SETTER = None,
-        description: Optional[str] = None,
+        description: str | None = None,
         links: LINKS_TYPE_SETTER = None,
         refids: list[str] | str | None = None,
         related_to: RELATED_TO_TYPE_SETTER = None,
-        summary: Optional[str] = None,
-        uid: Optional[str | uuid.UUID] = None,
+        summary: str | None = None,
+        uid: str | uuid.UUID | None = None,
     ):
         """Create a new alarm with all required properties.
 
@@ -294,7 +295,8 @@ class Alarm(Component):
             :class:`Alarm`
 
         Raises:
-            ~error.InvalidCalendar: If the content is not valid according to :rfc:`5545`.
+            ~error.InvalidCalendar: If the content is not valid
+                according to :rfc:`5545`.
 
         .. warning:: As time progresses, we will be stricter with the validation.
         """
@@ -309,9 +311,11 @@ class Alarm(Component):
         alarm.uid = uid
         alarm.attendees = attendees
         return alarm
+
     @classmethod
-    def example(cls, name: str = "example") -> "Alarm":
+    def example(cls, name: str = "example") -> Alarm:
         """Return the alarm example with the given name."""
         return cls.from_ical(get_example("alarms", name))
+
 
 __all__ = ["Alarm"]

--- a/src/icalendar/cal/availability.py
+++ b/src/icalendar/cal/availability.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import TYPE_CHECKING
 
 from icalendar.attr import (
     CONCEPTS_TYPE_SETTER,
@@ -36,6 +36,7 @@ from icalendar.error import InvalidCalendar
 from .component import Component
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from datetime import date
 
     from icalendar.cal.available import Available
@@ -237,29 +238,29 @@ class Availability(Component):
     def new(
         cls,
         /,
-        busy_type: Optional[BUSYTYPE] = None,
+        busy_type: BUSYTYPE | None = None,
         categories: Sequence[str] = (),
         comments: list[str] | str | None = None,
         components: Sequence[Available] | None = (),
         concepts: CONCEPTS_TYPE_SETTER = None,
         contacts: list[str] | str | None = None,
-        created: Optional[date] = None,
-        classification: Optional[CLASS] = None,
-        description: Optional[str] = None,
-        end: Optional[datetime] = None,
-        last_modified: Optional[date] = None,
+        created: date | None = None,
+        classification: CLASS | None = None,
+        description: str | None = None,
+        end: datetime | None = None,
+        last_modified: date | None = None,
         links: LINKS_TYPE_SETTER = None,
-        location: Optional[str] = None,
-        organizer: Optional[vCalAddress | str] = None,
-        priority: Optional[int] = None,
+        location: str | None = None,
+        organizer: vCalAddress | str | None = None,
+        priority: int | None = None,
         refids: list[str] | str | None = None,
         related_to: RELATED_TO_TYPE_SETTER = None,
-        sequence: Optional[int] = None,
-        stamp: Optional[date] = None,
-        start: Optional[datetime] = None,
-        summary: Optional[str] = None,
-        uid: Optional[str | uuid.UUID] = None,
-        url: Optional[str] = None,
+        sequence: int | None = None,
+        stamp: date | None = None,
+        start: datetime | None = None,
+        summary: str | None = None,
+        uid: str | uuid.UUID | None = None,
+        url: str | None = None,
     ):
         """Create a new event with all required properties.
 
@@ -295,7 +296,8 @@ class Availability(Component):
             :class:`Availability`
 
         Raises:
-            ~error.InvalidCalendar: If the content is not valid according to :rfc:`7953`.
+            ~error.InvalidCalendar: If the content is not valid
+                according to :rfc:`7953`.
 
         .. warning:: As time progresses, we will be stricter with the validation.
         """

--- a/src/icalendar/cal/available.py
+++ b/src/icalendar/cal/available.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import TYPE_CHECKING
 
 from icalendar.attr import (
     CONCEPTS_TYPE_SETTER,
@@ -35,6 +35,7 @@ from icalendar.error import InvalidCalendar
 from .component import Component
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from datetime import date
 
 
@@ -101,19 +102,19 @@ class Available(Component):
         comments: list[str] | str | None = None,
         concepts: CONCEPTS_TYPE_SETTER = None,
         contacts: list[str] | str | None = None,
-        created: Optional[date] = None,
-        description: Optional[str] = None,
-        end: Optional[datetime] = None,
-        last_modified: Optional[date] = None,
+        created: date | None = None,
+        description: str | None = None,
+        end: datetime | None = None,
+        last_modified: date | None = None,
         links: LINKS_TYPE_SETTER = None,
-        location: Optional[str] = None,
+        location: str | None = None,
         refids: list[str] | str | None = None,
         related_to: RELATED_TO_TYPE_SETTER = None,
-        sequence: Optional[int] = None,
-        stamp: Optional[date] = None,
-        start: Optional[datetime] = None,
-        summary: Optional[str] = None,
-        uid: Optional[str | uuid.UUID] = None,
+        sequence: int | None = None,
+        stamp: date | None = None,
+        start: datetime | None = None,
+        summary: str | None = None,
+        uid: str | uuid.UUID | None = None,
     ):
         """Create a new Available component with all required properties.
 
@@ -149,7 +150,8 @@ class Available(Component):
             :class:`Available`
 
         Raises:
-            ~error.InvalidCalendar: If the content is not valid according to :rfc:`7953`.
+            ~error.InvalidCalendar: If the content is not valid
+                according to :rfc:`7953`.
 
         .. warning:: As time progresses, we will be stricter with the validation.
         """

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -98,12 +98,13 @@ class Calendar(Component):
     def from_ical(
         cls,
         st: bytes | str,
-        multiple: bool = False,  # noqa: FBT001
+        multiple: bool = False,
     ) -> Calendar | list[Calendar]:
         """Parse iCalendar data into Calendar instances.
 
-        Wraps :meth:`Component.from_ical() <icalendar.cal.component.Component.from_ical>` with
-        timezone forward-reference resolution and VTIMEZONE caching.
+        Wraps :meth:`Component.from_ical()
+        <icalendar.cal.component.Component.from_ical>` with timezone
+        forward-reference resolution and VTIMEZONE caching.
 
         Parameters:
             st: iCalendar data as bytes or string
@@ -431,7 +432,7 @@ Example:
     .. code-block:: text
 
         -//ABC Corporation//NONSGML My Product//EN
-""",  # noqa: E501
+""",
     )
     version = single_string_property(
         "VERSION",
@@ -467,7 +468,7 @@ Description:
     specified in the iCalendar object.  It is expected that other
     calendar scales will be defined in other specifications or by
     future versions of this memo.
-        """,  # noqa: E501
+        """,
         default="GREGORIAN",
     )
     method = single_string_property(
@@ -490,7 +491,7 @@ Description:
     iCalendar object is merely being used to transport a snapshot of
     some calendar information; without the intention of conveying a
     scheduling semantic.
-""",  # noqa: E501
+""",
     )
     url = url_property
     source = source_property
@@ -601,7 +602,7 @@ Description:
             ~error.InvalidCalendar: If the content is not valid according to :rfc:`5545`.
 
         .. warning:: As time progresses, we will be stricter with the validation.
-        """  # noqa: E501
+        """
         calendar: Calendar = super().new(
             last_modified=last_modified,
             links=links,

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -110,7 +110,8 @@ class Component(CaselessDict):
         """Register a custom component class.
 
         Parameters:
-            component_class: Component subclass to register. Must have a ``name`` attribute.
+            component_class: Component subclass to register.
+                Must have a ``name`` attribute.
 
         Raises:
             ValueError: If ``component_class`` has no ``name`` attribute.
@@ -138,7 +139,8 @@ class Component(CaselessDict):
         existing = cls._components_factory.get(component_class.name)
         if existing is not None and existing is not component_class:
             raise ValueError(
-                f"Component '{component_class.name}' is already registered as {existing}"
+                f"Component '{component_class.name}' is already registered"
+                f" as {existing}"
             )
 
         cls._components_factory.add_component_class(component_class)
@@ -267,7 +269,7 @@ class Component(CaselessDict):
         name: str,
         value,
         parameters: dict[str, str] | Parameters = None,
-        encode: bool = True,  # noqa: FBT001
+        encode: bool = True,
     ):
         """Add a property.
 
@@ -389,7 +391,7 @@ class Component(CaselessDict):
         if (name is None or self.name == name) and select(self):
             result.append(self)
         for subcomponent in self.subcomponents:
-            result += subcomponent._walk(name, select)  # noqa: SLF001
+            result += subcomponent._walk(name, select)
         return result
 
     def walk(self, name=None, select=lambda _: True) -> list[Component]:
@@ -423,7 +425,7 @@ class Component(CaselessDict):
     def property_items(
         self,
         recursive=True,
-        sorted: bool = True,  # noqa: A002, FBT001
+        sorted: bool = True,
     ) -> list[tuple[str, object]]:
         """Returns properties in this component and subcomponents as:
         [(name, value), ...]
@@ -449,14 +451,18 @@ class Component(CaselessDict):
 
     @overload
     @classmethod
-    def from_ical(cls, st: str | bytes, multiple: Literal[False] = False) -> Component: ...
+    def from_ical(
+        cls, st: str | bytes, multiple: Literal[False] = False
+    ) -> Component: ...
 
     @overload
     @classmethod
     def from_ical(cls, st: str | bytes, multiple: Literal[True]) -> list[Component]: ...
 
     @classmethod
-    def from_ical(cls, st: str | bytes, multiple: bool = False) -> Component | list[Component]:  # noqa: FBT001
+    def from_ical(
+        cls, st: str | bytes, multiple: bool = False
+    ) -> Component | list[Component]:
         """Parse iCalendar data into component instances.
 
         Handles standard and custom components (``X-*``, IANA-registered).
@@ -549,7 +555,9 @@ class Component(CaselessDict):
                 if name.upper() == "CATEGORIES":
                     # Special handling for CATEGORIES - need raw value
                     # before unescaping to properly split on unescaped commas
-                    from icalendar.parser import split_on_unescaped_comma
+                    from icalendar.parser import (
+                        split_on_unescaped_comma,
+                    )
 
                     line_str = str(line)
                     # Use rfind to get the last colon (value separator)
@@ -557,8 +565,9 @@ class Component(CaselessDict):
                     colon_idx = line_str.rfind(":")
                     if colon_idx > 0:
                         raw_value = line_str[colon_idx + 1 :]
-                        # Parse categories immediately (not lazily) for both strict and tolerant components
-                        # This is because CATEGORIES needs special comma handling
+                        # Parse categories immediately (not lazily) for both
+                        # strict and tolerant components.
+                        # CATEGORIES needs special comma handling
                         try:
                             category_list = split_on_unescaped_comma(raw_value)
                             vals_inst = factory(category_list)
@@ -633,12 +642,12 @@ class Component(CaselessDict):
             return f"{error_description}: {bad_input[:truncate_to]} {elipsis}"
         return f"{error_description}: {bad_input}"
 
-    def content_line(self, name, value, sorted: bool = True):  # noqa: A002, FBT001
+    def content_line(self, name, value, sorted: bool = True):
         """Returns property as content line."""
         params = getattr(value, "params", Parameters())
         return Contentline.from_parts(name, params, value, sorted=sorted)
 
-    def content_lines(self, sorted: bool = True):  # noqa: A002, FBT001
+    def content_lines(self, sorted: bool = True):
         """Converts the Component and subcomponents into content lines."""
         contentlines = Contentlines()
         for name, value in self.property_items(sorted=sorted):
@@ -647,7 +656,7 @@ class Component(CaselessDict):
         contentlines.append("")  # remember the empty string in the end
         return contentlines
 
-    def to_ical(self, sorted: bool = True):  # noqa: A002, FBT001
+    def to_ical(self, sorted: bool = True):
         """
         :param sorted: Whether parameters and properties should be
                        lexicographically sorted.
@@ -756,7 +765,7 @@ class Component(CaselessDict):
         del self.CREATED
 
     def is_thunderbird(self) -> bool:
-        """Whether this component has attributes that indicate that Mozilla Thunderbird created it."""  # noqa: E501
+        """Whether this component has attributes that indicate that Mozilla Thunderbird created it."""
         return any(attr.startswith("X-MOZ-") for attr in self.keys())
 
     @staticmethod
@@ -824,9 +833,11 @@ class Component(CaselessDict):
             stamp: The :attr:`DTSTAMP` of the component.
 
         Raises:
-            ~error.InvalidCalendar: If the content is not valid according to :rfc:`5545`.
+            ~error.InvalidCalendar: If the content is not valid
+                according to :rfc:`5545`.
 
-        .. warning:: As time progresses, we will be stricter with the validation.
+        .. warning:: As time progresses, we will be stricter with the
+            validation.
         """
         component = cls()
         component.DTSTAMP = stamp
@@ -972,7 +983,7 @@ class Component(CaselessDict):
                 component.subcomponents.append(cls.from_jcal(subcomponent))
         return component
 
-    def copy(self, recursive:bool=False) -> Self:  # noqa: FBT001
+    def copy(self, recursive: bool = False) -> Self:
         """Copy the component.
 
         Parameters:

--- a/src/icalendar/cal/component_factory.py
+++ b/src/icalendar/cal/component_factory.py
@@ -34,7 +34,9 @@ class ComponentFactory(CaselessDict):
         >>> custom_class()
         X-VENDOR({})
 
-    If a component class is not yet supported, it can be either created using :meth:`get_component_class` or added manually as a subclass of :class:`~icalendar.cal.component.Component`.
+    If a component class is not yet supported, it can be either created
+    using :meth:`get_component_class` or added manually as a subclass of
+    :class:`~icalendar.cal.component.Component`.
     See :doc:`/how-to/custom-components` for details.
     """
 
@@ -48,7 +50,11 @@ class ComponentFactory(CaselessDict):
         from icalendar.cal.event import Event
         from icalendar.cal.free_busy import FreeBusy
         from icalendar.cal.journal import Journal
-        from icalendar.cal.timezone import Timezone, TimezoneDaylight, TimezoneStandard
+        from icalendar.cal.timezone import (
+            Timezone,
+            TimezoneDaylight,
+            TimezoneStandard,
+        )
         from icalendar.cal.todo import Todo
 
         self.add_component_class(Calendar)

--- a/src/icalendar/cal/event.py
+++ b/src/icalendar/cal/event.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import date, datetime, timedelta
-from typing import TYPE_CHECKING, Literal, Sequence
+from typing import TYPE_CHECKING, Literal
 
 from icalendar.attr import (
     CONCEPTS_TYPE_SETTER,
@@ -49,6 +49,8 @@ from icalendar.cal.component import Component
 from icalendar.cal.examples import get_example
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from icalendar.alarms import Alarms
     from icalendar.enums import CLASS, STATUS, TRANSP
     from icalendar.prop import vCalAddress
@@ -272,14 +274,14 @@ class Event(Component):
         "dt",
         (datetime, date),
         date,
-        'The "DTSTART" property for a "VEVENT" specifies the inclusive start of the event.',  # noqa: E501
+        'The "DTSTART" property for a "VEVENT" specifies the inclusive start of the event.',
     )
     DTEND = create_single_property(
         "DTEND",
         "dt",
         (datetime, date),
         date,
-        'The "DTEND" property for a "VEVENT" calendar component specifies the non-inclusive end of the event.',  # noqa: E501
+        'The "DTEND" property for a "VEVENT" calendar component specifies the non-inclusive end of the event.',
     )
 
     def _get_start_end_duration(self):
@@ -491,7 +493,8 @@ class Event(Component):
             :class:`Event`
 
         Raises:
-            ~error.InvalidCalendar: If the content is not valid according to :rfc:`5545`.
+            ~error.InvalidCalendar: If the content is not valid
+                according to :rfc:`5545`.
 
         .. warning:: As time progresses, we will be stricter with the validation.
         """

--- a/src/icalendar/cal/free_busy.py
+++ b/src/icalendar/cal/free_busy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import date, datetime, timedelta
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from icalendar.attr import (
     CONCEPTS_TYPE_SETTER,
@@ -72,18 +72,18 @@ class FreeBusy(Component):
         "dt",
         (datetime, date),
         date,
-        'The "DTSTART" property for a "VFREEBUSY" specifies the inclusive start of the component.',  # noqa: E501
+        'The "DTSTART" property for a "VFREEBUSY" specifies the inclusive start of the component.',
     )
     end = DTEND = create_single_property(
         "DTEND",
         "dt",
         (datetime, date),
         date,
-        'The "DTEND" property for a "VFREEBUSY" calendar component specifies the non-inclusive end of the component.',  # noqa: E501
+        'The "DTEND" property for a "VFREEBUSY" calendar component specifies the non-inclusive end of the component.',
     )
 
     @property
-    def duration(self) -> Optional[timedelta]:
+    def duration(self) -> timedelta | None:
         """The duration computed from start and end."""
         if self.DTSTART is None or self.DTEND is None:
             return None
@@ -96,15 +96,15 @@ class FreeBusy(Component):
         comments: list[str] | str | None = None,
         concepts: CONCEPTS_TYPE_SETTER = None,
         contacts: list[str] | str | None = None,
-        end: Optional[date | datetime] = None,
+        end: date | datetime | None = None,
         links: LINKS_TYPE_SETTER = None,
-        organizer: Optional[vCalAddress | str] = None,
+        organizer: vCalAddress | str | None = None,
         refids: list[str] | str | None = None,
         related_to: RELATED_TO_TYPE_SETTER = None,
-        stamp: Optional[date] = None,
-        start: Optional[date | datetime] = None,
-        uid: Optional[str | uuid.UUID] = None,
-        url: Optional[str] = None,
+        stamp: date | None = None,
+        start: date | datetime | None = None,
+        uid: str | uuid.UUID | None = None,
+        url: str | None = None,
     ):
         """Create a new alarm with all required properties.
 
@@ -130,7 +130,8 @@ class FreeBusy(Component):
             :class:`FreeBusy`
 
         Raises:
-            ~error.InvalidCalendar: If the content is not valid according to :rfc:`5545`.
+            ~error.InvalidCalendar: If the content is not valid
+                according to :rfc:`5545`.
 
         .. warning:: As time progresses, we will be stricter with the validation.
         """

--- a/src/icalendar/cal/journal.py
+++ b/src/icalendar/cal/journal.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import date, datetime, timedelta
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import TYPE_CHECKING
 
 from icalendar.attr import (
     CONCEPTS_TYPE_SETTER,
@@ -32,6 +32,8 @@ from icalendar.cal.component import Component
 from icalendar.error import IncompleteComponent
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from icalendar.enums import CLASS, STATUS
     from icalendar.prop import vCalAddress
 
@@ -104,7 +106,7 @@ class Journal(Component):
         "dt",
         (datetime, date),
         date,
-        'The "DTSTART" property for a "VJOURNAL" that specifies the exact date at which the journal entry was made.',  # noqa: E501
+        'The "DTSTART" property for a "VJOURNAL" that specifies the exact date at which the journal entry was made.',
     )
 
     @property
@@ -162,7 +164,7 @@ class Journal(Component):
         return "\r\n\r\n".join(descriptions)
 
     @description.setter
-    def description(self, description: Optional[str]):
+    def description(self, description: str | None):
         """Set the description"""
         self.descriptions = description
 
@@ -177,27 +179,27 @@ class Journal(Component):
     def new(
         cls,
         /,
-        attendees: Optional[list[vCalAddress]] = None,
+        attendees: list[vCalAddress] | None = None,
         categories: Sequence[str] = (),
-        classification: Optional[CLASS] = None,
-        color: Optional[str] = None,
+        classification: CLASS | None = None,
+        color: str | None = None,
         comments: list[str] | str | None = None,
         concepts: CONCEPTS_TYPE_SETTER = None,
         contacts: list[str] | str | None = None,
-        created: Optional[date] = None,
-        description: Optional[str | Sequence[str]] = None,
-        last_modified: Optional[date] = None,
+        created: date | None = None,
+        description: str | Sequence[str] | None = None,
+        last_modified: date | None = None,
         links: LINKS_TYPE_SETTER = None,
-        organizer: Optional[vCalAddress | str] = None,
+        organizer: vCalAddress | str | None = None,
         refids: list[str] | str | None = None,
         related_to: RELATED_TO_TYPE_SETTER = None,
-        sequence: Optional[int] = None,
-        stamp: Optional[date] = None,
-        start: Optional[date | datetime] = None,
-        status: Optional[STATUS] = None,
-        summary: Optional[str] = None,
-        uid: Optional[str | uuid.UUID] = None,
-        url: Optional[str] = None,
+        sequence: int | None = None,
+        stamp: date | None = None,
+        start: date | datetime | None = None,
+        status: STATUS | None = None,
+        summary: str | None = None,
+        uid: str | uuid.UUID | None = None,
+        url: str | None = None,
     ):
         """Create a new journal entry with all required properties.
 
@@ -234,7 +236,8 @@ class Journal(Component):
             :class:`Journal`
 
         Raises:
-            ~error.InvalidCalendar: If the content is not valid according to :rfc:`5545`.
+            ~error.InvalidCalendar: If the content is not valid
+                according to :rfc:`5545`.
 
         .. warning:: As time progresses, we will be stricter with the validation.
         """

--- a/src/icalendar/cal/timezone.py
+++ b/src/icalendar/cal/timezone.py
@@ -118,7 +118,7 @@ class Timezone(Component):
         tznames.add(tzname)
         return tzname
 
-    def to_tz(self, tzp: TZP = tzp, lookup_tzid: bool = True):  # noqa: FBT001
+    def to_tz(self, tzp: TZP = tzp, lookup_tzid: bool = True):
         """convert this VTIMEZONE component to a timezone object
 
         :param tzp: timezone provider to use
@@ -260,7 +260,7 @@ class Timezone(Component):
 
         .. note::
             This can take some time. Please cache the results.
-        """  # noqa: E501
+        """
         if tzid is None:
             tzid = tzid_from_tzinfo(timezone)
             if tzid is None:
@@ -268,8 +268,8 @@ class Timezone(Component):
                     f"Cannot get TZID from {timezone}. Please set the tzid parameter."
                 )
         normalize = getattr(timezone, "normalize", lambda dt: dt)  # pytz compatibility
-        first_datetime = datetime(first_date.year, first_date.month, first_date.day)  # noqa: DTZ001
-        last_datetime = datetime(last_date.year, last_date.month, last_date.day)  # noqa: DTZ001
+        first_datetime = datetime(first_date.year, first_date.month, first_date.day)
+        last_datetime = datetime(last_date.year, last_date.month, last_date.day)
         if hasattr(timezone, "localize"):  # pytz compatibility
             first_datetime = timezone.localize(first_datetime)
             last_datetime = timezone.localize(last_datetime)
@@ -287,7 +287,7 @@ class Timezone(Component):
             end = start
             offset_to = end.utcoffset()
             for add_offset in cls._from_tzinfo_skip_search:
-                last_end = end  # we need to save this as we might be left and right of the time change  # noqa: E501
+                last_end = end  # we need to save this as we might be left and right of the time change
                 end = normalize(end + add_offset)
                 try:
                     while end.utcoffset() == offset_to:
@@ -317,10 +317,10 @@ class Timezone(Component):
             first_start = min(starts)
             starts.remove(first_start)
             if first_start.date() == last_date:
-                first_start = datetime(last_date.year, last_date.month, last_date.day)  # noqa: DTZ001
+                first_start = datetime(last_date.year, last_date.month, last_date.day)
             subcomponent = TimezoneStandard() if is_standard else TimezoneDaylight()
             if offset_from is None:
-                offset_from = offset_to  # noqa: PLW2901
+                offset_from = offset_to
             subcomponent.TZOFFSETFROM = offset_from
             subcomponent.TZOFFSETTO = offset_to
             subcomponent.add("TZNAME", tzname)

--- a/src/icalendar/cal/todo.py
+++ b/src/icalendar/cal/todo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import date, datetime, timedelta
-from typing import TYPE_CHECKING, Literal, Sequence
+from typing import TYPE_CHECKING, Literal
 
 from icalendar.attr import (
     CONCEPTS_TYPE_SETTER,
@@ -48,6 +48,8 @@ from icalendar.cal.component import Component
 from icalendar.cal.examples import get_example
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from icalendar.alarms import Alarms
     from icalendar.enums import CLASS, STATUS
     from icalendar.prop import vCalAddress
@@ -149,14 +151,14 @@ class Todo(Component):
         "dt",
         (datetime, date),
         date,
-        'The "DTSTART" property for a "VTODO" specifies the inclusive start of the Todo.',  # noqa: E501
+        'The "DTSTART" property for a "VTODO" specifies the inclusive start of the Todo.',
     )
     DUE = create_single_property(
         "DUE",
         "dt",
         (datetime, date),
         date,
-        'The "DUE" property for a "VTODO" calendar component specifies the non-inclusive end of the Todo.',  # noqa: E501
+        'The "DUE" property for a "VTODO" calendar component specifies the non-inclusive end of the Todo.',
     )
     DURATION = property(
         property_get_duration,
@@ -378,7 +380,8 @@ class Todo(Component):
             :class:`Todo`
 
         Raises:
-            ~error.InvalidCalendar: If the content is not valid according to :rfc:`5545`.
+            ~error.InvalidCalendar: If the content is not valid
+                according to :rfc:`5545`.
 
         .. warning:: As time progresses, we will be stricter with the validation.
         """
@@ -413,11 +416,11 @@ class Todo(Component):
         if cls._validate_new:
             cls._validate_start_and_end(start, end)
         return todo
-    
-  
+
     @classmethod
-    def example(cls, name: str = "example") -> "Todo":
+    def example(cls, name: str = "example") -> Todo:
         """Return the todo example with the given name."""
         return cls.from_ical(get_example("todos", name))
+
 
 __all__ = ["Todo"]


### PR DESCRIPTION
## Summary
- Modernize type annotations: `Optional[X]` → `X | None`, `Union[X, Y]` → `X | Y`
- Remove deprecated `typing` imports (`Optional`, `Union`, `Sequence`)
- Wrap long docstring lines
- Add per-file-ignores for `cal/` in pyproject.toml

Related to #672