### PR TITLE
fix(parser): handle bytes input in escape_char using to_unicode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,7 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- Fixed :func:`~icalendar.parser.string.escape_char` to accept :class:`bytes` input by converting it to :class:`str` with :func:`~icalendar.parser_tools.to_unicode` before applying replacements. :issue:`1226`
 - ...
 
 Documentation

--- a/src/icalendar/parser/string.py
+++ b/src/icalendar/parser/string.py
@@ -2,10 +2,10 @@
 
 import re
 
-from icalendar.parser_tools import DEFAULT_ENCODING
+from icalendar.parser_tools import DEFAULT_ENCODING, to_unicode
 
 
-def escape_char(text: str | bytes) -> str | bytes:
+def escape_char(text: str | bytes) -> str:
     r"""Format value according to iCalendar TEXT escaping rules.
 
     Escapes special characters in text values according to :rfc:`5545#section-3.3.11`
@@ -29,7 +29,7 @@ def escape_char(text: str | bytes) -> str | bytes:
         6. ``"\n"`` -> ``r"\n"`` (transform a newline character to a literal, or raw,
            newline character)
     """
-    assert isinstance(text, (str, bytes))
+    text = to_unicode(text)
     # NOTE: ORDER MATTERS!
     return (
         text.replace(r"\N", "\n")

--- a/src/icalendar/tests/test_parsing.py
+++ b/src/icalendar/tests/test_parsing.py
@@ -9,7 +9,7 @@ from icalendar import vBinary, vRecur
 from icalendar.cal.calendar import Calendar
 from icalendar.cal.component_factory import ComponentFactory
 from icalendar.cal.event import Event
-from icalendar.parser import Contentline, Parameters, unescape_char
+from icalendar.parser import Contentline, Parameters, unescape_char, escape_char
 
 
 @pytest.mark.parametrize(
@@ -280,3 +280,14 @@ def test_create_a_component():
     my_component_class = factory.get_component_class("My-Component")
     assert my_component_class.name == "MY-COMPONENT"
     assert my_component_class.__name__ == "MyComponent"
+
+
+def test_escape_char_bytes():
+    """Test that escape_char accepts bytes input and returns str."""
+    assert escape_char(b"hello,world") == "hello\\,world"
+    assert escape_char(b"hello;world") == "hello\\;world"
+    assert escape_char(b"hello\\world") == "hello\\\\world"
+    assert escape_char(b"hello\nworld") == "hello\\nworld"
+    assert escape_char(b"hello\r\nworld") == "hello\\nworld"
+    assert escape_char(b"hello\\Nworld") == "hello\\nworld"
+    assert escape_char("hello,world") == "hello\\,world"


### PR DESCRIPTION
## Problem

`escape_char` in `icalendar.parser.string` was annotated to accept `str | bytes` but used `str.replace()` operations directly, causing `TypeError` when `bytes` input contained characters that needed escaping (comma, semicolon, backslash, newline).

This was flagged by Copilot in the review of #1222.

## Analysis

The function signature allowed `bytes` input, but the implementation used string literals for all replacements. When `bytes` was passed, Python would raise `TypeError: a bytes-like object is required, not str` (or similar, depending on the replacement).

The `unescape_char` function already handles this correctly by branching on `isinstance(text, str)` vs `isinstance(text, bytes)`. A more consistent approach is to use `to_unicode()`, which is already available in the codebase and converts `bytes` to `str` using the default encoding.

## Solution

- Use `to_unicode(text)` at the start of `escape_char` to normalize input to `str`
- Update the return type from `str | bytes` to `str`
- Add `test_escape_char_bytes` verifying all escape patterns work with bytes input

## Benchmarks

No performance impact expected — `to_unicode` is a fast encoding check/conversion that is already used extensively in the parser.

## Notes

- This aligns `escape_char` with the rest of the parser, which uses `to_unicode` for input normalization.
- The return type change from `str | bytes` to `str` is technically a narrowing, but since the function previously crashed on `bytes` input for most cases, this is a bugfix rather than a breaking change.

Closes #1226

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1330.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->