### PR TITLE
Fix the version switcher on Read the Docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,7 +47,8 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-- ...
+- Fixed the version switcher on Read the Docs, and documented the process for a major release. :issue:`1194`
+
 
 7.0.0 (2026-02-11)
 ------------------

--- a/docs/_static/version-switcher.json
+++ b/docs/_static/version-switcher.json
@@ -4,7 +4,8 @@
         "url": "https://icalendar.readthedocs.io/en/latest/"
     },
     {
-        "version": "7.x",
+        "name": "7.x (stable)",
+        "version": "v7.0.0",
         "url": "https://icalendar.readthedocs.io/en/stable/",
         "preferred": "true"
     },

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -98,8 +98,6 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
         export VERSION=7.0.0
 
-#.  If you want to cut a new release of a stable version, then in the ``main`` or development branch, update :file:`docs/_static/version-switcher.json` to match that version.
-
 #.  Create a commit on the ``release`` branch (or equivalent) to release this version.
 
     .. code-block:: shell
@@ -196,6 +194,58 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         git add CHANGES.rst
         git commit -m "Add new CHANGELOG section for future release"
         git push upstream main # could be origin or whatever reference
+
+#.  Update :file:`docs/_static/version-switcher.json`.
+
+    .. important::
+
+        Making a pull request won't have any effect to the version switcher on Read the Docs until it gets on to the ``main`` branch, so you might as well edit and push directly on the ``main`` branch for this step.
+
+    #.  When cutting a new *stable release* version, on the ``main`` or development branch, update :file:`docs/_static/version-switcher.json` to match that version.
+        The following examples were used for the 7.0.0 release.
+
+        #.  Copy the second previous major version and renumber it to the first previous version, in other words, copy ``5.x`` and renumber the copy to ``6.x``.
+
+            .. code-block:: json
+
+                {
+                    "version": "6.x",
+                    "url": "https://icalendar.readthedocs.io/en/6.x/"
+                },
+
+        #.  Next, edit the array item for the previous version to reflect the current major release.
+
+            .. code-block:: json
+
+                {
+                    "name": "7.x (stable)",
+                    "version": "v7.0.0",
+                    "url": "https://icalendar.readthedocs.io/en/stable/",
+                    "preferred": "true"
+                },
+
+    #.  When cutting a *minor or patch release* version, on the ``main`` or development branch, update :file:`docs/_static/version-switcher.json` to match that version's tag name.
+
+        .. code-block:: json
+
+            {
+                "name": "7.x (stable)",
+                "version": "v7.0.1",
+                "url": "https://icalendar.readthedocs.io/en/stable/",
+                "preferred": "true"
+            },
+
+#.  Configure `Read the Docs <https://app.readthedocs.org/projects/icalendar/>`_.
+
+    #.  Deactivate any non-stable releases.
+        Click on the ellipsis icon, and select :guilabel:`Configure version`.
+        Toggle the :guilabel:`Active` switch to deactivate the version.
+
+    #.  Click `Add version <https://app.readthedocs.org/dashboard/icalendar/version/create/>`_ to do just that.
+        Search for the previous major version ``#.x``.
+        Click on the version that appears in the select menu that matches your search.
+        Toggle the :guilabel:`Active` switch to activate the version.
+
 
 Links
 -----


### PR DESCRIPTION
- See #1194

This is an attempt to fix the version switcher. It needs to be merged to ``main`` for the switcher to be current and work for all versions. I'm going to do that without an approval.

I removed all the automation rules from RTD. They aren't needed.

I might need to fiddle around some more. We'll see.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1197.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->