### PR TITLE
maintainer section in pyproject.toml in docs

### DIFF
--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -43,7 +43,8 @@ Maintainers need the following permissions.
 
         -   `Discussion about how to be added to OSS Fuzz <https://github.com/collective/icalendar/pull/574#issuecomment-1790554766>`_
         -   :issue:`562`
-    
+Maintainer in ``pyproject.toml``
+    Maintainers should be mentioned with or without email address in the ``pyproject.toml`` file's `maintainers' section <https://github.com/collective/icalendar/blob/7ca9db18c0847d1530520e01baf75f8ab8f4fa06/pyproject.toml#L32>`_.
 
 Collaborators
 -------------


### PR DESCRIPTION
maintainers should also be added in ``pyproject.toml``.

No changelog entry needed. 

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1190.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->