### PR TITLE
Add type hints for some py files #938

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Minor changes
 - Created an :meth:`~icalendar.prop.binary.vBinary.ical_value` property for the :class:`~icalendar.prop.binary.vBinary` component. :issue:`876`
 - Put the link check as the last documentation CI task, allowing the documentation build and Vale to run first and fail faster. :pr:`1295`
 - Extended :func:`~icalendar.timezone.tzp.TZP.localize` to support localizing both :class:`datetime.datetime` and :class:`datetime.time` objects, returning timezone-aware :class:`datetime.time` objects for the latter. :issue:`1142`
+- Add type hints to tests directory functions. :issue:`938`
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/src/icalendar/tests/test_issue_1073_pyodide_import.py
+++ b/src/icalendar/tests/test_issue_1073_pyodide_import.py
@@ -10,7 +10,7 @@ from unittest import mock
 from icalendar.timezone.zoneinfo import ZONEINFO
 
 
-def test_zoneinfo_class_does_not_initialize_at_import_time():
+def test_zoneinfo_class_does_not_initialize_at_import_time() -> None:
     """Test that ZONEINFO class attributes are not computed at class definition.
 
     The class should have None placeholders for _utc and _available_timezones_cache
@@ -30,7 +30,7 @@ def test_zoneinfo_class_does_not_initialize_at_import_time():
     assert isinstance(ZONEINFO.__dict__["_available_timezones"], property)
 
 
-def test_zoneinfo_utc_property_works():
+def test_zoneinfo_utc_property_works() -> None:
     """Test that UTC timezone property returns a valid ZoneInfo."""
     z = ZONEINFO()
 
@@ -42,7 +42,7 @@ def test_zoneinfo_utc_property_works():
     assert z.utc is utc
 
 
-def test_zoneinfo_available_timezones_property_works():
+def test_zoneinfo_available_timezones_property_works() -> None:
     """Test that available_timezones property returns a valid set."""
     z = ZONEINFO()
 
@@ -55,7 +55,7 @@ def test_zoneinfo_available_timezones_property_works():
     assert z._available_timezones is timezones
 
 
-def test_zoneinfo_knows_timezone_id():
+def test_zoneinfo_knows_timezone_id() -> None:
     """Test that knows_timezone_id correctly uses the lazy _available_timezones."""
     z = ZONEINFO()
 
@@ -64,7 +64,7 @@ def test_zoneinfo_knows_timezone_id():
     assert z.knows_timezone_id("NonExistent/Timezone") is False
 
 
-def test_zoneinfo_can_be_instantiated_before_timezone_access():
+def test_zoneinfo_can_be_instantiated_before_timezone_access() -> None:
     """Test that ZONEINFO can be instantiated without triggering timezone lookups.
 
     This is the key test for Pyodide compatibility - we need to be able to create
@@ -83,13 +83,13 @@ def test_zoneinfo_can_be_instantiated_before_timezone_access():
             assert z.name == "zoneinfo"
 
 
-def test_zoneinfo_thread_safe_initialization():
+def test_zoneinfo_thread_safe_initialization() -> None:
     """Test that lazy initialization is thread-safe."""
     z = ZONEINFO()
     results = []
     errors = []
 
-    def access_utc():
+    def access_utc() -> None:
         try:
             utc = z.utc
             results.append(utc)

--- a/src/icalendar/tests/test_unit_caselessdict.py
+++ b/src/icalendar/tests/test_unit_caselessdict.py
@@ -4,7 +4,7 @@ import icalendar
 
 
 class TestCaselessdict(unittest.TestCase):
-    def test_caselessdict_canonsort_keys(self):
+    def test_caselessdict_canonsort_keys(self) -> None:
         canonsort_keys = icalendar.caselessdict.canonsort_keys
 
         keys = ["DTEND", "DTSTAMP", "DTSTART", "UID", "SUMMARY", "LOCATION"]
