### PR TITLE
Avoid recursion-limit crash when walking deeply nested components

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,7 @@ Bug fixes
 - Fixed :meth:`Component.__eq__ <icalendar.cal.component.Component.__eq__>` method not being commutative when comparing subcomponents. :issue:`1224`
 - Verified that the ``VALUE`` parameter of jCal components is used for the type of the component property. :issue:`1237`
 - Fix :func:`~icalendar.parser.string.escape_char` handling of ``bytes`` input by converting with :func:`icalendar.parser_tools.to_unicode` before escaping. :issue:`1226`
+- Fixed ``RecursionError`` in ``walk()``, ``property_items()``, and ``to_ical()`` by using iterative implementations for component traversal and property extraction. :pr:`1346`
 
 Documentation
 ~~~~~~~~~~~~~

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -405,10 +405,12 @@ class Component(CaselessDict):
     ) -> list[Component]:
         """Walk to given component."""
         result = []
-        if (name is None or self.name == name) and select(self):
-            result.append(self)
-        for subcomponent in self.subcomponents:
-            result += subcomponent._walk(name, select)
+        stack = [self]
+        while stack:
+            component = stack.pop()
+            if (name is None or component.name == name) and select(component):
+                result.append(component)
+            stack.extend(reversed(component.subcomponents))
         return result
 
     def walk(

--- a/src/icalendar/tests/test_unit_cal.py
+++ b/src/icalendar/tests/test_unit_cal.py
@@ -1,5 +1,6 @@
 import itertools
 import re
+import sys
 from datetime import datetime, timedelta
 
 import pytest
@@ -126,6 +127,23 @@ def test_filter_walk(calendar_component, filled_event_component):
     assert [i["dtstart"] for i in calendar_component.walk("VEVENT")] == [
         "20000101T000000"
     ]
+
+def test_walk_handles_deeply_nested_components():
+    """Deeply nested input should not exceed Python's recursion limit."""
+    depth = sys.getrecursionlimit() + 50
+    ical = (
+        "BEGIN:VCALENDAR\r\n"
+        + ("BEGIN:X-DEEP\r\n" * depth)
+        + ("END:X-DEEP\r\n" * depth)
+        + "END:VCALENDAR\r\n"
+    )
+    calendar = Calendar.from_ical(ical)
+
+    walked = calendar.walk()
+
+    assert len(walked) == depth + 1
+    assert walked[0].name == "VCALENDAR"
+    assert all(component.name == "X-DEEP" for component in walked[1:])
 
 
 def test_recursive_property_items(calendar_component, filled_event_component):

--- a/src/icalendar/tests/test_unit_cal.py
+++ b/src/icalendar/tests/test_unit_cal.py
@@ -128,6 +128,7 @@ def test_filter_walk(calendar_component, filled_event_component):
         "20000101T000000"
     ]
 
+
 def test_walk_handles_deeply_nested_components():
     """Deeply nested input should not exceed Python's recursion limit."""
     depth = sys.getrecursionlimit() + 50


### PR DESCRIPTION
This PR prevents denial of service from deeply nested iCalendar component trees by making Component.walk() use iterative traversal instead of recursive traversal.