### PR TITLE
Document vText

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -156,6 +156,7 @@ Documentation
 - Changed Sphinx configuration to inherit from ``CaselessDict``, displaying all of its class members in the in-page navigation.
   Fixed broken cross-component links in ``Availability.new()``. :issue:`994`
 - Configured Sphinx to append the docstring from the ``__init__`` method into its class docstring. :issue:`1156`
+- Document ``vText`` properties with :rfc:`5545`. :issue:`742`
 
 7.0.0a3 (2025-12-19)
 --------------------

--- a/src/icalendar/prop/text.py
+++ b/src/icalendar/prop/text.py
@@ -42,7 +42,7 @@ class vText(str):
     .. code-block:: pycon
 
         >>> from icalendar.prop import vText
-        >>> desc = ‘Project XYZ Final Review\nConference Room - 3B\nCome Prepared.’
+        >>> desc = 'Project XYZ Final Review\nConference Room - 3B\nCome Prepared.'
         >>> text = vText.from_ical(desc)
         >>> text
         vText(b'Project XYZ Final Review\\nConference Room - 3B\\nCome Prepared.')
@@ -53,8 +53,8 @@ class vText(str):
         >>>
         >>> from icalendar import Event
         >>> event = Event()
-        >>> event.add(‘TEXT’, desc)
-        >>> event[‘TEXT’]
+        >>> event.add('TEXT', desc)
+        >>> event['TEXT']
         vText(b'Project XYZ Final Review\\nConference Room - 3B\\nCome Prepared.')
     """
 


### PR DESCRIPTION
## Closes issue #742

- [x] Closes #742

## Description

FIxed issues with previous version of vText documentation.

## Checklist

- [x] I've added a change log entry to `CHANGES.rst`.
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information




<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1200.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->