### PR TITLE
Ruff format and lint prop/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,9 +240,16 @@ extend-safe-fixes = [
     "PLW2901", # loop variable overwritten
     "SLF001",  # private member access
 ]
-"src/icalendar/prop/*.py" = [
+"src/icalendar/prop/**" = [
+    "DTZ001",  # datetime() called without tzinfo
+    "DTZ007",  # naive datetime from strptime
+    "E501",    # line too long (docstrings with code examples)
+    "FBT003",  # boolean positional value in function call
     "N801",    # Class name should use CamelCase
-    "PLC0415", # Import property within class
+    "PERF203", # try-except in loop
+    "PLC0415", # import outside top-level (circular import avoidance)
+    "PLW1641", # eq without hash (mutable structured types)
+    "PLW2901", # loop variable overwritten
 ]
 "src/icalendar/fuzzing/*" = [
     "T201",   # print found

--- a/src/icalendar/prop/adr.py
+++ b/src/icalendar/prop/adr.py
@@ -1,4 +1,5 @@
 """ADR property of :rfc:`6350`."""
+
 from typing import Any, ClassVar, NamedTuple
 
 from icalendar.compatibility import Self
@@ -44,7 +45,8 @@ class vAdr:
     -   postal code
     -   country name (full name)
 
-    When a component value is missing, the associated component separator MUST still be specified.
+    When a component value is missing, the associated component separator
+    MUST still be specified.
 
     Semicolons are field separators and are NOT escaped.
     Commas and backslashes within field values ARE escaped per :rfc:`6350`.
@@ -92,6 +94,7 @@ class vAdr:
         # Each field is vText (handles comma/backslash escaping)
         # but we join with unescaped semicolons (field separators)
         from icalendar.prop.text import vText
+
         parts = [vText(f).to_ical().decode(DEFAULT_ENCODING) for f in self.fields]
         return ";".join(parts).encode(DEFAULT_ENCODING)
 
@@ -163,7 +166,6 @@ class vAdr:
     def examples(cls) -> list[Self]:
         """Examples of vAdr."""
         return [cls(("", "", "123 Main St", "Springfield", "IL", "62701", "USA"))]
-
 
 
 __all__ = ["AdrFields", "vAdr"]

--- a/src/icalendar/prop/boolean.py
+++ b/src/icalendar/prop/boolean.py
@@ -73,8 +73,8 @@ class vBoolean(int):
     def examples(cls) -> list[Self]:
         """Examples of vBoolean."""
         return [
-            cls(True),  # noqa: FBT003
-            cls(False),  # noqa: FBT003
+            cls(True),
+            cls(False),
         ]
 
     from icalendar.param import VALUE

--- a/src/icalendar/prop/broken.py
+++ b/src/icalendar/prop/broken.py
@@ -1,6 +1,5 @@
 """Parsing error value preservation."""
 
-
 from typing import Any, ClassVar
 
 from icalendar.compatibility import Self
@@ -71,5 +70,6 @@ class vBrokenProperty(vText):
                 parse_error="Invalid date format",
             )
         ]
+
 
 __all__ = ["vBrokenProperty"]

