### PR TITLE
Fix change log to reflect what actually happened in the proper version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,10 @@ Bug fixes
 - Fixed :meth:`Parameters.update_tzid_from <icalendar.parser.parameter.Parameters.update_tzid_from>`
   incorrectly setting ``TZID=UTC`` on UTC datetimes. :rfc:`5545` section 3.2.19 requires UTC datetimes to
   use the ``Z`` suffix without a ``TZID`` parameter. :issue:`1124`
+- Renamed the public functions ``escape_char`` and ``unescape_char`` to implicit private methods ``_escape_char`` and ``_unescape_char``.
+  Fixed regression from :issue:`1008` by restoring :func:`~icalendar.parser.string.escape_char` and :func:`~icalendar.parser.string.unescape_char` as public functions.
+  The public functions :func:`~icalendar.parser.string.escape_char` and :func:`~icalendar.parser.string.unescape_char` are now deprecated with warnings for external users.
+  :pr:`1241`.
 
 Documentation
 ~~~~~~~~~~~~~
@@ -229,7 +233,7 @@ New features
 Bug fixes
 ~~~~~~~~~
 
-- Fix double-unescaping in :meth:`vText.from_ical` and :meth:`vCategory.from_ical` by using private ``_unescape_char()`` function internally instead of the public version. The public ``escape_char()`` and ``unescape_char()`` functions are now deprecated with warnings for external users. See :issue:`1008`.
+- Fix double-unescaping in :meth:`vText.from_ical` and :meth:`vCategory.from_ical` by removing ``unescape_char()``. See :issue:`1008`.
 
 7.0.0a2 (2025-11-29)
 --------------------


### PR DESCRIPTION
This fixes an issue with the change log from PR #1241.

@japinderofficial-hub please don't rewrite change log entries after a release, especially where it changes its meaning and what was actually done. It's OK to fix typos and minor mistakes, but changing history is not OK.

@niccokunzmann I'd like to look at a better change log management system. The current one is prone to human error and annoying merge conflicts. I like [towncrier](https://towncrier.readthedocs.io/en/stable/). It's used throughout Plone and Collective.

No change log entry needed for this PR because it fixes a previous entry.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1255.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->