### PR TITLE
docs: convert docstrings in attr.py and calendar.py to Google Style

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,7 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-- ...
+- Convert docstrings in ``attr.py`` and ``cal/calendar.py`` to Google Style format. See :issue:`1072`.
 
 7.0.3 (2026-03-03)
 ------------------

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -903,7 +903,7 @@ def create_single_property(
 ):
     """Create a single property getter and setter.
 
-    Args:
+    Parameters:
         prop: The name of the property.
         value_attr: The name of the attribute to get the value from.
         value_type: The type of the value.

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -290,8 +290,9 @@ class Calendar(Component):
 
             Timezones that are not known will not be added.
 
-        :param first_date: earlier than anything that happens in the calendar
-        :param last_date: later than anything happening in the calendar
+        Parameters:
+            first_date: Earlier than anything that happens in the calendar.
+            last_date: Later than anything happening in the calendar.
 
         >>> from icalendar import Calendar, Event
         >>> from datetime import datetime


### PR DESCRIPTION
## Closes issue

- [x] Contributes to #1072

## Description

Convert old-style `:param` docstrings to [Google Style format](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) in two files:

- **`src/icalendar/attr.py`**: Converted `create_single_property()` docstring from `:param` style to `Args:` style
- **`src/icalendar/cal/calendar.py`**: Converted `add_missing_timezones()` docstring from `:param` style to `Args:` style

## Checklist

- [ ] I've added a change log entry to `CHANGES.rst`. (N/A - docstring formatting only)
- [ ] I've added or updated tests if applicable. (N/A - no code changes)
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

This is a partial contribution to #1072. More files with old-style docstrings can be converted in follow-up PRs.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1249.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->