### PR TITLE
docs: remove redundant :py: prefix from docstring cross-references

### DIFF
--- a/src/icalendar/cal/availability.py
+++ b/src/icalendar/cal/availability.py
@@ -230,7 +230,7 @@ class Availability(Component):
 
         This is a shortcut to get all VAVAILABLE sub-components.
         Modifications do not change the calendar.
-        Use :py:meth:`Component.add_component`.
+        Use :meth:`Component.add_component`.
         """
         return self.walk("AVAILABLE")
 

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -173,7 +173,7 @@ class Calendar(Component):
 
         This is a shortcut to get all events.
         Modifications do not change the calendar.
-        Use :py:meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
+        Use :meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
 
         >>> from icalendar import Calendar
         >>> calendar = Calendar.example()
@@ -191,7 +191,7 @@ class Calendar(Component):
 
         This is a shortcut to get all todos.
         Modifications do not change the calendar.
-        Use :py:meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
+        Use :meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
         """
         return self.walk("VTODO")
 
@@ -201,7 +201,7 @@ class Calendar(Component):
 
         This is a shortcut to get all journals.
         Modifications do not change the calendar.
-        Use :py:meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
+        Use :meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
         """
         return self.walk("VJOURNAL")
 
@@ -211,7 +211,7 @@ class Calendar(Component):
 
         This is a shortcut to get all availabilities.
         Modifications do not change the calendar.
-        Use :py:meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
+        Use :meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
         """
         return self.walk("VAVAILABILITY")
 
@@ -221,7 +221,7 @@ class Calendar(Component):
 
         This is a shortcut to get all FreeBusy.
         Modifications do not change the calendar.
-        Use :py:meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
+        Use :meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
         """
         return self.walk("VFREEBUSY")
 

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -152,9 +152,9 @@ class Component(CaselessDict):
         """Infer the ``VALUE`` parameter from a Python type.
 
         Parameters:
-            value: Python native type, one of :py:class:`date`, :py:mod:`datetime`,
-                :py:class:`timedelta`, :py:mod:`time`, :py:class:`tuple`,
-                or :py:class:`list`.
+            value: Python native type, one of :class:`date`, :mod:`datetime`,
+                :class:`timedelta`, :mod:`time`, :class:`tuple`,
+                or :class:`list`.
 
         Returns:
             str or None: The ``VALUE`` parameter string, for example, "DATE",

--- a/src/icalendar/parser/property.py
+++ b/src/icalendar/parser/property.py
@@ -28,7 +28,7 @@ _unescape_backslash_regex = re.compile(r"\\([\\,;:nN])")
 def unescape_backslash(val: str):
     r"""Unescape backslash sequences in iCalendar text.
 
-    Unlike :py:meth:`unescape_string`, this only handles actual backslash escapes
+    Unlike :meth:`unescape_string`, this only handles actual backslash escapes
     per :rfc:`5545`, not URL encoding. This preserves URL-encoded values
     like ``%3A`` in URLs.
 

--- a/src/icalendar/prop/dt/date.py
+++ b/src/icalendar/prop/dt/date.py
@@ -104,7 +104,7 @@ class vDate(TimeBase):
 
     @classmethod
     def parse_jcal_value(cls, jcal: str) -> date:
-        """Parse a jCal string to a :py:class:`datetime.date`.
+        """Parse a jCal string to a :class:`datetime.date`.
 
         Raises:
             ~error.JCalParsingError: If it can't parse a date.

--- a/src/icalendar/prop/dt/datetime.py
+++ b/src/icalendar/prop/dt/datetime.py
@@ -52,7 +52,7 @@ class vDatetime(TimeBase):
         vDatetime is timezone aware and uses a timezone library.
         When a vDatetime object is created from an
         ical string, you can pass a valid timezone identifier. When a
-        vDatetime object is created from a Python :py:mod:`datetime` object, it uses the
+        vDatetime object is created from a Python :mod:`datetime` object, it uses the
         tzinfo component, if present. Otherwise a timezone-naive object is
         created. Be aware that there are certain limitations with timezone naive
         DATE-TIME components in the icalendar standard.
@@ -155,7 +155,7 @@ class vDatetime(TimeBase):
 
     @classmethod
     def parse_jcal_value(cls, jcal: str) -> datetime:
-        """Parse a jCal string to a :py:class:`datetime.datetime`.
+        """Parse a jCal string to a :class:`datetime.datetime`.
 
         Raises:
             ~error.JCalParsingError: If it can't parse a date-time value.

--- a/src/icalendar/prop/dt/duration.py
+++ b/src/icalendar/prop/dt/duration.py
@@ -166,7 +166,7 @@ class vDuration(TimeBase):
 
     @classmethod
     def parse_jcal_value(cls, jcal: str) -> timedelta:
-        """Parse a jCal string to a :py:class:`datetime.timedelta`.
+        """Parse a jCal string to a :class:`datetime.timedelta`.
 
         Raises:
             ~error.JCalParsingError: If it can't parse a duration."""

--- a/src/icalendar/prop/dt/time.py
+++ b/src/icalendar/prop/dt/time.py
@@ -176,7 +176,7 @@ class vTime(TimeBase):
 
     @classmethod
     def parse_jcal_value(cls, jcal: str) -> time:
-        """Parse a jCal string to a :py:class:`datetime.time`.
+        """Parse a jCal string to a :class:`datetime.time`.
 
         Raises:
             ~error.JCalParsingError: If it can't parse a time.


### PR DESCRIPTION
## Summary

- Removed the `:py:` prefix from 18 cross-reference roles across 8 Python source files
- Affected roles: `:py:class:`, `:py:mod:`, `:py:meth:`
- Replaced with the preferred short forms: `:class:`, `:mod:`, `:meth:`
- Per the [icalendar style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html#cross-reference-python-objects): "Because icalendar uses the Python domain exclusively, it is safe to omit the ``:py`` prefix when creating references to Python objects."

## Files changed

- `src/icalendar/cal/availability.py` (1 fix)
- `src/icalendar/cal/calendar.py` (5 fixes)
- `src/icalendar/cal/component.py` (6 fixes)
- `src/icalendar/parser/property.py` (1 fix)
- `src/icalendar/prop/dt/date.py` (1 fix)
- `src/icalendar/prop/dt/datetime.py` (2 fixes)
- `src/icalendar/prop/dt/duration.py` (1 fix)
- `src/icalendar/prop/dt/time.py` (1 fix)

## Test plan

- [ ] Read the Docs preview build shows no broken cross-reference links in the affected API pages
- [ ] Verify the fixed roles resolve correctly in the rendered HTML docs

Closes part of #1158.

Generated with [Claude Code](https://claude.com/claude-code)