### PR TITLE
Add docs in __new__ methods to resolve issue #1118

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,7 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
+- Document ``__new__`` for :class:`~icalendar.prop.boolean.vBoolean`, :class:`~icalendar.prop.float.vFloat`, :class:`~icalendar.prop.text.vText`, :class:`~icalendar.prop.cal_address.vCalAddress`, and :class:`~icalendar.prop.uri.vUri`, and use the simple ``from icalendar import ...`` style in related docstring examples.
 - Run ``sphinx-build`` with ``-W`` to turn warnings into errors. :issue:`1306`
 - Added `sphinx-llms-txt <https://sphinx-llms-txt.readthedocs.io/en/stable/>`_ extension to generate :file:`llms.txt` and :file:`llms-full.txt` files for AI/LLM documentation consumption. :issue:`1302`
 - Fixed CI Vale check reporting and resolved Vale errors. :pr:`1278`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,7 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-- Document ``__new__`` for :class:`~icalendar.prop.boolean.vBoolean`, :class:`~icalendar.prop.float.vFloat`, :class:`~icalendar.prop.text.vText`, :class:`~icalendar.prop.cal_address.vCalAddress`, and :class:`~icalendar.prop.uri.vUri`, and use the simple ``from icalendar import ...`` style in related docstring examples.
+- Document ``__new__`` for :class:`~icalendar.prop.boolean.vBoolean`, :class:`~icalendar.prop.float.vFloat`, :class:`~icalendar.prop.text.vText`, :class:`~icalendar.prop.cal_address.vCalAddress`, and :class:`~icalendar.prop.uri.vUri` in related docstring examples. :issue: `1118`
 - Run ``sphinx-build`` with ``-W`` to turn warnings into errors. :issue:`1306`
 - Added `sphinx-llms-txt <https://sphinx-llms-txt.readthedocs.io/en/stable/>`_ extension to generate :file:`llms.txt` and :file:`llms-full.txt` files for AI/LLM documentation consumption. :issue:`1302`
 - Fixed CI Vale check reporting and resolved Vale errors. :pr:`1278`

--- a/src/icalendar/prop/boolean.py
+++ b/src/icalendar/prop/boolean.py
@@ -55,6 +55,33 @@ class vBoolean(int):
     def __new__(
         cls, *args: Any, params: dict[str, Any] | None = None, **kwargs: Any
     ) -> Self:
+        """Create a new :class:`~icalendar.prop.boolean.vBoolean` instance.
+
+        This method overrides :py:meth:`int.__new__` because BOOLEAN values
+        inherit from :class:`int`, which is immutable. The ``__new__`` method
+        creates the instance and attaches iCalendar property parameters.
+
+        Parameters:
+            *args: Positional arguments passed to :py:meth:`int.__new__`.
+                Typically a single Python :class:`bool` or ``0`` / ``1``.
+            params: Optional property parameters according to :rfc:`5545`.
+            **kwargs: Additional keyword arguments passed to
+                :py:meth:`int.__new__`.
+
+        Returns:
+            A new :class:`~icalendar.prop.boolean.vBoolean` instance with
+            associated parameters.
+
+        Examples:
+            .. code-block:: pycon
+
+                >>> from icalendar.prop import vBoolean
+                >>> b = vBoolean(True, params={"VALUE": "BOOLEAN"})
+                >>> bool(b)
+                True
+                >>> b.params
+                Parameters({'VALUE': 'BOOLEAN'})
+        """
         self = super().__new__(cls, *args, **kwargs)
         self.params = Parameters(params)
         return self

--- a/src/icalendar/prop/boolean.py
+++ b/src/icalendar/prop/boolean.py
@@ -35,7 +35,7 @@ class vBoolean(int):
 
     .. code-block:: pycon
 
-        >>> from icalendar import vBoolean
+        >>> from icalendar.prop import vBoolean
         >>> boolean = vBoolean.from_ical('TRUE')
         >>> boolean
         True

--- a/src/icalendar/prop/boolean.py
+++ b/src/icalendar/prop/boolean.py
@@ -35,7 +35,7 @@ class vBoolean(int):
 
     .. code-block:: pycon
 
-        >>> from icalendar.prop import vBoolean
+        >>> from icalendar import vBoolean
         >>> boolean = vBoolean.from_ical('TRUE')
         >>> boolean
         True
@@ -75,7 +75,7 @@ class vBoolean(int):
         Examples:
             .. code-block:: pycon
 
-                >>> from icalendar.prop import vBoolean
+                >>> from icalendar import vBoolean
                 >>> b = vBoolean(True, params={"VALUE": "BOOLEAN"})
                 >>> bool(b)
                 True

--- a/src/icalendar/prop/cal_address.py
+++ b/src/icalendar/prop/cal_address.py
@@ -87,7 +87,7 @@ class vCalAddress(str):
         Examples:
             .. code-block:: pycon
 
