### PR TITLE
feat: also set X-WR-CALNAME in Calendar.calendar_name setter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,7 @@ We still recommend checking out the new features and giving feedback in the repo
 Minor changes
 ~~~~~~~~~~~~~
 
-- ...
+- Setting :attr:`~cal.calendar.Calendar.calendar_name` now also writes ``X-WR-CALNAME``, and setting :attr:`~cal.calendar.Calendar.description` now also writes ``X-WR-CALDESC``, for improved client compatibility. See `Issue #918 <https://github.com/collective/icalendar/issues/918>`_.
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -357,6 +357,8 @@ def multi_language_text_property(
         fdel(self)
         if value is not None:
             self.add(main_prop, value)
+            if compatibility_prop is not None:
+                self.add(compatibility_prop, value)
 
     def fdel(self: Component):
         """Delete the property."""

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -329,6 +329,7 @@ class Calendar(Component):
             >>> print(calendar.to_ical())
             BEGIN:VCALENDAR
             NAME:My Calendar
+            X-WR-CALNAME:My Calendar
             END:VCALENDAR
     """,
     )
@@ -364,6 +365,7 @@ class Calendar(Component):
             >>> print(calendar.to_ical())
             BEGIN:VCALENDAR
             DESCRIPTION:This is a calendar
+            X-WR-CALDESC:This is a calendar
             END:VCALENDAR
     """,
     )

--- a/src/icalendar/tests/test_rfc_7986.py
+++ b/src/icalendar/tests/test_rfc_7986.py
@@ -35,10 +35,11 @@ def test_get_calendar_name(prop, name, calendar):
 
 @param_name
 def test_set_calendar_name(name, calendar):
-    """Setting the name overrides the old attributes."""
+    """Setting the name overrides the old attributes and sets both NAME and X-WR-CALNAME."""
     calendar.calendar_name = name
     assert calendar.calendar_name == name
     assert calendar["NAME"] == name
+    assert calendar["X-WR-CALNAME"] == name
 
 
 @param_name
@@ -65,12 +66,12 @@ def test_default_name(calendar):
 
 
 @param_name
-def test_setting_the_name_deletes_the_non_standard_attribute(calendar, name):
-    """The default_attr is deleted when setting the name."""
-    calendar["X-WR-CALNAME"] = name
-    assert "X-WR-CALNAME" in calendar
-    calendar.calendar_name = "other name"
-    assert "X-WR-CALNAME" not in calendar
+def test_setting_the_name_sets_both_properties(calendar, name):
+    """Setting calendar_name sets both NAME and X-WR-CALNAME for compatibility."""
+    calendar.calendar_name = name
+    assert calendar.calendar_name == name
+    assert calendar["NAME"] == name
+    assert calendar["X-WR-CALNAME"] == name
 
 
 @param_name


### PR DESCRIPTION
## Closes issue

- [x] Closes #918

## Description

Setting calendar_name now also writes X-WR-CALNAME for improved compatibility with clients that rely on the non-standard property.

**Changes:**

**1. Core fix** (`src/icalendar/attr.py`)
- `multi_language_text_property` setter now also writes to `compatibility_prop` if one is specified

**2. Docstring update** (`src/icalendar/cal/calendar.py`)
- Updated examples to reflect that both `NAME` and `X-WR-CALNAME` (and `DESCRIPTION` + `X-WR-CALDESC`) are written

**3. Test update** (`src/icalendar/tests/test_rfc_7986.py`)
- Updated `test_set_calendar_name` to assert `X-WR-CALNAME` is also set
- Renamed and rewrote `test_setting_the_name_deletes_the_non_standard_attribute` → `test_setting_the_name_sets_both_properties` to reflect the new behavior

**4. Changelog** (`CHANGES.rst`)
- Added entry in "Minor changes" section

## Checklist

- [x] I've added a change log entry to `CHANGES.rst`.
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1209.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->