--- a/src/icalendar/prop/dt/date.py
+++ b/src/icalendar/prop/dt/date.py
@@ -111,7 +111,7 @@ class vDate(TimeBase):
         """
         JCalParsingError.validate_value_type(jcal, str, cls)
         try:
-            return datetime.strptime(jcal, "%Y-%m-%d").date()  # noqa: DTZ007
+            return datetime.strptime(jcal, "%Y-%m-%d").date()
         except ValueError as e:
             raise JCalParsingError("Cannot parse date.", cls, value=jcal) from e
 

--- a/src/icalendar/prop/dt/datetime.py
+++ b/src/icalendar/prop/dt/datetime.py
@@ -126,11 +126,11 @@ class vDatetime(TimeBase):
                 int(ical[13:15]),  # second
             )
             if tzinfo:
-                return tzp.localize(datetime(*timetuple), tzinfo)  # noqa: DTZ001
+                return tzp.localize(datetime(*timetuple), tzinfo)
             if not ical[15:]:
-                return datetime(*timetuple)  # noqa: DTZ001
+                return datetime(*timetuple)
             if ical[15:16] == "Z":
-                return tzp.localize_utc(datetime(*timetuple))  # noqa: DTZ001
+                return tzp.localize_utc(datetime(*timetuple))
         except Exception as e:
             raise ValueError(f"Wrong datetime format: {ical}") from e
         raise ValueError(f"Wrong datetime format: {ical}")
@@ -138,7 +138,7 @@ class vDatetime(TimeBase):
     @classmethod
     def examples(cls) -> list[Self]:
         """Examples of vDatetime."""
-        return [cls(datetime(2025, 11, 10, 16, 52))]  # noqa: DTZ001
+        return [cls(datetime(2025, 11, 10, 16, 52))]
 
     from icalendar.param import VALUE
 
@@ -165,7 +165,7 @@ class vDatetime(TimeBase):
         if utc:
             jcal = jcal[:-1]
         try:
-            dt = datetime.strptime(jcal, "%Y-%m-%dT%H:%M:%S")  # noqa: DTZ007
+            dt = datetime.strptime(jcal, "%Y-%m-%dT%H:%M:%S")
         except ValueError as e:
             raise JCalParsingError("Cannot parse date-time.", cls, value=jcal) from e
         if utc:

--- a/src/icalendar/prop/dt/list.py
+++ b/src/icalendar/prop/dt/list.py
@@ -62,7 +62,7 @@ class vDDDLists:
     @classmethod
     def examples(cls) -> list[Self]:
         """Examples of vDDDLists."""
-        return [vDDDLists([datetime(2025, 11, 10, 16, 50)])]  # noqa: DTZ001
+        return [vDDDLists([datetime(2025, 11, 10, 16, 50)])]
 
     def to_jcal(self, name: str) -> list:
         """The jCal representation of this property according to :rfc:`7265`."""

--- a/src/icalendar/prop/dt/period.py
+++ b/src/icalendar/prop/dt/period.py
@@ -158,8 +158,8 @@ class vPeriod(TimeBase):
     def examples(cls) -> list[Self]:
         """Examples of vPeriod."""
         return [
-            vPeriod((datetime(2025, 11, 10, 16, 35), timedelta(hours=1, minutes=30))),  # noqa: DTZ001
-            vPeriod((datetime(2025, 11, 10, 16, 35), datetime(2025, 11, 10, 18, 5))),  # noqa: DTZ001
+            vPeriod((datetime(2025, 11, 10, 16, 35), timedelta(hours=1, minutes=30))),
+            vPeriod((datetime(2025, 11, 10, 16, 35), datetime(2025, 11, 10, 18, 5))),
         ]
 
     from icalendar.param import VALUE

--- a/src/icalendar/prop/dt/types.py
+++ b/src/icalendar/prop/dt/types.py
@@ -153,7 +153,7 @@ class vDDDTypes(TimeBase):
         for jcal_type in (vDatetime, vDate, vTime, vDuration):
             try:
                 return jcal_type.parse_jcal_value(jcal)
-            except JCalParsingError:  # noqa: PERF203
+            except JCalParsingError:
                 pass
         raise JCalParsingError(
             "Cannot parse date, time, date-time, duration, or period.", cls, value=jcal

--- a/src/icalendar/prop/image.py
+++ b/src/icalendar/prop/image.py
@@ -51,8 +51,8 @@ class Image:
             raise TypeError("Value must be URI or BINARY.")
         try:
             value_type = value.params.get("VALUE", "").upper()
-        except (AttributeError, TypeError):
-            raise TypeError("Value must have a valid params attribute.")
+        except (AttributeError, TypeError) as err:
+            raise TypeError("Value must have a valid params attribute.") from err
         if value_type == "URI" or isinstance(value, vUri):
             params["uri"] = str(value)
         elif isinstance(value, vBinary):

--- a/src/icalendar/prop/n.py
+++ b/src/icalendar/prop/n.py
@@ -1,6 +1,5 @@
 """N property from :rfc:`6350`."""
 
-
 from typing import Any, ClassVar, NamedTuple
 
 from icalendar.compatibility import Self
@@ -87,6 +86,7 @@ class vN:
     def to_ical(self) -> bytes:
         """Generate vCard format with semicolon-separated fields."""
         from icalendar.prop.text import vText
+
         parts = [vText(f).to_ical().decode(DEFAULT_ENCODING) for f in self.fields]
         return ";".join(parts).encode(DEFAULT_ENCODING)
 
@@ -156,5 +156,6 @@ class vN:
     def examples(cls) -> list[Self]:
         """Examples of vN."""
         return [cls(("Doe", "John", "M.", "Dr.", "Jr."))]
+
 
 __all__ = ["NFields", "vN"]

--- a/src/icalendar/prop/org.py
+++ b/src/icalendar/prop/org.py
@@ -1,6 +1,5 @@
 """The ORG property from :rfc:`6350`."""
 
-
 from typing import Any, ClassVar
 
 from icalendar.compatibility import Self
@@ -12,10 +11,12 @@ from icalendar.parser_tools import DEFAULT_ENCODING, to_unicode
 class vOrg:
     r"""vCard ORG (Organization) structured property per :rfc:`6350#section-6.6.4`.
 
