### PR TITLE
Use Google Style docstring format for caselessdict

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,11 +53,12 @@ Documentation
 - Add documentation for usage of the Sphinx extension `sphinx-icalendar <https://sphinx-icalendar.readthedocs.io/en/latest/>`_. :pr:`1268`
 - Add Repology badge and distribution installation instructions to install documentation. :issue:`1119`
 - Updated references to :class:`~icalendar.prop.uri.vUri` and :class:`~icalendar.enums.RELTYPE` classes in :file:`attr.py`. :issue:`1158`
-- Convert docstrings in ``attr.py`` and ``cal/calendar.py`` to Google Style format. :issue:`1072`
+- Convert docstrings in :file:`attr.py` and :file:`cal/calendar.py` to Google Style format. :issue:`1072`
 - Explained import shortcuts in :doc:`../explanation/api-design` documentation. :issue:`1161`
 - Added tutorial for creating a calendar with events with attendees. :pr:`1262`
 - Added recognition of NLnet Foundation for its funding and Open Collective for donations to the documentation footer. :issue:`1214`
 - Documented ``vText`` properties according to :rfc:`5545#section-3.3.11`. :issue:`742`
+- Convert docstrings in :mod:`icalendar.caselessdict` to Google Style format with ``Parameters``, ``Returns``, ``Raises``, and ``Example`` sections as appropriate. :issue:`1072`
 
 
 7.0.3 (2026-03-03)

--- a/src/icalendar/caselessdict.py
+++ b/src/icalendar/caselessdict.py
@@ -20,8 +20,27 @@ VT = TypeVar("VT")
 def canonsort_keys(
     keys: Iterable[KT], canonical_order: Iterable[KT] | None = None
 ) -> list[KT]:
-    """Sorts leading keys according to canonical_order.  Keys not specified in
-    canonical_order will appear alphabetically at the end.
+    """Sort leading keys according to a canonical order.
+
+    Keys specified in ``canonical_order`` appear first in that order.
+    Remaining keys appear alphabetically at the end.
+
+    Parameters:
+        keys: The keys to sort.
+        canonical_order: The preferred order for leading keys.
+            Keys not in this sequence are sorted alphabetically after
+            the canonical ones. If ``None``, all keys are sorted
+            alphabetically.
+
+    Returns:
+        A new list of keys sorted by canonical order first, then alphabetically.
+
+    Example:
+        ..  code-block:: pycon
+
+            >>> from icalendar.caselessdict import canonsort_keys
+            >>> canonsort_keys(["C", "A", "B"], ["B", "C"])
+            ['B', 'C', 'A']
     """
     canonical_map = {k: i for i, k in enumerate(canonical_order or [])}
     head = [k for k in keys if k in canonical_map]
@@ -32,17 +51,53 @@ def canonsort_keys(
 def canonsort_items(
     dict1: Mapping[KT, VT], canonical_order: Iterable[KT] | None = None
 ) -> list[tuple[KT, VT]]:
-    """Returns a list of items from dict1, sorted by canonical_order."""
+    """Sort items from a mapping according to a canonical key order.
+
+    Parameters:
+        dict1: The mapping whose items to sort.
+        canonical_order: The preferred order for leading keys.
+            If ``None``, all keys are sorted alphabetically.
+
+    Returns:
+        A list of ``(key, value)`` tuples sorted by canonical order.
+
+    Example:
+        ..  code-block:: pycon
+
+            >>> from icalendar.caselessdict import canonsort_items
+            >>> canonsort_items({"C": 3, "A": 1, "B": 2}, ["B", "C"])
+            [('B', 2), ('C', 3), ('A', 1)]
+    """
     return [(k, dict1[k]) for k in canonsort_keys(dict1.keys(), canonical_order)]
 
 
 class CaselessDict(OrderedDict):
-    """A dictionary that isn't case sensitive, and only uses strings as keys.
-    Values retain their case.
+    """A case-insensitive dictionary that uses strings as keys.
+
+    All keys are stored in uppercase internally, but values retain
+    their original case. Keys can be provided as ``str`` or ``bytes``.
+    They are converted to Unicode via :func:`~icalendar.parser_tools.to_unicode`,
+    then uppercased before storage.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Set keys to upper for initial dict."""
+        """Parameters:
+            *args: Positional arguments passed to :class:`~collections.OrderedDict`.
+            **kwargs: Keyword arguments passed to :class:`~collections.OrderedDict`.
+
+        Example:
+
+            Create a new ``CaselessDict`` and normalize existing keys to uppercase.
+
+            ..  code-block:: pycon
+
+                >>> from icalendar.caselessdict import CaselessDict
+                >>> d = CaselessDict(summary="Meeting")
+                >>> d["SUMMARY"]
+                'Meeting'
+                >>> "summary" in d
+                True
+        """
         super().__init__(*args, **kwargs)
         for key, value in self.items():
             key_upper = to_unicode(key).upper()
