### PR TITLE
fix(parser): handle bytes input in escape_char function

### DIFF
--- a/src/icalendar/parser/string.py
+++ b/src/icalendar/parser/string.py
@@ -2,10 +2,10 @@
 
 import re
 
-from icalendar.parser_tools import DEFAULT_ENCODING
+from icalendar.parser_tools import DEFAULT_ENCODING, to_unicode
 
 
-def escape_char(text: str | bytes) -> str | bytes:
+def escape_char(text: str | bytes) -> str:
     r"""Format value according to iCalendar TEXT escaping rules.
 
     Escapes special characters in text values according to :rfc:`5545#section-3.3.11`
@@ -30,6 +30,8 @@ def escape_char(text: str | bytes) -> str | bytes:
            newline character)
     """
     assert isinstance(text, (str, bytes))
+    # Convert bytes to str before processing
+    text = to_unicode(text)
     # NOTE: ORDER MATTERS!
     return (
         text.replace(r"\N", "\n")

--- a/src/icalendar/tests/test_parsing.py
+++ b/src/icalendar/tests/test_parsing.py
@@ -9,7 +9,7 @@ from icalendar import vBinary, vRecur
 from icalendar.cal.calendar import Calendar
 from icalendar.cal.component_factory import ComponentFactory
 from icalendar.cal.event import Event
-from icalendar.parser import Contentline, Parameters, unescape_char
+from icalendar.parser import Contentline, Parameters, escape_char, unescape_char
 
 
 @pytest.mark.parametrize(
@@ -237,6 +237,20 @@ def test_escaped_characters_read(event_name, expected_cn, expected_ics, events):
 def test_unescape_char():
     assert unescape_char(b"123") == b"123"
     assert unescape_char(b"\\n") == b"\n"
+
+
+def test_escape_char_with_bytes():
+    """Test that escape_char handles bytes input correctly."""
+    # Basic bytes input
+    assert escape_char(b"123") == "123"
+    # Bytes with characters that need escaping
+    assert escape_char(b"test;value") == r"test\;value"
+    assert escape_char(b"test,value") == r"test\,value"
+    assert escape_char(b"test\\value") == r"test\\value"
+    # Bytes with newlines get escaped to literal \n
+    assert escape_char(b"line1\nline2") == r"line1\nline2"
+    # Bytes with \N should be converted to newline, then escaped to \n
+    assert escape_char(b"test\\Nvalue") == r"test\nvalue"
 
 
 def test_split_on_unescaped_comma():


### PR DESCRIPTION
## Problem

The escape_char function in icalendar.parser.string was annotated to accept str | bytes but would fail with TypeError when given bytes input.

## Analysis

The function signature allowed bytes input, but the implementation used string literals for replacements.

## Solution

Superseded by a new PR that builds on the recently merged deprecation refactor (#XXXX). Closing this to avoid confusion.

Thanks for the review feedback!