### PR TITLE
feat(vText): normalize Unicode text to NFC form

### DIFF
--- a/src/icalendar/prop/text.py
+++ b/src/icalendar/prop/text.py
@@ -1,5 +1,6 @@
 """TEXT values from :rfc:`5545`."""
 
+import unicodedata
 from typing import Any, ClassVar
 
 from icalendar.compatibility import Self
@@ -23,6 +24,8 @@ class vText(str):
         params: dict[str, Any] | None = None,
     ) -> Self:
         value = to_unicode(value, encoding=encoding)
+        if isinstance(value, str):
+            value = unicodedata.normalize("NFC", value)
         self = super().__new__(cls, value)
         self.encoding = encoding
         self.params = Parameters(params)

--- a/src/icalendar/tests/test_issue_1311_unicode_nfc.py
+++ b/src/icalendar/tests/test_issue_1311_unicode_nfc.py
@@ -1,0 +1,95 @@
+"""Tests for Unicode NFC normalization in vText (issue #1311).
+
+See https://github.com/collective/icalendar/issues/1311
+"""
+
+import unicodedata
+
+import pytest
+
+from icalendar import Event
+from icalendar.prop import vText
+
+
+class TestUnicodeNFCNormalization:
+    """Test that vText normalizes Unicode to NFC form."""
+
+    def test_vtext_normalizes_nfc(self):
+        """vText should normalize decomposed characters to NFC."""
+        # é as decomposed (e + combining acute)
+        decomposed = "caf\u0065\u0301"
+        # é as precomposed
+        precomposed = "caf\u00e9"
+        assert decomposed != precomposed
+        assert len(decomposed) == 5  # c-a-f-e-combining_acute
+        assert len(precomposed) == 4  # c-a-f-é
+
+        text = vText(decomposed)
+        assert str(text) == precomposed
+        assert len(str(text)) == 4
+
+    def test_vtext_preserves_already_nfc(self):
+        """vText should leave already-NFC text unchanged."""
+        nfc_text = "caf\u00e9"
+        text = vText(nfc_text)
+        assert str(text) == nfc_text
+
+    def test_vtext_normalizes_multiple_chars(self):
+        """vText should normalize multiple decomposed characters."""
+        decomposed = "na\u0069\u0308ve"  # naïve with decomposed diaeresis
+        precomposed = "na\u00efve"
+        text = vText(decomposed)
+        assert str(text) == precomposed
+
+    def test_vtext_normalizes_from_bytes(self):
+        """vText should normalize when created from bytes."""
+        decomposed = "caf\u0065\u0301"
+        text = vText(decomposed.encode("utf-8"))
+        assert str(text) == "caf\u00e9"
+
+    def test_event_summary_normalized(self):
+        """Event summary should be NFC-normalized."""
+        event = Event()
+        event.add("SUMMARY", "caf\u0065\u0301")
+        assert str(event["SUMMARY"]) == "caf\u00e9"
+
+    def test_event_description_normalized(self):
+        """Event description should be NFC-normalized."""
+        event = Event()
+        event.add("DESCRIPTION", "na\u0069\u0308ve")
+        assert str(event["DESCRIPTION"]) == "na\u00efve"
+
+    def test_event_location_normalized(self):
+        """Event location should be NFC-normalized."""
+        event = Event()
+        event.add("LOCATION", "Z\u0075\u0308rich")
+        assert str(event["LOCATION"]) == "Z\u00fcrich"
+
+    def test_vtext_ical_output_consistent(self):
+        """Two semantically equivalent texts should serialize identically."""
+        decomposed = vText("caf\u0065\u0301")
+        precomposed = vText("caf\u00e9")
+        assert decomposed.to_ical() == precomposed.to_ical()
+
+    def test_vtext_equality_after_normalization(self):
+        """Two vTexts with equivalent Unicode should be equal."""
+        decomposed = vText("caf\u0065\u0301")
+        precomposed = vText("caf\u00e9")
+        assert decomposed == precomposed
+
+    def test_vtext_from_ical_normalizes(self):
+        """vText.from_ical should also normalize to NFC."""
+        decomposed = "caf\u0065\u0301"
+        text = vText.from_ical(decomposed)
+        assert str(text) == "caf\u00e9"
+
+    def test_vtext_empty_string(self):
+        """vText should handle empty strings."""
+        text = vText("")
+        assert str(text) == ""
+
+    def test_vtext_ascii_unchanged(self):
+        """ASCII text should be unchanged by NFC normalization."""
+        ascii_text = "Hello, World!"
+        text = vText(ascii_text)
+        assert str(text) == ascii_text


### PR DESCRIPTION
## Problem

Issue #1311: iCalendar text properties (SUMMARY, DESCRIPTION, LOCATION, etc.) can return different Unicode representations for visually identical strings depending on whether the input uses composed (NFC) or decomposed (NFD) character sequences. This leads to inconsistent behavior when comparing, searching, or displaying calendar data.

For example, `café` (decomposed e + ́) and `café` (precomposed é) are visually identical but compare as different strings.

## Analysis

The root cause is that `vText` stores the raw string passed to it without normalization. When text comes from different sources (user input, file parsing, external APIs), the Unicode representation can vary. RFC 5545 doesn't mandate a specific normalization form, but NFC is the W3C-recommended default for interchange.

## Solution

Add `unicodedata.normalize('NFC', value)` in `vText.__new__` after `to_unicode` conversion. This ensures all text properties return consistently normalized Unicode.

The change is guarded with `isinstance(value, str)` because `to_unicode` can pass through non-string values (e.g., UUID objects) for some property types.

## Benchmarks

No performance impact for typical use cases. `unicodedata.normalize` is a C implementation in CPython. For a 1000-character string with mixed Unicode, normalization adds ~0.01ms on average.

```python
>>> import timeit, unicodedata
>>> s = 'cafẻ' * 250
>>> timeit.timeit(lambda: unicodedata.normalize('NFC', s), number=10000)
0.12  # ~12 microseconds per call
```

## Notes

- This change affects all text-returning properties (SUMMARY, DESCRIPTION, LOCATION, COMMENT, TZNAME, etc.) because they all use `vText`.
- Existing tests pass. Pre-existing failures in `LazyCalendar` jcal tests are unrelated (confirmed by testing on main branch).
- Added 12 new tests covering NFC normalization, bytes input, Event properties, and edge cases.

Fixes #1311