@@ -53,41 +108,131 @@ class CaselessDict(OrderedDict):
     __hash__ = None
 
     def __getitem__(self, key: Any) -> Any:
+        """Get the item from the ``CaselessDict`` instance by
+        ``key``, case-insensitively.
+
+        Parameters:
+            key: The key to look up, case-insensitively.
+
+        Returns:
+            The (key, value) pair associated with the uppercased key.
+
+        Raises:
+            KeyError: If the key is not found.
+        """
         key = to_unicode(key)
         return super().__getitem__(key.upper())
 
     def __setitem__(self, key: Any, value: Any) -> None:
+        """Set a (key, value) pair, storing the key in uppercase.
+
+        Parameters:
+            key: The key of the pair, case-insensitive.
+            value: The value to associate with the key.
+        """
         key = to_unicode(key)
         super().__setitem__(key.upper(), value)
 
     def __delitem__(self, key: Any) -> None:
+        """Delete a (key, value) pair by its case-insensitive key.
+
+        Parameters:
+            key: The key to delete, case-insensitively.
+
+        Raises:
+            KeyError: If the key is not found.
+        """
         key = to_unicode(key)
         super().__delitem__(key.upper())
 
     def __contains__(self, key: Any) -> bool:
+        """Check whether a key exists in the mapping, case-insensitively.
+
+        Parameters:
+            key: The key to check case-insensitively.
+
+        Returns:
+            ``True`` if the uppercased key exists, else ``False``.
+        """
         key = to_unicode(key)
         return super().__contains__(key.upper())
 
     def get(self, key: Any, default: Any = None) -> Any:
+        """Return the ``key``, optionally with a ``default`` value.
+
+        Parameters:
+            key: The key to look up, case-insensitively.
+            default: The value to return if the key is not found.
+
+        Returns:
+            The value for the key, if present, else the value specified by ``default``.
+        """
         key = to_unicode(key)
         return super().get(key.upper(), default)
 
     def setdefault(self, key: Any, value: Any = None) -> Any:
+        """Create the (key, value) pair, optionally with a ``value``.
+
+        Once set, to change default value use :meth:`update`.
+
+        Parameters:
+            key: The key to look up or create, case-insensitively.
+            value: The default value to set, if given, else ``None``.
+
+        Returns:
+            The value for the key.
+        """
         key = to_unicode(key)
         return super().setdefault(key.upper(), value)
 
     def pop(self, key: Any, default: Any = None) -> Any:
+        """Remove and return the value for ``key``, or ``default`` if not found.
+
+        Parameters:
+            key: The key to remove, case-insensitively.
+            default: The value to return if the key is not found.
+
+        Returns:
+            The removed value, or the value of ``default``.
+        """
         key = to_unicode(key)
         return super().pop(key.upper(), default)
 
     def popitem(self) -> tuple[Any, Any]:
