### PR TITLE
Fix ruff 0.15 warnings in tests

### DIFF
--- a/src/icalendar/tests/conftest.py
+++ b/src/icalendar/tests/conftest.py
@@ -206,7 +206,7 @@ ICS_FILES = [
         CALENDARS_FOLDER.iterdir(), TIMEZONES_FOLDER.iterdir(), EVENTS_FOLDER.iterdir()
     )
     if file.name not in BROKEN_SOURCE_FILES
-    and file.suffix in (".ics",)
+    and file.suffix == ".ics"
     and FUZZ_TESTCASES_BROKEN_CALENDARS not in file.name
 ]
 
@@ -216,7 +216,7 @@ JCAL_FILES = [
         CALENDARS_FOLDER.iterdir(), TIMEZONES_FOLDER.iterdir(), EVENTS_FOLDER.iterdir()
     )
     if file.name not in BROKEN_SOURCE_FILES
-    and file.suffix in (".jcal",)
+    and file.suffix == ".jcal"
     and FUZZ_TESTCASES_BROKEN_CALENDARS not in file.name
 ]
 

--- a/src/icalendar/tests/prop/test_vBinary.py
+++ b/src/icalendar/tests/prop/test_vBinary.py
@@ -39,7 +39,7 @@ def test_repr():
 
 
 def test_from_ical():
-    with pytest.raises(ValueError, match="Not valid base 64 encoding."):
+    with pytest.raises(ValueError, match=r"Not valid base 64 encoding\."):
         vBinary.from_ical("value")
-    with pytest.raises(ValueError, match="Not valid base 64 encoding."):
+    with pytest.raises(ValueError, match=r"Not valid base 64 encoding\."):
         vBinary.from_ical("áèਮ")

