### PR TITLE
fix: use to_unicode in _escape_char to handle bytes input

### DIFF
--- a/src/icalendar/parser/string.py
+++ b/src/icalendar/parser/string.py
@@ -3,10 +3,10 @@
 import re
 import warnings
 
-from icalendar.parser_tools import DEFAULT_ENCODING
+from icalendar.parser_tools import DEFAULT_ENCODING, to_unicode
 
 
-def _escape_char(text: str | bytes) -> str | bytes:
+def _escape_char(text: str | bytes) -> str:
     r"""Format value according to iCalendar TEXT escaping rules.
 
     Escapes special characters in text values according to :rfc:`5545#section-3.3.11`
@@ -14,7 +14,8 @@ def _escape_char(text: str | bytes) -> str | bytes:
     The order of replacements matters to avoid double-escaping.
 
     Parameters:
-        text: The text to escape.
+        text: The text to escape. If ``bytes`` are provided, they are decoded
+            to a Unicode string before escaping.
 
     Returns:
         The escaped text with special characters escaped.
@@ -31,6 +32,7 @@ def _escape_char(text: str | bytes) -> str | bytes:
            newline character)
     """
     assert isinstance(text, (str, bytes))
+    text = to_unicode(text)
     # NOTE: ORDER MATTERS!
     return (
         text.replace(r"\N", "\n")
@@ -42,7 +44,7 @@ def _escape_char(text: str | bytes) -> str | bytes:
     )
 
 
-def escape_char(text: str | bytes) -> str | bytes:
+def escape_char(text: str | bytes) -> str:
     r"""Format value according to iCalendar TEXT escaping rules.
 
     .. deprecated:: 7.0.0

--- a/src/icalendar/tests/test_parsing.py
+++ b/src/icalendar/tests/test_parsing.py
@@ -9,7 +9,7 @@ from icalendar import vBinary, vRecur
 from icalendar.cal.calendar import Calendar
 from icalendar.cal.component_factory import ComponentFactory
 from icalendar.cal.event import Event
-from icalendar.parser import Contentline, Parameters, _unescape_char
+from icalendar.parser import Contentline, Parameters, _escape_char, _unescape_char
 
 
 @pytest.mark.parametrize(
@@ -232,6 +232,13 @@ def test_escaped_characters_read(event_name, expected_cn, expected_ics, events):
     event = events[event_name]
     assert event["ORGANIZER"].params["CN"] == expected_cn
     assert event["ORGANIZER"].to_ical() == expected_ics.encode("utf-8")
+
+
+def test_escape_char_bytes():
+    """_escape_char accepts bytes and returns str (issue #1226)."""
+    assert _escape_char(b"hello") == "hello"
+    assert _escape_char(b"hello,world") == r"hello\,world"
+    assert _escape_char(b"line\nbreak") == r"line\nbreak"
 
 
 def test_unescape_char():


### PR DESCRIPTION
## Summary

Fixes #1226

`_escape_char` was annotated to accept `str | bytes` but used str-only replacement patterns (`r"\N"`, `"\\"`, etc.), which raises `TypeError` when bytes are passed.

**Fix:** Call `to_unicode(text)` at the start of `_escape_char` to decode bytes to str before applying the replacement chain. This is the approach requested in the issue.

**Changes:**
- Import `to_unicode` from `icalendar.parser_tools` in `parser/string.py`
- Update `_escape_char` to call `to_unicode(text)` before replacements
- Update return type annotation from `str | bytes` to `str` (bytes are always decoded to str)
- Update `escape_char` public wrapper return type annotation accordingly
- Add `test_escape_char_bytes` test to verify bytes input works correctly

## Test

```python
assert _escape_char(b"hello") == "hello"
assert _escape_char(b"hello,world") == r"hello\,world"
assert _escape_char(b"line\nbreak") == r"line\nbreak"
```