### PR TITLE
fix: replace broken PR #1278 link in CHANGES.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,7 +50,7 @@ Documentation
 
 - Run ``sphinx-build`` with ``-W`` to turn warnings into errors. :issue:`1306`
 - Added `sphinx-llms-txt <https://sphinx-llms-txt.readthedocs.io/en/stable/>`_ extension to generate :file:`llms.txt` and :file:`llms-full.txt` files for AI/LLM documentation consumption. :issue:`1302`
-- Fixed CI Vale check reporting and resolved Vale errors. :pr:`1278`
+- Fixed CI Vale check reporting and resolved Vale errors. :issue:`1277`
 - Include :file:`Makefile` in documentation workflow path filters so documentation CI runs when Makefile logic changes, and keep Vale failures visible in CI output. :issue:`1277`
 - Document how to install icalendar on Alpine Linux. :pr:`1290`
 - Add documentation for usage of the Sphinx extension `sphinx-icalendar <https://sphinx-icalendar.readthedocs.io/en/latest/>`_. :pr:`1268`


### PR DESCRIPTION
## Summary

Replaces a broken PR reference in `CHANGES.rst` with the related issue.

PR #1278 returns 404 (deleted fork or force-pushed). The changelog entry "Fixed CI Vale check reporting and resolved Vale errors" is documented in issue #1277, so I updated the reference from `:pr:`\`1278\`` to `:issue:`\`1277\``.

This was found via `make linkcheckbroken` — the only broken link in the entire documentation build.

## Verification

```
make linkcheckbroken
```

Before: `reference/changelog.rst:53: [broken] https://github.com/collective/icalendar/pull/1278: 404`
After: No broken links.

Refs #1158

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1321.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->