@@ -35,7 +35,7 @@ class TestCaselessdict(unittest.TestCase):
         out = canonsort_keys(keys, ("UID", "DTSTART", "DTEND", "RRULE", "EXDATE"))
         assert out == ["UID", "DTSTART", "DTEND", "DTSTAMP", "LOCATION", "SUMMARY"]
 
-    def test_caselessdict_canonsort_items(self):
+    def test_caselessdict_canonsort_items(self) -> None:
         canonsort_items = icalendar.caselessdict.canonsort_items
 
         d = {
@@ -73,7 +73,7 @@ class TestCaselessdict(unittest.TestCase):
             ("r", 1.0),
         ]
 
-    def test_caselessdict_copy(self):
+    def test_caselessdict_copy(self) -> None:
         CaselessDict = icalendar.caselessdict.CaselessDict
 
         original_dict = CaselessDict(key1="val1", key2="val2")
@@ -81,7 +81,7 @@ class TestCaselessdict(unittest.TestCase):
 
         assert original_dict == copied_dict
 
-    def test_CaselessDict(self):
+    def test_CaselessDict(self) -> None:
         CaselessDict = icalendar.caselessdict.CaselessDict
 
         ncd = CaselessDict(key1="val1", key2="val2")
@@ -112,7 +112,7 @@ class TestCaselessdict(unittest.TestCase):
         keys = sorted(ncd.keys())
         assert keys == ["KEY1", "KEY2", "KEY3", "KEY5", "KEY6"]
 
-    def test_eq_with_non_dict_types(self):
+    def test_eq_with_non_dict_types(self) -> None:
         """Test that CaselessDict.__eq__ handles non-dict comparisons correctly."""
         CaselessDict = icalendar.caselessdict.CaselessDict
 
@@ -132,7 +132,7 @@ class TestCaselessdict(unittest.TestCase):
         assert d != {"TEST": 2}
         assert d != {"OTHER": 1}
 
-    def test_ne_with_non_dict_types(self):
+    def test_ne_with_non_dict_types(self) -> None:
         """Test that CaselessDict.__ne__ handles non-dict comparisons correctly."""
         CaselessDict = icalendar.caselessdict.CaselessDict
 

--- a/src/icalendar/tests/test_with_doctest.py
+++ b/src/icalendar/tests/test_with_doctest.py
@@ -36,12 +36,12 @@ MODULE_NAMES = [
 ]
 
 
-def test_this_module_is_among_them():
+def test_this_module_is_among_them() -> None:
     assert __name__ in MODULE_NAMES
 
 
 @pytest.mark.parametrize("module_name", MODULE_NAMES)
-def test_docstring_of_python_file(module_name, env_for_doctest):
+def test_docstring_of_python_file(module_name: str, env_for_doctest) -> None:
     """This test runs doctest on the Python module."""
     try:
         module = importlib.import_module(module_name)
@@ -65,7 +65,7 @@ DOCUMENT_PATHS = list(REPOSITORY.glob("**/*.rst"))
         "index.rst",
     ],
 )
-def test_files_is_included(filename):
+def test_files_is_included(filename: str) -> None:
     assert any(path.name == filename for path in DOCUMENT_PATHS)
 
 
@@ -91,6 +91,6 @@ def test_documentation_file(document, zoneinfo_only, env_for_doctest, tzp):
     )
 
 
-def test_can_import_zoneinfo(env_for_doctest):
+def test_can_import_zoneinfo(env_for_doctest) -> None:
     """Allow importing zoneinfo for tests."""
     assert "zoneinfo" in sys.modules


### PR DESCRIPTION
## Closes issue

Replace `ISSUE_NUMBER` with the issue number that your pull request fixes. Then GitHub will link and automatically close the related issue.

- [ ] contributes to #938 

## Description

Write a description of the fixes or improvements.

## Checklist

- [x] I've added a change log entry to `CHANGES.rst`.
- [ ] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

I think env_for_doctest in test_with_doctest.py needs to use `Any` for type hints. But it requires additional library import, so I've left it as-is for now.


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1317.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->