-    The ORG property specifies the organizational name and units associated with the vCard.
+    The ORG property specifies the organizational name and units
+    associated with the vCard.
 
-    Its value is a structured type consisting of components separated by semicolons.
-    The components are the organization name, followed by zero or more levels of organizational unit names:
+    Its value is a structured type consisting of components separated
+    by semicolons. The components are the organization name, followed
+    by zero or more levels of organizational unit names:
 
     .. code-block:: text
 
@@ -71,6 +72,7 @@ class vOrg:
     def to_ical(self) -> bytes:
         """Generate vCard format with semicolon-separated fields."""
         from icalendar.prop.text import vText
+
         parts = [vText(f).to_ical().decode(DEFAULT_ENCODING) for f in self.fields]
         return ";".join(parts).encode(DEFAULT_ENCODING)
 
@@ -136,8 +138,9 @@ class vOrg:
         JCalParsingError.validate_property(jcal_property, cls)
         if len(jcal_property) < 4:  # name, params, value_type, at least 1 field
             raise JCalParsingError(
-                f"ORG must have at least 4 elements (name, params, value_type, org name), "
-                f"got {len(jcal_property)}"
+                "ORG must have at least 4 elements"
+                " (name, params, value_type, org name),"
+                f" got {len(jcal_property)}"
             )
         for i, field in enumerate(jcal_property[3:], start=3):
             JCalParsingError.validate_value_type(field, str, cls, i)
@@ -150,5 +153,6 @@ class vOrg:
     def examples(cls) -> list[Self]:
         """Examples of vOrg."""
         return [cls(("ABC Inc.", "North American Division", "Marketing"))]
+
 
 __all__ = ["vOrg"]

--- a/src/icalendar/prop/recur/recur.py
+++ b/src/icalendar/prop/recur/recur.py
@@ -98,7 +98,7 @@ class vRecur(CaselessDict):
             >>> event.add('RRULE', 'FREQ=DAILY;COUNT=10')
             >>> event.rrules
             [vRecur({'FREQ': ['DAILY'], 'COUNT': [10]})]
-    """  # noqa: E501
+    """
 
     default_value: ClassVar[str] = "RECUR"
     params: Parameters
@@ -177,7 +177,7 @@ class vRecur(CaselessDict):
         for key, vals in self.sorted_items():
             typ = self.types.get(key, vText)
             if not isinstance(vals, SEQUENCE_TYPES):
-                vals = [vals]  # noqa: PLW2901
+                vals = [vals]
             param_vals = b",".join(typ(val).to_ical() for val in vals)
 
             # CaselessDict keys are always unicode

--- a/src/icalendar/prop/uid.py
+++ b/src/icalendar/prop/uid.py
@@ -1,6 +1,5 @@
 """UID values from :rfc:`9253`."""
 
-
 import uuid
 from typing import ClassVar
 
@@ -50,5 +49,6 @@ class vUid(vText):
     def examples(cls) -> list[Self]:
         """Examples of vUid."""
         return [cls("d755cef5-2311-46ed-a0e1-6733c9e15c63")]
+
 
 __all__ = ["vUid"]

--- a/src/icalendar/prop/unknown.py
+++ b/src/icalendar/prop/unknown.py
@@ -1,6 +1,5 @@
 """UNKNOWN values from :rfc:`7265`."""
 
-
 from typing import ClassVar
 
 from icalendar.compatibility import Self
@@ -22,5 +21,6 @@ class vUnknown(vText):
         return [vUnknown("Some property text.")]
 
     from icalendar.param import VALUE
+
 
 __all__ = ["vUnknown"]


### PR DESCRIPTION
## Summary
- Apply ruff formatting and fix lint warnings across `prop/` and subdirectories
- Fix B904 raise-without-from in `image.py`
- Wrap long docstring lines in `adr.py`, `n.py`, `org.py`
- Add per-file-ignores for `prop/**` (DTZ001, DTZ007, E501, FBT003, PLW1641, PLW2901, PERF203, PLC0415, N801)
- Remove unused noqa directives

Related to #672