### PR TITLE
Remove @abe-101 from docs-related CODEOWNERS entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,15 +5,15 @@
 * @niccokunzmann @stevepiercy
 
 # Documentation, except docstrings in `src`
-*.md @stevepiercy @abe-101
-*.rst @stevepiercy @abe-101
-/.readthedocs.yml @stevepiercy @niccokunzmann @abe-101
-/.vale.ini @stevepiercy @abe-101
-/CONTRIBUTING.md @niccokunzmann @stevepiercy @abe-101
-/docs/ @stevepiercy @abe-101
-/docs/tutorials/ @stevepiercy @abe-101 @peskypotato
-/Makefile @stevepiercy @abe-101
-/styles @stevepiercy @abe-101
+*.md @stevepiercy
+*.rst @stevepiercy
+/.readthedocs.yml @stevepiercy @niccokunzmann
+/.vale.ini @stevepiercy
+/CONTRIBUTING.md @niccokunzmann @stevepiercy
+/docs/ @stevepiercy
+/docs/tutorials/ @stevepiercy @peskypotato
+/Makefile @stevepiercy
+/styles @stevepiercy
 
 # Core calendar logic
 /src/ @niccokunzmann @SashankBhamidi @stevepiercy @angatha
@@ -34,7 +34,7 @@
 /tox.ini @niccokunzmann @stevepiercy
 
 # Security
-/SECURITY.md @niccokunzmann @stevepiercy @abe-101 @angatha
+/SECURITY.md @niccokunzmann @stevepiercy @angatha
 
 # Release stuff
 /CHANGES.rst @niccokunzmann @stevepiercy

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Change log
 Minor changes
 ~~~~~~~~~~~~~
 
+- Remove ``@abe-101`` from docs-related CODEOWNERS entries to reduce review noise.
 - Deprecate ``icalendar.parser.escape_string`` and ``icalendar.parser.unescape_string`` for icalendar version 8. Use ``_escape_string`` and ``_unescape_string`` internally. :issue:`1011`
 - Added behavioral tests for :class:`~icalendar.cal.lazy.LazyCalendar` covering serialization round-trips, ``.todos``, ``.journals``, forward timezone references, and ``with_uid()`` substring false-positives. :issue:`1050`
 - Added edge case tests for :class:`~icalendar.prop.conference.Conference` parameter normalization covering string passthrough, empty list filtering, and None omission. :issue:`925`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,6 @@ Change log
 Minor changes
 ~~~~~~~~~~~~~
 
-- Remove ``@abe-101`` from docs-related CODEOWNERS entries to reduce review noise.
 - Deprecate ``icalendar.parser.escape_string`` and ``icalendar.parser.unescape_string`` for icalendar version 8. Use ``_escape_string`` and ``_unescape_string`` internally. :issue:`1011`
 - Added behavioral tests for :class:`~icalendar.cal.lazy.LazyCalendar` covering serialization round-trips, ``.todos``, ``.journals``, forward timezone references, and ``with_uid()`` substring false-positives. :issue:`1050`
 - Added edge case tests for :class:`~icalendar.prop.conference.Conference` parameter normalization covering string passthrough, empty list filtering, and None omission. :issue:`925`


### PR DESCRIPTION
## Closes issue

~`ISSUE_NUMBER` with the issue number that your pull request fixes. Then GitHub will link and automatically close the related issue.~

~- [ ] Closes #ISSUE_NUMBER~
I assume this isn't needed given the simplicity of this change

## Description

Being listed as a codeowner for all docs-related files was generating too much PR review noise. Removing myself to reduce that noise while leaving the other appropriate owners in place.

## Checklist

- [x] I've added a change log entry to `CHANGES.rst`.
- [ ] I've added or updated tests if applicable.
- [ ] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

Upload screenshots, videos, links to documentation, or any other relevant information.


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1319.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->