### PR TITLE
Document saving calendars to files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,7 @@ Documentation
 - Add documentation for how to use uv for development. :issue:`1102`
 - Reorganize Design documentation. :issue:`1292`
 - Improve docstring for ``categories_property``, which renders to HTML in :attr:`Calendar.categories <icalendar.cal.calendar.Calendar.categories>`, :attr:`Event.categories <icalendar.cal.event.Event.categories>`, :attr:`Journal.categories <icalendar.cal.journal.Journal.categories>`, and :attr:`Todo.categories <icalendar.cal.todo.Todo.categories>`. :issue:`1244`
+- Documented how to save calendars to ``.ics`` files. :pr:`1343`
 
 7.0.3 (2026-03-03)
 ------------------

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -267,18 +267,32 @@ To read a calendar from a URL, retrieve the data first, then parse it in icalend
 Modify content
 ''''''''''''''
 
-After loading the example file, edit and save it.
+After loading the example file, edit it.
 
 .. code:: pycon
 
     >>> calendar.calendar_name = "My Modified Calendar"  # modify
-    >>> print(calendar.to_ical()[:121])  # save modification
+    >>> print(calendar.to_ical()[:121])
     BEGIN:VCALENDAR
     VERSION:2.0
     PRODID:collective/icalendar
     CALSCALE:GREGORIAN
     METHOD:PUBLISH
     NAME:My Modified Calendar
+
+
+Save calendar to file
+'''''''''''''''''''''
+
+Use :meth:`~icalendar.cal.component.Component.to_ical` to serialize the
+calendar, then write the bytes to a :file:`.ics` file.
+
+.. code:: pycon
+
+    >>> output_path = Path("modified-calendar.ics")
+    >>> output_path.write_bytes(calendar.to_ical()) > 0
+    True
+    >>> output_path.unlink()
 
 
 iCalendar objects

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -267,12 +267,12 @@ To read a calendar from a URL, retrieve the data first, then parse it in icalend
 Modify content
 ''''''''''''''
 
-After loading the example file, edit it.
+After loading the example file, edit and save it.
 
 .. code:: pycon
 
     >>> calendar.calendar_name = "My Modified Calendar"  # modify
-    >>> print(calendar.to_ical()[:121])
+    >>> print(calendar.to_ical()[:121])  # save modification
     BEGIN:VCALENDAR
     VERSION:2.0
     PRODID:collective/icalendar
@@ -287,7 +287,7 @@ Save calendar to file
 Use :meth:`~icalendar.cal.component.Component.to_ical` to serialize the
 calendar, then write the bytes to a :file:`.ics` file.
 
-.. code:: pycon
+..  code-block:: pycon
 
     >>> output_path = Path("modified-calendar.ics")
     >>> output_path.write_bytes(calendar.to_ical()) > 0


### PR DESCRIPTION
## Summary

- Split saving from the existing modify-content example on the Usage page.
- Add a focused example showing how to serialize a calendar with `to_ical()` and write it to a `.ics` file.

## Why

This addresses one item from #626: documenting how to save a file.

## Testing

- Ran the new save-calendar snippet manually with `python3`.
- `python3 -m doctest docs/how-to/usage.rst` still reports existing unrelated doctest mismatches around bytes/repr output in the page.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1343.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->