### PR TITLE
Update ruff version from 0.15.0 to 0.15.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0 # also update pyproject.toml
+    rev: v0.15.2 # also update pyproject.toml
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ test = [
 ]
 
 formatting = [
-    "ruff==0.15.0", # also update .pre-commit-config.yaml
+    "ruff==0.15.2", # also update .pre-commit-config.yaml
     "pre-commit",
 ]
 


### PR DESCRIPTION
## Description

This PR updates the ruff code formatter to the latest version 0.15.2 (from 0.15.0).

## Changes

- Updated `ruff` version in `pyproject.toml` from 0.15.0 to 0.15.2
- Updated `ruff` version in `.pre-commit-config.yaml` from v0.15.0 to v0.15.2

## Testing

- All existing tests pass: **12091 passed, 25 skipped**
- Code formatting check: **212 files left unchanged** (no formatting changes needed)
- Lint check: **All checks passed**

## Related Issue

Closes #1217