### PR TITLE
ci: remove redundant coveralls pip package causing CI failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox coveralls coverage-python-version
+        pip install tox coverage-python-version
     - name: Test
       run: tox -e ${{ matrix.tox_env }}
     - name: Coveralls Parallel


### PR DESCRIPTION
This is a very minor fix to the github CI.  I think the normal pull request checklist does not apply.  This pull request should fix a transient github test run problem that was triggered in pull request #1279.  At least Claude claims so - I don't know if it's correct or not.

---
⚠️ The text below is AI-generated (Claude Sonnet 4.6 via Claude Code) on behalf of tobixen ⚠️

## Summary

- `coverallsapp/github-action@v2` manages its own coveralls binary download
- The Python `coveralls` package was also being installed via `pip install tox coveralls coverage-python-version`, but is not referenced anywhere in `tox.ini` or tests
- When the action's binary download has a transient checksum failure, it falls back to the pip-installed `coveralls` in `$PATH`, which has a different CLI (no `report` subcommand) and exits with code 1
- This causes the job to fail even with `fail-on-error: false` set, which then cascades to cancel other matrix jobs

## Fix

Remove `coveralls` from the pip install line. The action is self-contained and does not need the Python package.

## Test plan

- [ ] Trigger a CI run and verify the Coveralls step no longer fails when the binary download has a transient issue
- [ ] Verify coverage reporting still works end-to-end on a successful binary download

⚠️ This comment is AI-generated (Claude Sonnet 4.6 via Claude Code) on behalf of tobixen ⚠️