### PR TITLE
test: add edge case coverage for Conference parameter normalization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Minor changes
 
 - Deprecate ``icalendar.parser.escape_string`` and ``icalendar.parser.unescape_string`` for icalendar version 8. Use ``_escape_string`` and ``_unescape_string`` internally. :issue:`1011`
 - Added behavioral tests for :class:`~icalendar.cal.lazy.LazyCalendar` covering serialization round-trips, ``.todos``, ``.journals``, forward timezone references, and ``with_uid()`` substring false-positives. :issue:`1050`
+- Added edge case tests for :class:`~icalendar.prop.conference.Conference` parameter normalization covering string passthrough, empty list filtering, and None omission. :issue:`925`
 - Make icalendar an explicit editable install for clarity. :pr:`1268`
 - Do not run some tests until a pull request is approved. :pr:`1246`
 - Mark skipped CI tasks as skipped instead of running them. :issue:`1286`

--- a/src/icalendar/tests/prop/test_conference.py
+++ b/src/icalendar/tests/prop/test_conference.py
@@ -176,3 +176,62 @@ def test_from_uri_string_adds_value_type():
     conference = Conference.from_uri("http://asd")
     uri = conference.to_uri()
     assert uri.VALUE == "URI"
+
+
+def test_string_feature_passthrough():
+    """A string feature should be kept as-is, not wrapped in a list."""
+    conf = Conference(uri="https://example.com", feature="AUDIO")
+    vuri = conf.to_uri()
+    assert vuri.params["FEATURE"] == "AUDIO"
+
+
+def test_empty_list_feature_filtered():
+    """An empty list feature should be omitted from params entirely."""
+    conf = Conference(uri="https://example.com", feature=[])
+    vuri = conf.to_uri()
+    assert "FEATURE" not in vuri.params
+
+
+def test_none_feature_omitted():
+    """A None feature should not appear in params."""
+    conf = Conference(uri="https://example.com")
+    vuri = conf.to_uri()
+    assert "FEATURE" not in vuri.params
+
+
+@pytest.mark.parametrize(
+    "param_name,kwargs",
+    [
+        ("FEATURE", {"feature": "AUDIO"}),
+        ("LABEL", {"label": "Room A"}),
+        ("LANGUAGE", {"language": "EN"}),
+    ],
+)
+def test_string_passthrough_all_params(param_name, kwargs):
+    """String values for feature, label, and language should pass through unchanged."""
+    conf = Conference(uri="https://example.com", **kwargs)
+    vuri = conf.to_uri()
+    assert vuri.params[param_name] == list(kwargs.values())[0]
+
+
+@pytest.mark.parametrize(
+    "param_name,kwargs",
+    [
+        ("FEATURE", {"feature": []}),
+        ("LABEL", {"label": []}),
+        ("LANGUAGE", {"language": []}),
+    ],
+)
+def test_empty_list_filtered_all_params(param_name, kwargs):
+    """Empty lists for feature, label, and language should be omitted from params."""
+    conf = Conference(uri="https://example.com", **kwargs)
+    vuri = conf.to_uri()
+    assert param_name not in vuri.params
+
+
+@pytest.mark.parametrize("param_name", ["FEATURE", "LABEL", "LANGUAGE"])
+def test_none_omitted_all_params(param_name):
+    """None values for feature, label, and language should not appear in params."""
+    conf = Conference(uri="https://example.com")
+    vuri = conf.to_uri()
+    assert param_name not in vuri.params

--- a/src/icalendar/tests/prop/test_conference.py
+++ b/src/icalendar/tests/prop/test_conference.py
@@ -200,7 +200,7 @@ def test_none_feature_omitted():
 
 
 @pytest.mark.parametrize(
-    "param_name,kwargs",
+    ("param_name", "kwargs"),
     [
         ("FEATURE", {"feature": "AUDIO"}),
         ("LABEL", {"label": "Room A"}),
@@ -215,7 +215,7 @@ def test_string_passthrough_all_params(param_name, kwargs):
 
 
 @pytest.mark.parametrize(
-    "param_name,kwargs",
+    ("param_name", "kwargs"),
     [
         ("FEATURE", {"feature": []}),
         ("LABEL", {"label": []}),


### PR DESCRIPTION
## Summary

Adds 12 tests covering edge cases in the `normalize()` function used by `Conference.to_uri()` for the `feature`, `label`, and `language` parameters.

## Why this matters

PR #921 fixed the normalization bug from #908, but left edge cases untested. The `normalize()` function in `conference.py:88-93` handles three input types (string, empty list, None) and any of these branches could regress during refactoring without test coverage.

## Changes

`src/icalendar/tests/prop/test_conference.py`: Added 12 new tests in three groups:

- **Focused tests** (`test_string_feature_passthrough`, `test_empty_list_feature_filtered`, `test_none_feature_omitted`): Verify core behavior with `feature` parameter
- **Parametrized string passthrough** (`test_string_passthrough_all_params`): Verifies string values pass through unchanged for all three parameters
- **Parametrized empty list filtering** (`test_empty_list_filtered_all_params`): Verifies empty lists are omitted for all three parameters
- **Parametrized None omission** (`test_none_omitted_all_params`): Verifies None values produce no param entry for all three parameters

## Testing

All 36 tests pass (24 existing + 12 new):
```
============================== 36 passed in 0.22s ==============================
```

Fixes #925

This contribution was developed with AI assistance (Claude Code).