--- a/src/icalendar/tests/rfc_7265_jcal/test_invalid_jcal.py
+++ b/src/icalendar/tests/rfc_7265_jcal/test_invalid_jcal.py
@@ -69,7 +69,8 @@ def test_component_is_too_short_or_too_long(length):
 
     """
     with pytest.raises(
-        JCalParsingError, match="in Component: A component must be a list with 3 items."
+        JCalParsingError,
+        match=r"in Component: A component must be a list with 3 items\.",
     ):
         Component.from_jcal(["vevent", [], [], [], []][:length])
 
@@ -79,12 +80,12 @@ def test_invalid_component_type(list_expected):
     if isinstance(list_expected, str):
         return  # skip JSON
     with pytest.raises(
-        JCalParsingError, match="Component: A component must be a list with 3 items."
+        JCalParsingError, match=r"Component: A component must be a list with 3 items\."
     ):
         Component.from_jcal(list_expected)
     with pytest.raises(
         JCalParsingError,
-        match="\\[2\\]\\[0\\] in Calendar: A component must be a list.",
+        match=r"\[2\]\[0\] in Calendar: A component must be a list with 3 items\.",
     ):
         Component.from_jcal(["VCALENDAR", [], [list_expected]])
 
@@ -92,7 +93,7 @@ def test_invalid_component_type(list_expected):
 def test_invalid_component_name(str_expected):
     """Test the component name."""
     with pytest.raises(
-        JCalParsingError, match="\\[0\\] in Component: The name must be a string."
+        JCalParsingError, match=r"\[0\] in Component: The name must be a string\."
     ):
         Component.from_jcal([str_expected, [], []])
 
@@ -100,7 +101,7 @@ def test_invalid_component_name(str_expected):
 def test_invalid_component_properties(list_expected):
     """Test the component properties."""
     with pytest.raises(
-        JCalParsingError, match="\\[1\\] in Alarm: The properties must be a list."
+        JCalParsingError, match=r"\[1\] in Alarm: The properties must be a list\."
     ):
         Component.from_jcal(["valarm", list_expected, []])
 
@@ -108,7 +109,7 @@ def test_invalid_component_properties(list_expected):
 def test_invalid_component_subcomponents(list_expected):
     """Test the component subcomponents."""
     with pytest.raises(
-        JCalParsingError, match="\\[2\\] in Todo: The subcomponents must be a list."
+        JCalParsingError, match=r"\[2\] in Todo: The subcomponents must be a list\."
     ):
         Component.from_jcal(["vtodo", [], list_expected])
 
@@ -118,7 +119,7 @@ def test_invalid_component_property(list_expected, i):
     """Test the component properties."""
     with pytest.raises(
         JCalParsingError,
-        match=f"\\[1\\]\\[{i}\\] in Event: The property must be a list with at least 4 items.",
+        match=rf"\[1\]\[{i}\] in Event: The property must be a list with at least 4 items\.",
     ):
         Component.from_jcal(
             ["vevent", [["x-x", {}, "unknown", ""]] * i + [list_expected], []]
@@ -131,13 +132,13 @@ def test_property_too_short(length, v_prop_example, v_prop):
     jcal = v_prop_example.to_jcal("name")[:length]
     with pytest.raises(
         JCalParsingError,
-        match=f"in {v_prop.__name__}: The property must be a list with at least 4 items.",
+        match=rf"in {v_prop.__name__}: The property must be a list with at least 4 items\.",
     ):
         v_prop.from_jcal(jcal)
 
     with pytest.raises(
         JCalParsingError,
-        match="in Parameters: The property must be a list with at least 4 items.",
+        match=r"in Parameters: The property must be a list with at least 4 items\.",
     ):
         Parameters.from_jcal_property(jcal)
 
@@ -148,7 +149,7 @@ def test_property_name(v_prop_example, v_prop, str_expected):
     jcal[0] = str_expected
     with pytest.raises(
         JCalParsingError,
-        match=f"\\[0\\] in {v_prop.__name__}: The name must be a string.",
+        match=rf"\[0\] in {v_prop.__name__}: The name must be a string\.",
     ):
         v_prop.from_jcal(jcal)
 
@@ -159,12 +160,12 @@ def test_property_params(v_prop_example, v_prop, object_expected):
     jcal[1] = object_expected
     with pytest.raises(
         JCalParsingError,
-        match=f"\\[1\\] in {v_prop.__name__}: The parameters must be a mapping.",
+        match=rf"\[1\] in {v_prop.__name__}: The parameters must be a mapping\.",
     ):
         v_prop.from_jcal(jcal)
     with pytest.raises(
         JCalParsingError,
-        match="\\[1\\] in Parameters: The parameters must be a mapping.",
+        match=r"\[1\] in Parameters: The parameters must be a mapping\.",
     ):
         Parameters.from_jcal_property(jcal)
 
@@ -175,7 +176,7 @@ def test_property_type(v_prop_example, v_prop, str_expected):
     jcal[2] = str_expected
     with pytest.raises(
         JCalParsingError,
-        match=f"\\[2\\] in {v_prop.__name__}: The VALUE parameter must be a string.",
+        match=rf"\[2\] in {v_prop.__name__}: The VALUE parameter must be a string\.",
     ):
         v_prop.from_jcal(jcal)
 
@@ -192,7 +193,7 @@ def test_property_too_short_in_component(v_prop_example, v_prop, index):
     print(jcal)
     with pytest.raises(
         JCalParsingError,
-        match=f"\\[1\\]\\[{index}\\] in Calendar: The property must be a list with at least 4 items.",
+        match=rf"\[1\]\[{index}\] in Calendar: The property must be a list with at least 4 items\.",
     ):
         Component.from_jcal(component)
 
@@ -203,7 +204,7 @@ def test_parameters_keys(str_expected):
         return  # TypeError: unhashable type
     with pytest.raises(
         JCalParsingError,
-        match="in Parameters: All parameter names must be strings.",
+        match=r"in Parameters: All parameter names must be strings\.",
     ):
         Parameters.from_jcal_property(["", {str_expected: "value"}, "", ""])
 
@@ -213,7 +214,7 @@ def test_values_allowed_in_parameters(parameter_value_expected, key):
     """The parameter keys should be all strings."""
     with pytest.raises(
         JCalParsingError,
-        match=f'\\[1\\]\\["{key}"\\] in Parameters: Parameter values must be a string, integer or float or a list of those.',
+        match=rf'\[1\]\["{key}"\] in Parameters: Parameter values must be a string, integer or float or a list of those\.',
     ):
         Parameters.from_jcal_property(["", {key: parameter_value_expected}, "", ""])
 
@@ -233,15 +234,15 @@ def test_failing_example_delegated_to(calendars):
 @pytest.mark.parametrize(
     ("v_prop", "ty", "message", "value"),
     [
-        (vDatetime, "date-time", "Cannot parse date-time.", ""),
-        (vDate, "date", "Cannot parse date.", ""),
-        (vTime, "time", "Cannot parse time.", ""),
-        (vTime, "time", "Cannot parse time.", "asd"),
-        (vDuration, "duration", "Cannot parse duration.", "PXD"),
+        (vDatetime, "date-time", r"Cannot parse date-time\.", ""),
+        (vDate, "date", r"Cannot parse date\.", ""),
+        (vTime, "time", r"Cannot parse time\.", ""),
+        (vTime, "time", r"Cannot parse time\.", "asd"),
+        (vDuration, "duration", r"Cannot parse duration\.", "PXD"),
         (
             vDDDTypes,
             "date-time",
-            "Cannot parse date, time, date-time, duration, or period.",
+            r"Cannot parse date, time, date-time, duration, or period\.",
             "",
         ),
     ],
@@ -250,7 +251,7 @@ def test_date_time_parsing_errors(v_prop, message, ty, value):
     """An empty datetime should raise an error."""
     with pytest.raises(
         JCalParsingError,
-        match=f"\\[3\\] in {v_prop.__name__}: {message}",
+        match=rf"\[3\] in {v_prop.__name__}: {message}",
     ):
         v_prop.from_jcal(["dt", {}, ty, value])
 
@@ -271,7 +272,7 @@ def test_wrong_type(v_prop, str_expected):
         return  # skip vPeriod
     with pytest.raises(
         JCalParsingError,
-        match=f"\\[3\\] in {v_prop.__name__}: The value must be a string.",
+        match=rf"\[3\] in {v_prop.__name__}: The value must be a string\.",
     ):
         v_prop.from_jcal(["dt", {}, "date-time", str_expected])
 
@@ -280,14 +281,14 @@ def test_vPeriod_wrong_type(str_expected):
     """Passing an int or float where a string is expected should raise an error."""
     with pytest.raises(
         JCalParsingError,
-        match="\\[3\\]\\[0\\] in .*: The value must be a string.",
+        match=r"\[3\]\[0\] in .*: The value must be a string\.",
     ):
         vPeriod.from_jcal(
             ["rdate", {}, "period", [str_expected, "2024-01-01T00:00:00Z"]]
         )
     with pytest.raises(
         JCalParsingError,
-        match="\\[3\\]\\[1\\] in .*: The value must be a string.",
+        match=r"\[3\]\[1\] in .*: The value must be a string\.",
     ):
         vPeriod.from_jcal(
             ["rdate", {}, "period", ["2024-01-01T00:00:00Z", str_expected]]
@@ -298,7 +299,7 @@ def test_vPeriod_too_short():
     """A period with too few items should raise an error."""
     with pytest.raises(
         JCalParsingError,
-        match="\\[3\\] in vPeriod: A period must be a list with exactly 2 items.",
+        match=r"\[3\] in vPeriod: A period must be a list with exactly 2 items\.",
     ):
         vPeriod.from_jcal(["rdate", {}, "period", ["2024-01-01T00:00:00Z"]])
 
@@ -307,7 +308,7 @@ def test_vPeriod_too_long():
     """A period with too many items should raise an error."""
     with pytest.raises(
         JCalParsingError,
-        match="\\[3\\] in vPeriod: A period must be a list with exactly 2 items.",
+        match=r"\[3\] in vPeriod: A period must be a list with exactly 2 items\.",
     ):
         vPeriod.from_jcal(
             [
@@ -323,7 +324,7 @@ def test_vPeriod_expects_date_time_as_start():
     """vPeriod expects date-time as start but we hand in a duration."""
     with pytest.raises(
         JCalParsingError,
-        match="\\[3\\]\\[0\\] in .*: Cannot parse date-time.",
+        match=r"\[3\]\[0\] in .*: Cannot parse date-time\.",
     ):
         vPeriod.from_jcal(
             [
@@ -339,7 +340,7 @@ def test_vPeriod_expects_date_time_or_duration_as_second_item():
     """vPeriod expects date-time or duration as second item but we hand in a date."""
     with pytest.raises(
         JCalParsingError,
-        match="\\[3\\]\\[1\\] in .*: Cannot parse date-time or duration.",
+        match=r"\[3\]\[1\] in .*: Cannot parse date-time or duration\.",
     ):
         vPeriod.from_jcal(
             [
@@ -356,7 +357,7 @@ def test_invalid_category_type(str_expected, index):
     """The name is a string."""
     with pytest.raises(
         JCalParsingError,
-        match=f"\\[{index + 3}\\] in vCategory: The value must be a string.",
+        match=rf"\[{index + 3}\] in vCategory: The value must be a string\.",
     ):
         vCategory.from_jcal(["categories", {}, "text"] + [""] * index + [str_expected])
 
@@ -366,7 +367,7 @@ def test_validation_of_list():
     JCalParsingError.validate_list_type(["a", "b", "c"], str, "test", ["path"])
     with pytest.raises(
         JCalParsingError,
-        match="\\[3\\]\\[1\\] in test: Each item in the list must be a string.",
+        match=r"\[3\]\[1\] in test: Each item in the list must be a string\.",
     ):
         JCalParsingError.validate_list_type(["a", 1, "c"], str, "test", path=3)
 
@@ -375,7 +376,7 @@ def test_recurrence_rule_must_be_mapping(object_expected):
     """The recurrence rule must be a mapping."""
     with pytest.raises(
         JCalParsingError,
-        match="\\[3\\] in vRecur: The recurrence rule must be a mapping with string keys.",
+        match=r"\[3\] in vRecur: The recurrence rule must be a mapping with string keys\.",
     ):
         vRecur.from_jcal(["rrule", {}, "recur", object_expected])
 
@@ -386,7 +387,7 @@ def test_recurrence_rule_must_be_mapping_with_str(str_expected):
         return  # skip unhashable type
     with pytest.raises(
         JCalParsingError,
-        match="\\[3\\] in vRecur: The recurrence rule must be a mapping with string keys.",
+        match=r"\[3\] in vRecur: The recurrence rule must be a mapping with string keys\.",
     ):
         vRecur.from_jcal(["rrule", {}, "recur", {str_expected: 1}])
 
@@ -437,7 +438,7 @@ def test_parse_jcal_value_month_invalid(invalid):
     """Test parsing of vMonth jCal values."""
     with pytest.raises(
         JCalParsingError,
-        match="in vMonth: The value must be a string or an integer.",
+        match=r"in vMonth: The value must be a string or an integer\.",
     ):
         vMonth.parse_jcal_value(invalid)
 
@@ -447,7 +448,7 @@ def test_skip():
     assert vSkip.parse_jcal_value("OMIT") is vSkip.OMIT
     with pytest.raises(
         JCalParsingError,
-        match="in vSkip: The value must be a valid skip value.",
+        match=r"in vSkip: The value must be a valid skip value\.",
     ):
         vSkip.parse_jcal_value("INVALID")
 
@@ -460,6 +461,6 @@ def test_frequency():
     # parse bad value
     with pytest.raises(
         JCalParsingError,
-        match='\\[3\\]\\["FREQ"\\] in vFrequency: The value must be a valid frequency.',
+        match=r'\[3\]\["FREQ"\] in vFrequency: The value must be a valid frequency\.',
     ):
         vRecur.from_jcal(["rrule", {}, "recur", {"FREQ": "INVALID"}])

--- a/src/icalendar/tests/test_equality.py
+++ b/src/icalendar/tests/test_equality.py
@@ -59,7 +59,7 @@ def test_parsed_calendars_are_equal_if_parsed_again_jcal(source_file, tzp):
 
     source -> calendar -> jcal -> same calendar
     """
-    if source_file.source_file in ("issue_464_invalid_rdate.ics",):
+    if source_file.source_file == "issue_464_invalid_rdate.ics":
         pytest.skip(
             "Invalid RDATE falls back to vBrokenProperty, which can't round-trip to jCal."
         )


### PR DESCRIPTION
## Summary
- RUF043: Use raw strings for `pytest.raises` match patterns with regex metacharacters
- FURB171: Replace single-item membership tests with equality checks
- Fix inexact match pattern in `test_invalid_component_type`

Related to #672