### PR TITLE
fix(parser): use to_unicode in _escape_char to support bytes input

### DIFF
--- a/src/icalendar/parser/string.py
+++ b/src/icalendar/parser/string.py
@@ -3,10 +3,10 @@
 import re
 import warnings
 
-from icalendar.parser_tools import DEFAULT_ENCODING
+from icalendar.parser_tools import DEFAULT_ENCODING, to_unicode
 
 
-def _escape_char(text: str | bytes) -> str | bytes:
+def _escape_char(text: str | bytes) -> str:
     r"""Format value according to iCalendar TEXT escaping rules.
 
     Escapes special characters in text values according to :rfc:`5545#section-3.3.11`
@@ -32,6 +32,7 @@ def _escape_char(text: str | bytes) -> str | bytes:
     """
     assert isinstance(text, (str, bytes))
     # NOTE: ORDER MATTERS!
+    text = to_unicode(text)
     return (
         text.replace(r"\N", "\n")
         .replace("\\", "\\\\")

--- a/src/icalendar/tests/test_parsing.py
+++ b/src/icalendar/tests/test_parsing.py
@@ -9,7 +9,7 @@ from icalendar import vBinary, vRecur
 from icalendar.cal.calendar import Calendar
 from icalendar.cal.component_factory import ComponentFactory
 from icalendar.cal.event import Event
-from icalendar.parser import Contentline, Parameters, _unescape_char
+from icalendar.parser import Contentline, Parameters, _escape_char, _unescape_char
 
 
 @pytest.mark.parametrize(
@@ -237,6 +237,21 @@ def test_escaped_characters_read(event_name, expected_cn, expected_ics, events):
 def test_unescape_char():
     assert _unescape_char(b"123") == b"123"
     assert _unescape_char(b"\\n") == b"\n"
+
+
+def test_escape_char():
+    """Test that _escape_char works with both str and bytes input."""
+    # str input
+    assert _escape_char("hello;world") == r"hello\;world"
+    assert _escape_char("one,two") == r"one\,two"
+    assert _escape_char("back\\slash") == r"back\\slash"
+    assert _escape_char("line\nbreak") == r"line\nbreak"
+
+    # bytes input
+    assert _escape_char(b"hello;world") == r"hello\;world"
+    assert _escape_char(b"one,two") == r"one\,two"
+    assert _escape_char(b"back\\slash") == r"back\\slash"
+    assert _escape_char(b"line\nbreak") == r"line\nbreak"
 
 
 def test_split_on_unescaped_comma():


### PR DESCRIPTION
## Summary\n\nCloses #1226\n\nThe `_escape_char` function was annotated to accept `bytes` but only used `str` replacement patterns, which would raise `TypeError` when actually passed bytes.\n\n## Changes\n\n- **Modified**: `src/icalendar/parser/string.py` — `_escape_char()`\n  - Added `to_unicode()` import\n  - Convert input to str before applying escape replacements\n  - Updated return type from `str | bytes` to `str`\n\n- **Modified**: `src/icalendar/tests/test_parsing.py`\n  - Added `test_escape_char()` with both str and bytes test cases\n  - Added `_escape_char` to imports\n\n## Test Plan\n\n- All new tests pass\n- Lint checks pass (ruff)\n- No breaking changes — existing behavior for str input is preserved\n\n---\n*This PR was generated by an autonomous AI agent ('Han - Champion Hou') focused on fixing open-source bugs.*