### PR TITLE
deprecate escape_string and unescape_string for icalendar 8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Change log
 Minor changes
 ~~~~~~~~~~~~~
 
+- Deprecate ``icalendar.parser.escape_string`` and ``icalendar.parser.unescape_string`` for icalendar version 8. Use ``_escape_string`` and ``_unescape_string`` internally. :issue:`1011`
 - Added behavioral tests for :class:`~icalendar.cal.lazy.LazyCalendar` covering serialization round-trips, ``.todos``, ``.journals``, forward timezone references, and ``with_uid()`` substring false-positives. :issue:`1050`
 - Make icalendar an explicit editable install for clarity. :pr:`1268`
 - Do not run some tests until a pull request is approved. :pr:`1246`

--- a/src/icalendar/parser/__init__.py
+++ b/src/icalendar/parser/__init__.py
@@ -25,7 +25,9 @@ from .property import (
 )
 from .string import (
     _escape_char,
+    _escape_string,
     _unescape_char,
+    _unescape_string,
     escape_char,
     escape_string,
     foldline,
@@ -39,7 +41,9 @@ __all__ = [
     "Contentlines",
     "Parameters",
     "_escape_char",
+    "_escape_string",
     "_unescape_char",
+    "_unescape_string",
     "dquote",
     "escape_char",
     "escape_string",

--- a/src/icalendar/parser/content_line.py
+++ b/src/icalendar/parser/content_line.py
@@ -5,9 +5,9 @@ import re
 from icalendar.parser.parameter import Parameters
 from icalendar.parser.property import unescape_backslash, unescape_list_or_string
 from icalendar.parser.string import (
-    escape_string,
+    _escape_string,
+    _unescape_string,
     foldline,
-    unescape_string,
     validate_token,
 )
 from icalendar.parser_tools import DEFAULT_ENCODING, ICAL_TYPE, to_unicode
@@ -210,10 +210,10 @@ class Contentline(str):
             raw_param_str = self[name_split + 1 : value_split]
             if not self.strict:
                 raw_param_str = _strip_ows_around_delimiters(raw_param_str)
-            param_str = escape_string(raw_param_str)
+            param_str = _escape_string(raw_param_str)
             params = Parameters.from_ical(param_str, strict=self.strict)
             params = Parameters(
-                (unescape_string(key), unescape_list_or_string(value))
+                (_unescape_string(key), unescape_list_or_string(value))
                 for key, value in iter(params.items())
             )
             # Unescape backslash sequences in values but preserve URL encoding

--- a/src/icalendar/parser/property.py
+++ b/src/icalendar/parser/property.py
@@ -2,13 +2,13 @@
 
 import re
 
-from icalendar.parser.string import unescape_string
+from icalendar.parser.string import _unescape_string
 
 
 def unescape_list_or_string(val: str | list[str]) -> str | list[str]:
     """Unescape a value that may be a string or list of strings.
 
-    Applies :func:`unescape_string` to the value. If the value is a list,
+    Applies :func:`_unescape_string` to the value. If the value is a list,
     unescapes each element.
 
     Parameters:
@@ -18,8 +18,8 @@ def unescape_list_or_string(val: str | list[str]) -> str | list[str]:
         The unescaped values.
     """
     if isinstance(val, list):
-        return [unescape_string(s) for s in val]
-    return unescape_string(val)
+        return [_unescape_string(s) for s in val]
+    return _unescape_string(val)
 
 
 _unescape_backslash_regex = re.compile(r"\\([\\,;:nN])")

--- a/src/icalendar/parser/string.py
+++ b/src/icalendar/parser/string.py
@@ -196,7 +196,7 @@ def foldline(line: str, limit: int = 75, fold_sep: str = "\r\n ") -> str:
     return "".join(ret_chars)
 
 
-def escape_string(val: str) -> str:
+def _escape_string(val: str) -> str:
     r"""Escape backslash sequences to URL-encoded hex values.
 
     Converts backslash-escaped characters to their percent-encoded hex
@@ -226,10 +226,26 @@ def escape_string(val: str) -> str:
     )
 
 
-def unescape_string(val: str) -> str:
+def escape_string(val: str) -> str:
+    r"""Escape backslash sequences to URL-encoded hex values.
+
+    .. deprecated:: 7.0.0
+        Use the private :func:`_escape_string` internally. For external use,
+        this function is deprecated.
+    """
+    warnings.warn(
+        "escape_string is deprecated and will be removed in icalendar 8. "
+        "If you are using this function externally, please contact the maintainers.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _escape_string(val)
+
+
+def _unescape_string(val: str) -> str:
     r"""Unescape URL-encoded hex values to their original characters.
 
-    Reverses :func:`escape_string` by converting percent-encoded hex values
+    Reverses :func:`_escape_string` by converting percent-encoded hex values
     back to their original characters. This is used for parameter parsing.
 
     Parameters:
@@ -252,6 +268,22 @@ def unescape_string(val: str) -> str:
         .replace("%3B", ";")
         .replace("%5C", "\\")
     )
+
+
+def unescape_string(val: str) -> str:
+    r"""Unescape URL-encoded hex values to their original characters.
+
+    .. deprecated:: 7.0.0
+        Use the private :func:`_unescape_string` internally. For external use,
+        this function is deprecated.
+    """
+    warnings.warn(
+        "unescape_string is deprecated and will be removed in icalendar 8. "
+        "If you are using this function externally, please contact the maintainers.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _unescape_string(val)
 
 
 # [\w-] because of the iCalendar RFC
@@ -279,7 +311,9 @@ def validate_token(name: str) -> None:
 
 __all__ = [
     "_escape_char",
+    "_escape_string",
     "_unescape_char",
+    "_unescape_string",
     "escape_char",
     "escape_string",
     "foldline",


### PR DESCRIPTION
## Summary

Renames `escape_string` and `unescape_string` to private `_escape_string` and `_unescape_string`, with deprecated public wrappers that emit `DeprecationWarning`.

## Why this matters

Per the maintainer's request in #1011, functions not in the public API (`icalendar.__all__`) should be prefixed with `_`. External callers get a deprecation warning pointing them to contact maintainers before removal in icalendar 8.

## Changes

Follows the same pattern already established for `escape_char`/`unescape_char`:

- `src/icalendar/parser/string.py`: Renamed implementations to `_escape_string` and `_unescape_string`. Added deprecated wrappers. Updated `__all__`.
- `src/icalendar/parser/content_line.py`: Updated imports and call sites to use private versions.
- `src/icalendar/parser/property.py`: Updated import and call sites.
- `src/icalendar/parser/__init__.py`: Added private names to imports and `__all__`.
- `CHANGES.rst`: Added changelog entry under 7.0.4 Minor changes.

## Testing

- Internal callers use the private functions directly (no deprecation warnings in normal operation)
- External callers using `escape_string`/`unescape_string` will see `DeprecationWarning`
- The deprecated wrappers delegate to the private implementations, so behavior is unchanged

Partial fix for #1011

This contribution was developed with AI assistance (Claude Code).

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1308.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->