-                >>> from icalendar.prop import vCalAddress
+                >>> from icalendar import vCalAddress
                 >>> a = vCalAddress(
                 ...     "mailto:jsmith@example.com",
                 ...     params={"CN": "John Smith"},

--- a/src/icalendar/prop/cal_address.py
+++ b/src/icalendar/prop/cal_address.py
@@ -66,6 +66,37 @@ class vCalAddress(str):
         /,
         params: dict[str, Any] | None = None,
     ) -> Self:
+        """Create a new :class:`~icalendar.prop.cal_address.vCalAddress` instance.
+
+        This method overrides :py:meth:`str.__new__` because CAL-ADDRESS values
+        inherit from :class:`str`, which is immutable. The ``__new__`` method
+        decodes bytes if needed, creates the string instance, and attaches
+        iCalendar property parameters.
+
+        Parameters:
+            value: Calendar user address, usually a ``mailto`` URI as defined in
+                :rfc:`5545#section-3.3.3`, passed through
+                :func:`~icalendar.parser_tools.to_unicode`.
+            encoding: Encoding used when ``value`` is :class:`bytes`.
+            params: Optional property parameters according to :rfc:`5545`.
+
+        Returns:
+            A new :class:`~icalendar.prop.cal_address.vCalAddress` instance with
+            associated parameters.
+
+        Examples:
+            .. code-block:: pycon
+
+                >>> from icalendar.prop import vCalAddress
+                >>> a = vCalAddress(
+                ...     "mailto:jsmith@example.com",
+                ...     params={"CN": "John Smith"},
+                ... )
+                >>> str(a)
+                'mailto:jsmith@example.com'
+                >>> a.params["CN"]
+                'John Smith'
+        """
         value = to_unicode(value, encoding=encoding)
         self = super().__new__(cls, value)
         self.params = Parameters(params)

--- a/src/icalendar/prop/float.py
+++ b/src/icalendar/prop/float.py
@@ -38,7 +38,7 @@ class vFloat(float):
 
         .. code-block:: pycon
 
-            >>> from icalendar import vFloat
+            >>> from icalendar.prop import vFloat
             >>> float = vFloat.from_ical('1000000.0000001')
             >>> float
             1000000.0000001
@@ -129,7 +129,7 @@ class vFloat(float):
         """
         JCalParsingError.validate_property(jcal_property, cls)
         if jcal_property[0].upper() == "GEO":
-            from icalendar import vGeo
+            from icalendar.prop import vGeo
 
             return vGeo.from_jcal(jcal_property)
         JCalParsingError.validate_value_type(jcal_property[3], float, cls, 3)

--- a/src/icalendar/prop/float.py
+++ b/src/icalendar/prop/float.py
@@ -38,7 +38,7 @@ class vFloat(float):
 
         .. code-block:: pycon
 
-            >>> from icalendar.prop import vFloat
+            >>> from icalendar import vFloat
             >>> float = vFloat.from_ical('1000000.0000001')
             >>> float
             1000000.0000001
@@ -80,7 +80,7 @@ class vFloat(float):
         Examples:
             .. code-block:: pycon
 
-                >>> from icalendar.prop import vFloat
+                >>> from icalendar import vFloat
                 >>> x = vFloat(1.333, params={"VALUE": "FLOAT"})
                 >>> float(x)
                 1.333
@@ -129,7 +129,7 @@ class vFloat(float):
         """
         JCalParsingError.validate_property(jcal_property, cls)
         if jcal_property[0].upper() == "GEO":
-            from icalendar.prop import vGeo
+            from icalendar import vGeo
 
             return vGeo.from_jcal(jcal_property)
         JCalParsingError.validate_value_type(jcal_property[3], float, cls, 3)

--- a/src/icalendar/prop/float.py
+++ b/src/icalendar/prop/float.py
@@ -59,6 +59,34 @@ class vFloat(float):
     def __new__(
         cls, *args: Any, params: dict[str, Any] | None = None, **kwargs: Any
     ) -> Self:
+        """Create a new :class:`~icalendar.prop.float.vFloat` instance.
+
+        This method overrides :py:meth:`float.__new__` because FLOAT values
+        inherit from :class:`float`, which is immutable. The ``__new__`` method
+        creates the instance and attaches iCalendar property parameters.
+
+        Parameters:
+            *args: Positional arguments passed to :py:meth:`float.__new__`.
+                Typically a single numeric value or string accepted by
+                :class:`float`.
+            params: Optional property parameters according to :rfc:`5545`.
+            **kwargs: Additional keyword arguments passed to
+                :py:meth:`float.__new__`.
+
+        Returns:
+            A new :class:`~icalendar.prop.float.vFloat` instance with
+            associated parameters.
+
+        Examples:
+            .. code-block:: pycon
+
+                >>> from icalendar.prop import vFloat
+                >>> x = vFloat(1.333, params={"VALUE": "FLOAT"})
+                >>> float(x)
+                1.333
+                >>> x.params
+                Parameters({'VALUE': 'FLOAT'})
+        """
         self = super().__new__(cls, *args, **kwargs)
         self.params = Parameters(params)
         return self

