### PR TITLE
Add Calendar.journals property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,7 @@ New features
 ~~~~~~~~~~~~
 
 - Enabled :meth:`Calendar.from_ical <icalendar.cal.calendar.Calendar.from_ical>` to read calendars from files. :issue:`756`
+- Added :attr:`Calendar.journals <icalendar.cal.calendar.Calendar.journals>` property to retrieve all journal components. :issue:`1230`
 
 Bug fixes
 ~~~~~~~~~

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from icalendar.cal.availability import Availability
     from icalendar.cal.event import Event
     from icalendar.cal.free_busy import FreeBusy
+    from icalendar.cal.journal import Journal
     from icalendar.cal.todo import Todo
 
 
@@ -193,6 +194,16 @@ class Calendar(Component):
         Use :py:meth:`Component.add_component`.
         """
         return self.walk("VTODO")
+
+    @property
+    def journals(self) -> list[Journal]:
+        """All journal components in the calendar.
+
+        This is a shortcut to get all journals.
+        Modifications do not change the calendar.
+        Use :py:meth:`Component.add_component`.
+        """
+        return self.walk("VJOURNAL")
 
     @property
     def availabilities(self) -> list[Availability]:

--- a/src/icalendar/tests/test_unit_cal.py
+++ b/src/icalendar/tests/test_unit_cal.py
@@ -9,6 +9,7 @@ from icalendar import prop
 from icalendar.cal.calendar import Calendar
 from icalendar.cal.component import Component
 from icalendar.cal.event import Event
+from icalendar.cal.journal import Journal
 from icalendar.timezone import tzid_from_dt
 
 
@@ -410,6 +411,13 @@ def test_minimal_calendar_component_with_one_event():
         b"DTSTART:20050404T080000\r\nUID:42\r\n"
         b"END:VEVENT\r\n"
     )
+
+
+def test_calendar_journals_property(calendars):
+    """Calendar.journals returns all VJOURNAL components."""
+    journals = calendars.rfc_7986_image.journals
+    assert len(journals) == 2
+    assert all(isinstance(j, Journal) for j in journals)
 
 
 def test_calendar_with_parsing_errors_includes_all_events(calendars):


### PR DESCRIPTION
## Summary

- Adds `Calendar.journals` property to retrieve all `VJOURNAL` components, consistent with the existing `Calendar.events`, `Calendar.todos`, and `Calendar.availabilities` properties

Closes #1230

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1232.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->