### PR TITLE
Remove misleading `TOX_ENV` variable from `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ SHELL           = bash
 # You can set these variables from the command line.
 SPHINXOPTS      ?=
 PAPER           ?=
-TOX_ENV			?=
 
 # Internal variables.
 RUFFPATH        = "$(realpath .venv/bin/ruff)"


### PR DESCRIPTION
This is a follow up to the just merged #1315, per a discussion with @SashankBhamidi in Signal.

tox actually handles this black magic, not Make.

https://github.com/tox-dev/tox/blob/4dcde44c0746138421bef38f1c0dac42ee505223/src/tox/config/cli/env_var.py#L24

No change log is needed, since it's removing dead code.