### PR TITLE
Add sphinx-icalendar to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,8 +102,8 @@ Related projects
 `ical2jcal <https://pypi.org/project/ical2jcal>`_
     Convert between iCalendar and jCalendar.
 
-`sphinx-icalendar <https://pypi.org/project/sphinx-icalenadar>`_
-    Provide calendar code blocks and syntax highlighting for Sphinx.
+`sphinx-icalendar <https://pypi.org/project/sphinx-icalendar/>`_
+    Provides calendar code blocks and syntax highlighting in a tabbed interface for documentation as an extension to Sphinx.
 
 Change log
 ==========


### PR DESCRIPTION
## Closes issue

This links related work.

## Description
Added sphinx-icalendar project link and description.


## Checklist

- [ ] I've added a change log entry to `CHANGES.rst`.
- [ ] I've added or updated tests if applicable.
- [ ] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

#1251 

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1252.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->