### PR TITLE
Add tests for Event.new() implicit end/duration per RFC 5545 §3.6.1

### DIFF
--- a/src/icalendar/tests/test_issue_662_component_properties.py
+++ b/src/icalendar/tests/test_issue_662_component_properties.py
@@ -377,7 +377,7 @@ def test_event_new_datetime_no_dtend_implicit_zero_duration():
     assert "DTEND" not in event
 
 
-def test_event_new_datetime_tzaware_no_dtend_implicit_zero_duration():
+def test_event_new_datetime_tzaware_no_dtend_implicit_zero_duration(tzp):
     """Event.new() with a timezone-aware datetime and no end/duration: implicit zero duration.
 
     See https://github.com/collective/icalendar/issues/1275
@@ -385,8 +385,7 @@ def test_event_new_datetime_tzaware_no_dtend_implicit_zero_duration():
     This is the exact case reported in the issue: timezone-aware DTSTART with
     neither DTEND nor DURATION should yield zero duration, not raise an error.
     """
-    tz = ZoneInfo("Europe/Berlin")
-    start = datetime(2026, 3, 21, 6, 30, 0, tzinfo=tz)
+    start = tzp.localize(datetime(2026, 3, 21, 6, 30, 0), "Europe/Berlin")
     event = Event.new(start=start)
     assert event.end == start
     assert event.duration == timedelta(0)


### PR DESCRIPTION
## Closes issue

- [x] Closes #1275

## Description

This pull request was AI-generated.  

Asking Claude about opinions on #1275 and also asking if it's sufficient test code, it claimed that tests for `Event.new()` was missing.  It added tests with and without time zone as stevepiercy requested.  I've looked through the changes, LGTM.  Are those tests useful, or do they just add clutter and increased test run time?  Honestly, I don't know the answer to that.

This change introduces new tests, and no code changes.  I didn't spent much effort on this, and I promise not to break down and cry if the pull request is rejected.

Claude also wanted to add a line to CHANGES.rst, but I deem this to be too insignificant to clutter that file.

## Checklist

- [ ] I did not add a change log entry to `CHANGES.rst`.
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I did not add any documentation
