### PR TITLE
Put the link check as the last documentation CI task, allowing the do…

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -47,11 +47,11 @@ jobs:
       - name: Create Python virtual environment, install requirements
         run: make .venv PYTHONVERSION=${{ matrix.python-version }}
 
-      - name: Check for broken links
-        run: make linkcheckbroken PYTHONVERSION=${{ matrix.python-version }}
-
       - name: Build HTML documentation
         run: make html PYTHONVERSION=${{ matrix.python-version }}
 
       - name: Run vale
         run: make vale VALEOPTS="--minAlertLevel='warning'" PYTHONVERSION=${{ matrix.python-version }}
+
+      - name: Check for broken links
+        run: make linkcheckbroken PYTHONVERSION=${{ matrix.python-version }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Minor changes
 - Created an :meth:`~icalendar.prop.float.vFloat.ical_value` property for the :class:`~icalendar.prop.float.vFloat` component. See :issue:`876`.
 - Created an :meth:`~icalendar.prop.integer.vInt.ical_value` property for the :class:`~icalendar.prop.integer.vInt` component. See :issue:`876`.
 - Created an :meth:`~icalendar.prop.binary.vBinary.ical_value` property for the :class:`~icalendar.prop.binary.vBinary` component. See :issue:`876`.
+- Put the link check as the last documentation CI task, allowing the documentation build and Vale to run first and fail faster. :pr:`1295`
 
 Breaking changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
…cumentation build and Vale to run first and fail faster.

