### PR TITLE
Fix broken docstring link in availability.py #1158

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,7 +61,7 @@ Documentation
 - Added recognition of NLnet Foundation for its funding and Open Collective for donations to the documentation footer. :issue:`1214`
 - Documented ``vText`` properties according to :rfc:`5545#section-3.3.11`. :issue:`742`
 - Convert docstrings in :mod:`icalendar.caselessdict` to Google Style format with ``Parameters``, ``Returns``, ``Raises``, and ``Example`` sections as appropriate. :issue:`1072`
-- Fix broken docstring link in `cal/availability.py`. :issue:`1158`
+- Fix broken docstring link in :file:`cal/availability.py`. :issue:`1158`
 
 7.0.3 (2026-03-03)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,7 +61,7 @@ Documentation
 - Added recognition of NLnet Foundation for its funding and Open Collective for donations to the documentation footer. :issue:`1214`
 - Documented ``vText`` properties according to :rfc:`5545#section-3.3.11`. :issue:`742`
 - Convert docstrings in :mod:`icalendar.caselessdict` to Google Style format with ``Parameters``, ``Returns``, ``Raises``, and ``Example`` sections as appropriate. :issue:`1072`
-- Fix broken docstring link in :file:`cal/availability.py`. :issue:`1158`
+- Fix broken docstring for :meth:`~icalendar.cal.component.Component.add_component` link in :attr:`~icalendar.cal.availability.Availability.available`. :issue:`1158`
 
 7.0.3 (2026-03-03)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,7 +61,7 @@ Documentation
 - Added recognition of NLnet Foundation for its funding and Open Collective for donations to the documentation footer. :issue:`1214`
 - Documented ``vText`` properties according to :rfc:`5545#section-3.3.11`. :issue:`742`
 - Convert docstrings in :mod:`icalendar.caselessdict` to Google Style format with ``Parameters``, ``Returns``, ``Raises``, and ``Example`` sections as appropriate. :issue:`1072`
-
+- Fix broken docstring link in `cal/availability.py`. :issue:`1158`
 
 7.0.3 (2026-03-03)
 ------------------

--- a/src/icalendar/cal/availability.py
+++ b/src/icalendar/cal/availability.py
@@ -230,7 +230,7 @@ class Availability(Component):
 
         This is a shortcut to get all VAVAILABLE sub-components.
         Modifications do not change the calendar.
-        Use :meth:`icalendar.cal.component.Component.add_component`.
+        Use :meth:`~icalendar.cal.component.Component.add_component`.
         """
         return self.walk("AVAILABLE")
 

--- a/src/icalendar/cal/availability.py
+++ b/src/icalendar/cal/availability.py
@@ -230,7 +230,7 @@ class Availability(Component):
 
         This is a shortcut to get all VAVAILABLE sub-components.
         Modifications do not change the calendar.
-        Use :py:meth:`Component.add_component`.
+        Use :meth:`icalendar.cal.component.Component.add_component`.
         """
         return self.walk("AVAILABLE")
 


### PR DESCRIPTION
## Closes issue

Replace `ISSUE_NUMBER` with the issue number that your pull request fixes. Then GitHub will link and automatically close the related issue.

- Part of #1158

## Description

Fix broken reference link in src/icalendar/cal/availability.py docstring.

## Checklist

- [x] I've added a change log entry to `CHANGES.rst`.
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

Upload screenshots, videos, links to documentation, or any other relevant information.


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1313.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->