### PR TITLE
Docs: fix grammar in usage documentation

### DIFF
--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -404,7 +404,7 @@ To continue to receive ``pytz`` timezones in parsed results, you can receive all
 Complete recurring meeting
 ''''''''''''''''''''''''''
 
-This section shows how create a complete and typical iCalendar file of a recurring meeting event, then add some properties to it, including a location, organizer, attendees, alarms, recurrence, and other properties.
+This section shows how to create a complete and typical iCalendar file of a recurring meeting event, then add some properties to it, including a location, organizer, attendees, alarms, recurrence, and other properties.
 This file can be loaded into any application that supports iCalendar files.
 
 Initialize the calendar.


### PR DESCRIPTION
Fixed a small grammar issue in docs/how-to/usage.rst.

Changed:
"how create" → "how to create"

This is a small documentation improvement.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1240.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->