### PR TITLE
Improve markup, follow up to #1245

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,14 +47,14 @@ Bug fixes
 ~~~~~~~~~
 
 - Fixed :meth:`Calendar.get_missing_tzids <icalendar.cal.calendar.Calendar.get_missing_tzids>`
-  raising ``KeyError`` when a VTIMEZONE exists for a timezone not referenced by any event TZID
-  (e.g. added by x-wr-timezone conversion). :issue:`1124`
+  raising ``KeyError`` when a VTIMEZONE exists for a timezone not referenced by any event TZID,
+  for example, when added by the ``x-wr-timezone`` conversion. :issue:`1124`
 - Fixed :meth:`Calendar.get_missing_tzids <icalendar.cal.calendar.Calendar.get_missing_tzids>`
   and :meth:`Calendar.add_missing_timezones <icalendar.cal.calendar.Calendar.add_missing_timezones>`
-  generating a spurious ``VTIMEZONE`` for UTC. :rfc:`5545` section 3.2.19 requires UTC datetimes
+  generating a spurious ``VTIMEZONE`` for UTC. :rfc:`5545#section-3.2.19` requires UTC datetimes
   to use the ``Z`` suffix; no ``VTIMEZONE`` component is needed or permitted. :issue:`1124`
 - Fixed :meth:`Parameters.update_tzid_from <icalendar.parser.parameter.Parameters.update_tzid_from>`
-  incorrectly setting ``TZID=UTC`` on UTC datetimes. :rfc:`5545` section 3.2.19 requires UTC datetimes to
+  incorrectly setting ``TZID=UTC`` on UTC datetimes. :rfc:`5545#section-3.2.19` requires UTC datetimes to
   use the ``Z`` suffix without a ``TZID`` parameter. :issue:`1124`
 - Renamed the public functions ``escape_char`` and ``unescape_char`` to implicit private methods ``_escape_char`` and ``_unescape_char``.
   Fixed regression from :issue:`1008` by restoring :func:`~icalendar.parser.string.escape_char` and :func:`~icalendar.parser.string.unescape_char` as public functions.

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -250,7 +250,7 @@ class Calendar(Component):
         To create a :rfc:`5545` compatible calendar,
         all of these timezones should be added.
 
-        UTC is excluded: per :rfc:`5545` section 3.2.19, UTC datetimes use
+        UTC is excluded: per :rfc:`5545#section-3.2.19`, UTC datetimes use
         the ``Z`` suffix and never require a VTIMEZONE component.
         """
         tzids = self.get_used_tzids() - {"UTC"}

--- a/src/icalendar/parser/parameter.py
+++ b/src/icalendar/parser/parameter.py
@@ -463,8 +463,8 @@ class Parameters(CaselessDict):
         """Update the TZID parameter from a datetime object.
 
         This sets the TZID parameter or deletes it according to the datetime.
-        :rfc:`5545` section 3.2.19 prohibits TZID on UTC datetimes,
-        which use the Z suffix instead.
+        :rfc:`5545#section-3.2.19` prohibits TZID on UTC datetimes,
+        which use the ``Z`` suffix instead.
         """
         if isinstance(dt, (datetime, time)):
             tzid = tzid_from_dt(dt)

--- a/src/icalendar/tests/test_issue_1124_no_utc_vtimezone.py
+++ b/src/icalendar/tests/test_issue_1124_no_utc_vtimezone.py
@@ -1,6 +1,6 @@
 """UTC datetimes must not generate a spurious VTIMEZONE component.
 
-Per :rfc:`5545` section 3.2.19, the TZID parameter MUST NOT be applied to
+Per :rfc:`5545#section-3.2.19`, the TZID parameter MUST NOT be applied to
 DATE-TIME or TIME properties whose time values are specified in UTC.
 
 See https://github.com/collective/icalendar/issues/1124
@@ -36,7 +36,7 @@ def test_utc_not_in_missing_tzids():
     Even if UTC were present in get_used_tzids() (e.g. from a legacy calendar
     with TZID=UTC), get_missing_tzids() must filter it out so that
     add_missing_timezones() never creates a VTIMEZONE for UTC.
-    Per :rfc:`5545` section 3.2.19, UTC datetimes use the Z suffix instead.
+    Per :rfc:`5545#section-3.2.19`, UTC datetimes use the Z suffix instead.
     """
     calendar = Calendar()
     event = Event()


### PR DESCRIPTION
- Link to specific section in the RFC 5545
- Conform with MS Style Guide (no Latin abbreviations)
- Improve grammar
- Use inline literal for `x-wr-timezone`

No change log needed. This is merely a tidying of #1245.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1260.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->