### PR TITLE
fix: recognize dateutil tzwin objects as UTC on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,10 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- Fixed :func:`~icalendar.timezone.tzid.tzids_from_tzinfo` not recognizing
+  ``dateutil.tz.win.tzwin`` objects on Windows. UTC datetimes using
+  ``dateutil.tz.gettz("UTC")`` now correctly serialize with the ``Z`` suffix
+  instead of ``TZID=Coordinated Universal Time``. :issue:`1056`
 - Fixed :meth:`Calendar.get_missing_tzids <icalendar.cal.calendar.Calendar.get_missing_tzids>`
   raising ``KeyError`` when a VTIMEZONE exists for a timezone not referenced by any event TZID,
   for example, when added by the ``x-wr-timezone`` conversion. :issue:`1124`

--- a/src/icalendar/tests/test_timezone_identification.py
+++ b/src/icalendar/tests/test_timezone_identification.py
@@ -6,6 +6,7 @@ timezone database (zoneinfo, dateutil) or the package (pytz).
 We want to make sure we can roughly identify most of them.
 """
 
+import sys
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -62,3 +63,28 @@ def test_some_timezones_are_recognized_as_utc():
 def test_getting_a_timezone_name_for_timezones(tzinfo):
     """We should get a name that we can use."""
     assert tzid_from_tzinfo(tzinfo)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="tzwin only exists on Windows")
+def test_tzwin_utc_is_identified():
+    """tzwin('UTC') from dateutil.tz.gettz('UTC') must be recognized as UTC.
+
+    On Windows, dateutil.tz.gettz('UTC') returns tzwin('UTC') whose tzname()
+    is 'Coordinated Universal Time', not 'UTC'. This must still be identified
+    as UTC so that datetimes use the Z suffix instead of a TZID parameter.
+    """
+    from dateutil.tz import gettz
+
+    tzinfo = gettz("UTC")  # returns tzwin('UTC') on Windows
+    assert "UTC" in tzids_from_tzinfo(tzinfo)
+    assert tzid_from_tzinfo(tzinfo) == "UTC"
+    assert is_utc(tzinfo)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="tzwin only exists on Windows")
+def test_tzwin_non_utc_is_identified():
+    """tzwin for a non-UTC Windows timezone maps to its IANA equivalent."""
+    from dateutil.tz import gettz
+
+    tzinfo = gettz("Eastern Standard Time")
+    assert tzid_from_tzinfo(tzinfo) == "America/New_York"

--- a/src/icalendar/timezone/tzid.py
+++ b/src/icalendar/timezone/tzid.py
@@ -15,7 +15,13 @@ from typing import TYPE_CHECKING
 from dateutil.tz import tz
 
 from icalendar.timezone import equivalent_timezone_ids_result
+from icalendar.timezone.windows_to_olson import WINDOWS_TO_OLSON
 from icalendar.tools import is_date
+
+try:
+    from dateutil.tz.win import tzwin as _tzwin
+except ImportError:
+    _tzwin = None  # not on Windows
 
 if TYPE_CHECKING:
     from datetime import datetime, tzinfo
@@ -52,6 +58,11 @@ def tzids_from_tzinfo(tzinfo: tzinfo | None) -> tuple[str]:
         return get_equivalent_tzids(tzinfo._tzid)  # noqa: SLF001
     if isinstance(tzinfo, tz.tzstr):
         return get_equivalent_tzids(tzinfo._s)  # noqa: SLF001
+    if _tzwin is not None and isinstance(tzinfo, _tzwin):
+        olson = WINDOWS_TO_OLSON.get(tzinfo._name)  # noqa: SLF001
+        if olson is not None:
+            return get_equivalent_tzids(olson)
+        return get_equivalent_tzids(tzinfo._name)  # noqa: SLF001
     if hasattr(tzinfo, "_filename"):  # dateutil.tz.tzfile  # noqa: SIM102
         if DATEUTIL_ZONEINFO_PATH is not None:
             # tzfile('/usr/share/zoneinfo/Europe/Berlin')


### PR DESCRIPTION
## Summary

On Windows, `dateutil.tz.gettz("UTC")` returns `tzwin('UTC')` whose `tzname()` is `'Coordinated Universal Time'`, not `'UTC'`. Because `tzids_from_tzinfo()` had no branch for `tzwin` objects, they fell through to `return ()`, causing UTC datetimes to be serialized with `TZID=Coordinated Universal Time` instead of the `Z` suffix, violating RFC 5545 §3.2.19.

Fixes #1056