--- a/src/icalendar/prop/text.py
+++ b/src/icalendar/prop/text.py
@@ -76,6 +76,35 @@ class vText(str):
         /,
         params: dict[str, Any] | None = None,
     ) -> Self:
+        """Create a new :class:`~icalendar.prop.text.vText` instance.
+
+        This method overrides :py:meth:`str.__new__` because TEXT values
+        inherit from :class:`str`, which is immutable. The ``__new__`` method
+        decodes bytes if needed, creates the string instance, and attaches
+        encoding metadata and iCalendar property parameters.
+
+        Parameters:
+            value: Raw text passed to :func:`~icalendar.parser_tools.to_unicode`
+                before constructing the :class:`str` value.
+            encoding: Encoding used when ``value`` is :class:`bytes`.
+            params: Optional property parameters according to :rfc:`5545`.
+
+        Returns:
+            A new :class:`~icalendar.prop.text.vText` instance with
+            associated parameters.
+
+        Examples:
+            .. code-block:: pycon
+
+                >>> from icalendar.prop import vText
+                >>> t = vText("Hello", params={"LANGUAGE": "en"})
+                >>> str(t)
+                'Hello'
+                >>> t.encoding
+                'utf-8'
+                >>> t.params
+                Parameters({'LANGUAGE': 'en'})
+        """
         value = to_unicode(value, encoding=encoding)
         self = super().__new__(cls, value)
         self.encoding = encoding

--- a/src/icalendar/prop/text.py
+++ b/src/icalendar/prop/text.py
@@ -96,7 +96,7 @@ class vText(str):
         Examples:
             .. code-block:: pycon
 
-                >>> from icalendar.prop import vText
+                >>> from icalendar import vText
                 >>> t = vText("Hello", params={"LANGUAGE": "en"})
                 >>> str(t)
                 'Hello'

--- a/src/icalendar/prop/uri.py
+++ b/src/icalendar/prop/uri.py
@@ -85,7 +85,7 @@ class vUri(str):
         Examples:
             .. code-block:: pycon
 
-                >>> from icalendar.prop import vUri
+                >>> from icalendar import vUri
                 >>> u = vUri(
                 ...     "http://example.com/agenda.doc",
                 ...     params={"VALUE": "URI"},

--- a/src/icalendar/prop/uri.py
+++ b/src/icalendar/prop/uri.py
@@ -65,6 +65,36 @@ class vUri(str):
         /,
         params: dict[str, Any] | None = None,
     ) -> Self:
+        """Create a new :class:`~icalendar.prop.uri.vUri` instance.
+
+        This method overrides :py:meth:`str.__new__` because URI values inherit
+        from :class:`str`, which is immutable. The ``__new__`` method decodes
+        bytes if needed, creates the string instance, and attaches iCalendar
+        property parameters.
+
+        Parameters:
+            value: URI string or bytes decoded with ``encoding``, passed through
+                :func:`~icalendar.parser_tools.to_unicode`.
+            encoding: Encoding used when ``value`` is :class:`bytes`.
+            params: Optional property parameters according to :rfc:`5545`.
+
+        Returns:
+            A new :class:`~icalendar.prop.uri.vUri` instance with associated
+            parameters.
+
+        Examples:
+            .. code-block:: pycon
+
+                >>> from icalendar.prop import vUri
+                >>> u = vUri(
+                ...     "http://example.com/agenda.doc",
+                ...     params={"VALUE": "URI"},
+                ... )
+                >>> u.uri
+                'http://example.com/agenda.doc'
+                >>> u.params["VALUE"]
+                'URI'
+        """
         value = to_unicode(value, encoding=encoding)
         self = super().__new__(cls, value)
         self.params = Parameters(params)


### PR DESCRIPTION
**Closes issue**
Closes #1118 

**Description**
This pull request adds Google-style docstrings to the __new__ methods of immutable value types in icalendar.prop so the API docs explain how instances are constructed and how params is attached:

vBoolean (icalendar.prop.boolean)
vFloat (icalendar.prop.float)
vText (icalendar.prop.text)
vCalAddress (icalendar.prop.cal_address)
vUri (icalendar.prop.uri)

- Each docstring summarizes why __new__ is overridden (subclass of int, float, or str), documents Parameters and Returns per the [Python docstrings](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html#python-docstrings) section of the documentation style guide, and includes runnable Examples using .. code-block:: pycon where appropriate.

- No behavioral changes to serialization or parsing are intended; this is documentation only.

Link: [icalendar documentation style guide — Python docstrings](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html#python-docstrings).

## Closes issue