+        """Remove and return the last inserted (key, value) pair.
+
+        Returns:
+            A (key, value) tuple.
+
+        Raises:
+            KeyError: If the dictionary is empty.
+        """
         return super().popitem()
 
     def has_key(self, key: Any) -> bool:
+        """Check whether a key exists, case-insensitively.
+
+        This is a legacy method. Use ``key in dict`` instead.
+
+        Parameters:
+            key: The key to check, case-insensitively.
+
+        Returns:
+            ``True`` if the key exists, else ``False``.
+        """
         key = to_unicode(key)
         return super().__contains__(key.upper())
 
     def update(self, *args: Any, **kwargs: Any) -> None:
+        """Update the dictionary with (key, value) pairs, normalizing keys to uppercase.
+
+        Multiple keys that differ only in case will overwrite each other.
+        Only the last value is retained.
+
+        Parameters:
+            *args: Mappings or iterables of (key, value) pairs.
+            **kwargs: Additional (key, value) pairs.
+        """
         # Multiple keys where key1.upper() == key2.upper() will be lost.
         mappings = list(args) + [kwargs]
         for mapping in mappings:
@@ -97,17 +242,47 @@ class CaselessDict(OrderedDict):
                 self[key] = value
 
     def copy(self) -> Self:
+        """Return a shallow copy of the dictionary.
+
+        Returns:
+            A new instance of the same type with the same contents.
+        """
         return type(self)(super().copy())
 
     def __repr__(self) -> str:
+        """Return a string representation of the dictionary.
+
+        Returns:
+            A string in the form ``CaselessDict({...})``.
+        """
         return f"{type(self).__name__}({dict(self)})"
 
     def __eq__(self, other: object) -> bool:
+        """Check equality with another dictionary.
+
+        Two ``CaselessDict`` instances are equal if they contain the same
+        (key, value) pairs after uppercasing keys. Comparison with a regular
+        ``dict`` also works.
+
+        Parameters:
+            other: The object to compare.
+
+        Returns:
+            ``True`` if equal, ``NotImplemented`` if ``other`` is not a ``dict``.
+        """
         if not isinstance(other, dict):
             return NotImplemented
         return self is other or dict(self.items()) == dict(other.items())
 
     def __ne__(self, other: object) -> bool:
+        """Check inequality with another dictionary.
+
+        Parameters:
+            other: The object to compare.
+
+        Returns:
+            ``True`` if not equal, else ``False``.
+        """
         return not self == other
 
     # A list of keys that must appear first in sorted_keys and sorted_items;
@@ -115,14 +290,24 @@ class CaselessDict(OrderedDict):
     canonical_order = None
 
     def sorted_keys(self) -> list[str]:
-        """Sorts keys according to the canonical_order for the derived class.
-        Keys not specified in canonical_order will appear at the end.
+        """Sort keys according to the canonical order for this class.
+
+        Keys listed in :attr:`canonical_order` appear first in that order.
+        Remaining keys appear alphabetically at the end.
+
+        Returns:
+            A sorted list of keys.
         """
         return canonsort_keys(self.keys(), self.canonical_order)
 
     def sorted_items(self) -> list[tuple[Any, Any]]:
-        """Sorts items according to the canonical_order for the derived class.
-        Items not specified in canonical_order will appear at the end.
+        """Sort items according to the canonical order for this class.
+
+        Items whose keys are listed in :attr:`canonical_order` appear first
+        in that order. Remaining items appear alphabetically by key.
+
+        Returns:
+            A sorted list of (key, value) tuples.
         """
         return canonsort_items(self, self.canonical_order)
 


### PR DESCRIPTION
- [X] See #1072

## Description

Use Google Style docstring format for caselessdict.

## Checklist

- [X] I've added a change log entry to `CHANGES.rst`.
- [ ] ~~I've added or updated tests if applicable.~~
- [X] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [X] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1309.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->