### PR TITLE
Update release process

### DIFF
--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -112,16 +112,6 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         git checkout main
         git pull
 
-#.  When cutting any new release that you'll tag and want to be considered "stable" on either the ``main`` or development branch, update the Sphinx configuration file :file:`docs/conf.py` to match that version.
-
-    Hide the warning banner.
-
-    .. code-block:: python
-
-        html_theme_options = {
-            # ...
-            "show_version_warning_banner": False,
-
 #.  Check that the file :file:`CHANGES.rst` is up to date with the `latest merged pull requests <https://github.com/collective/icalendar/pulls?q=is%3Apr+is%3Amerged>`_, and the version you want to release is correctly named.
     Change the date of the release, and remove empty sections.
 
@@ -130,33 +120,18 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         -7.0.0 (unreleased)
         +7.0.0 (2026-02-11)
 
-#.  Create a commit on a ``release`` branch to release this version.
-
-    .. code-block:: shell
-
-        git checkout -b release-$VERSION main
-        git add CHANGES.rst docs/conf.py
-        git commit -m"version $VERSION"
-
-#.  Push the commit and `create a pull request <https://github.com/collective/icalendar/compare?expand=1>`_.
-    Here is an `example pull request #457 <https://github.com/collective/icalendar/pull/457>`_.
-
-    .. code-block:: shell
-
-        git push -u origin release-$VERSION
-
-#.  See if the `CI tests <https://github.com/collective/icalendar/actions>`_ are running on the pull request.
-    If they are not running, no new release can be issued.
-    If the CI passes, merge the pull request.
-
-#.  Clean up behind you!
+#.  Create a commit on a ``main`` branch to release this version.
 
     .. code-block:: shell
 
         git checkout main
-        git pull
-        git branch -d release-$VERSION
-        git push -d origin release-$VERSION
+        git add CHANGES.rst
+        git commit -m"version $VERSION"
+        git push # to collective/icalendar
+
+#.  See if the `CI tests <https://github.com/collective/icalendar/actions>`_ are running on commit.
+    If they are not running, no new release can be issued.
+    If the CI passes, go ahead.
 
 #.  Create a tag for the release on its release branch ``*.x`` and see if the `CI tests`_ are running.
 
@@ -165,8 +140,9 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         git checkout main
         git pull
         git checkout 7.x
+        git pull
         git merge main
-        git push upstream 7.x  # to collective/icalendar
+        git push  # to collective/icalendar
         git tag "v$VERSION"
         git push upstream "v$VERSION" # to collective/icalendar
 
@@ -184,7 +160,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
         tests: PyPI is waiting for your review
 
-#.  If the release is approved by a maintainer, it will be pushed to `PyPI`_.
+#.  If the release is approved by a maintainer, it will be pushed to `PyPI`_. Do not wait for that, continue.
 #.  Copy this to the start of :file:`CHANGES.rst`, and increase the version number.
 
     .. code-block:: shell
@@ -228,7 +204,13 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
         git add CHANGES.rst
         git commit -m "Add new CHANGELOG section for future release"
-        git push upstream main # to collective/icalendar
+        git push # to collective/icalendar
+
+#.  Go through all open PRs and tell them to adjust their changelog entries to the new section.
+
+    .. code-block:: text
+
+        Hi, we created a new release, please move your edits in CHANGES.rst to the new section.
 
 #.  Once the release is pushed to `PyPI`_, notify the issues mentioned on the new release of the new release.
     Example:
@@ -272,6 +254,16 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
                     "preferred": "true"
                 },
     
+        #.  Also update :file:`.github/workflows/tests.yml` to include the new release branch in the list of branches that trigger the CI tests.
+
+            .. code-block:: yaml
+
+                push:
+                  branches:
+                  - main
+                  - 7.x
+                  tags:
+                  - v*
 
     #.  When cutting a *minor or patch release* version, on the ``main`` branch, update :file:`docs/_static/version-switcher.json` to match that version's tag name.
 
@@ -283,33 +275,27 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
                 "url": "https://icalendar.readthedocs.io/en/stable/",
                 "preferred": "true"
             },
+        
+        .. code-block:: shell
 
-#.  When cutting a new *stable release* version, update the Sphinx configuration file :file:`docs/conf.py` as shown.
+            git checkout main
+            git pull
+            git add docs/_static/version-switcher.json
+            git commit -m "Update version switcher for $VERSION"
+            git push # to collective/icalendar
 
-    #.  On the ``main`` branch, show the warning banner.
+#.  When cutting a new *major stable release* version, update the Sphinx configuration file :file:`docs/conf.py` as shown.
+    On the previous numbered major release branch, show the warning banner.
+    For example, when releasing 7.0.0, checkout ``6.x``, and update it as shown.
 
-        .. code-block:: python
+    .. code-block:: python
 
-            html_theme_options = {
-                # ...
-                "show_version_warning_banner": True,
+        html_theme_options = {
+            # ...
+            "show_version_warning_banner": True,
 
-    #.  On the previous numbered major release branch, show the warning banner.
-        For example, when releasing 7.0.0, checkout ``6.x``, and update it as shown.
-
-        .. code-block:: python
-
-            html_theme_options = {
-                # ...
-                "show_version_warning_banner": True,
-
-#.  Configure `Read the Docs <https://app.readthedocs.org/projects/icalendar/>`_.
-
-    #.  After a *minor release*, *patch release*, or an *unstable release*, deactivate previous releases in that release line.
-        Click on the ellipsis icon, and select :guilabel:`Configure version`.
-        Toggle the :guilabel:`Active` switch to deactivate the version.
-
-    #.  After a *major release*, verify that the version was activated automatically on Read the Docs.
+#.  After a *major release*, configure `Read the Docs <https://app.readthedocs.org/projects/icalendar/>`_.
+    Verify that the version was activated automatically on Read the Docs.
 
 
 Links

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -154,8 +154,8 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
     .. code-block:: shell
 
-        git checkout main
-        git pull
+        git checkout main  # You should already be on ``main``.
+        git pull  # In case someone else updated ``main`` while tests ran.
         git checkout 7.x
         git pull
         git merge main

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -212,7 +212,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
             git pull
 
     #.  When cutting a new *major* release version, update :file:`docs/_static/version-switcher.json` to match that version.
-    
+
         -   Duplicate the second previous major version stanza and renumber it to the first previous version.
             In other words, duplicate the ``5.x`` stanza, and renumber the copy to ``6.x``.
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -311,7 +311,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         Toggle the :guilabel:`Active` switch to deactivate the version.
 
 
-#.  Add a comment to each of the issues mentioned in the new release of the new release.
+#.  Add a comment to each of the issues mentioned in the new release.
     Example:
 
     .. code-block:: text

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -211,7 +211,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
             git checkout main
             git pull
 
-    #.  When cutting a new *major release* version, and update :file:`docs/_static/version-switcher.json` to match that version.
+    #.  When cutting a new *major release* version, update :file:`docs/_static/version-switcher.json` to match that version.
     
         #.  Duplicate the second previous major version stanza and renumber it to the first previous version.
             In other words, duplicate the ``5.x`` stanza, and renumber the copy to ``6.x``.

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -161,25 +161,42 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
 #.  Create a tag for the release on its release branch ``*.x``, push, and make sure the `CI tests`_ are running.
 
-    .. code-block:: shell
+    a.  First, make sure you're on the ``main`` branch and it's current, in case someone else updated ``main`` while tests ran.
 
-        git checkout main  # You should already be on ``main``.
-        git pull  # In case someone else updated ``main`` while tests ran.
-        # For a major release, create a new branch and check it out.
-        git checkout -b 7.x
-        # For a minor or patch release, check out the existing branch.
-        git checkout 7.x
-        git pull
-        git merge main
-        git push  # to collective/icalendar
-        git tag "v$VERSION"
-        git push upstream "v$VERSION" # to collective/icalendar
+        .. code-block:: shell
 
-    .. warning::
+            git checkout main
+            git pull
 
-        Once a tag is pushed to the repository, it must not be re-tagged or deleted.
-        This creates issues for downstream repositories.
-        See :issue:`1033`.
+    #.  Next, depending on the release type, do one of the following.
+
+        -   For a major release, create a new branch, check it out, and set the tracked branch.
+
+            .. code-block:: shell
+
+                git switch -c 7.x -t upstream/main
+
+        -   For a minor or patch release, check out the existing branch.
+
+            .. code-block:: shell
+
+                git checkout 7.x
+
+    #.  Continue to update the release branch, merge ``main`` into the branch, push changes, tag it, and push the tag.
+
+        .. code-block:: shell
+
+            git pull
+            git merge main
+            git push  # to collective/icalendar
+            git tag "v$VERSION"
+            git push upstream "v$VERSION" # to collective/icalendar
+
+        .. warning::
+
+            Once a tag is pushed to the repository, it must not be re-tagged or deleted.
+            This creates issues for downstream repositories.
+            See :issue:`1033`.
 
 #.  Once the tag is pushed and its `CI tests`_ pass, check the `GitHub Actions <https://github.com/collective/icalendar/actions>`_, and wait for maintainers to get an email:
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -202,7 +202,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
             json_url = "https://icalendar.readthedocs.io/en/latest/_static/version-switcher.json"
 
-        The following examples were used for the 7.0.0 release.
+    The following examples were used for the 7.0.0 release.
 
     #.  Check out the ``main`` branch and update it.
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -123,7 +123,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
           tags:
           - v*
 
-.. _hide-version-warning-banner::
+    .. _hide-version-warning-banner:
 
 #.  Hide the version warning banner on the "stable" version on Read the Docs.
     Update the Sphinx configuration file :file:`docs/conf.py`, which you'll commit and tag.

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -128,7 +128,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
         make changes
 
-#.  Create a commit on a ``main`` branch to release this version.
+#.  Create a commit on the ``main`` branch to release this version.
 
     .. code-block:: shell
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -204,7 +204,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
     The following examples were used for the 7.0.0 release.
 
-    #.  Check out the ``main`` branch and update it.
+    a.  Check out the ``main`` branch and update it.
 
         ..  code-block:: shell
 
@@ -296,7 +296,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
 #.  Configure `Read the Docs <https://app.readthedocs.org/projects/icalendar/>`_.
 
-    #.  Verify that the "stable" version was activated automatically on Read the Docs.
+    a.  Verify that the "stable" version was activated automatically on Read the Docs.
 
     #.  Deactivate previous releases in that current stable release line.
         Click on the ellipsis icon, and select :guilabel:`Configure version`.

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -136,7 +136,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         git commit -m"version $VERSION"
         git push  # to collective/icalendar
 
-#.  See if the `CI tests <https://github.com/collective/icalendar/actions>`_ are running on commit.
+#.  See if the `CI tests <https://github.com/collective/icalendar/actions>`_ are running on the commit.
     If they are not running, no new release can be issued.
     If the CI passes, go ahead.
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -211,7 +211,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
             git checkout main
             git pull
 
-    #.  When cutting a new *major release* version, update :file:`docs/_static/version-switcher.json` to match that version.
+    #.  When cutting a new *major* release version, update :file:`docs/_static/version-switcher.json` to match that version.
     
         #.  Duplicate the second previous major version stanza and renumber it to the first previous version.
             In other words, duplicate the ``5.x`` stanza, and renumber the copy to ``6.x``.
@@ -235,7 +235,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
                     "preferred": "true"
                 },
 
-    #.  When cutting a *minor or patch release* version, update :file:`docs/_static/version-switcher.json` to match that version's tag name.
+    #.  When cutting a *minor* or *patch* release version, update :file:`docs/_static/version-switcher.json` to match that version's tag name.
 
         .. code-block:: json
             :emphasize-lines: 2-3
@@ -274,7 +274,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         git commit -m "Restore version warning banner for 'latest' on Read the Docs"
         git push  # to collective/icalendar
 
-#.  If you cut a new *major release* version, update the Sphinx configuration file :file:`docs/conf.py` on the *previous* numbered major release branch to show the version warning banner.
+#.  If you cut a new *major* release version, update the Sphinx configuration file :file:`docs/conf.py` on the *previous* numbered major release branch to show the version warning banner.
     For example, when releasing 7.0.0, checkout ``6.x``, and update it as shown.
 
     .. code-block:: shell

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -170,25 +170,43 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
     #.  Next, depending on the release type, do one of the following.
 
-        -   For a major release, create a new branch, check it out, and set the tracked branch.
+        -   For a major release, create a new branch, and check it out.
 
             .. code-block:: shell
 
                 git switch -c 7.x
 
-        -   For a minor or patch release, check out the existing branch.
+        -   For a minor or patch release, check out the existing branch, and update it.
 
             .. code-block:: shell
 
                 git checkout 7.x
+                git pull
 
-    #.  Continue to update the release branch, merge ``main`` into the branch, push changes, tag it, and push the tag.
+    #.  Next, merge ``main`` into the release branch.
 
         .. code-block:: shell
 
-            git pull
             git merge main
-            git push  # to collective/icalendar
+
+    #.  Next, push changes upstream, changing the command according to the release type.
+
+        -   For a major release, push, create, and track the upstream branch.
+
+            .. code-block:: shell
+
+                git push -u upstream 7.x  # to collective/icalendar
+
+        -   For a minor or patch release, just push.
+
+            .. code-block:: shell
+
+                git push  # to collective/icalendar
+
+    #.  Next create a tag, and push the tag.
+
+        .. code-block:: shell
+
             git tag "v$VERSION"
             git push upstream "v$VERSION" # to collective/icalendar
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -149,7 +149,8 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
     .. code-block:: shell
 
-        git add CHANGES.rst docs/conf.py news/
+        git add CHANGES.rst news/
+        git add .github/workflows/tests.yml  # Only for a new major release
         git commit -m"version $VERSION"
         git push  # to collective/icalendar
 
@@ -163,6 +164,9 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
         git checkout main  # You should already be on ``main``.
         git pull  # In case someone else updated ``main`` while tests ran.
+        # For a major release, create a new branch and check it out.
+        git checkout -b 7.x
+        # For a minor or patch release, check out the existing branch.
         git checkout 7.x
         git pull
         git merge main
@@ -304,7 +308,6 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
     .. code-block:: text
 
         This is included in v7.0.0.
-
 
 
 Links

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -225,7 +225,10 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
         -   Next, edit the array item for the previous version to reflect the current major release.
 
+            .. vale off
+
             .. code-block:: json
+                :emphasize-lines: 2-3
 
                 {
                     "name": "7.x (stable)",
@@ -234,9 +237,14 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
                     "preferred": "true"
                 },
 
+            .. vale on
+
     #.  When cutting a *minor* or *patch* release version, update :file:`docs/_static/version-switcher.json` to match that version's tag name.
 
+        .. vale off
+
         .. code-block:: json
+            :emphasize-lines: 2-3
 
             {
                 "name": "7.x (stable)",
@@ -244,6 +252,8 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
                 "url": "https://icalendar.readthedocs.io/en/stable/",
                 "preferred": "true"
             },
+
+        .. vale on
 
     #.  For all releases, add, commit, and push the changes.
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -114,12 +114,13 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
 #.  If you'll create a new *major* release, update :file:`.github/workflows/tests.yml` to include the new release branch in the list of branches that trigger the CI tests.
 
-    .. code-block:: yaml
+    ..  code-block:: yaml
+        :emphasize-lines: 4
 
         push:
           branches:
           - main
-          - 7.x  # Update the major version
+          - 7.x
           tags:
           - v*
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -222,16 +222,6 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
                     "preferred": "true"
                 },
     
-        #.  Also update :file:`.github/workflows/tests.yml` to include the new release branch in the list of branches that trigger the CI tests.
-
-            .. code-block:: yaml
-
-                push:
-                  branches:
-                  - main
-                  - 7.x
-                  tags:
-                  - v*
 
     #.  When cutting a *minor or patch release* version, on the ``main`` branch, update :file:`docs/_static/version-switcher.json` to match that version's tag name.
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -174,7 +174,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
             .. code-block:: shell
 
-                git switch -c 7.x -t upstream/main
+                git switch -c 7.x
 
         -   For a minor or patch release, check out the existing branch.
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -167,7 +167,8 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
         tests: PyPI is waiting for your review
 
-#.  If the release is approved by a maintainer, it will be pushed to `PyPI`_. Do not wait for that, continue.
+#.  If the release is approved by a maintainer, it will be pushed to `PyPI`_.
+    Don't wait for that, continue.
 
 #.  Once the release is pushed to `PyPI`_, notify the issues mentioned on the new release of the new release.
     Example:

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -180,13 +180,6 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 #.  If the release is approved by a maintainer, it will be pushed to `PyPI`_.
     Don't wait for that, continue.
 
-#.  Once the release is pushed to `PyPI`_, notify the issues mentioned on the new release of the new release.
-    Example:
-
-    .. code-block:: text
-
-        This is included in v7.0.0.
-
 #.  Update the version switcher file :file:`docs/_static/version-switcher.json`.
 
     .. note::
@@ -254,6 +247,14 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
 #.  After a *major release*, configure `Read the Docs <https://app.readthedocs.org/projects/icalendar/>`_.
     Verify that the version was activated automatically on Read the Docs.
+
+#.  Add a comment to each of the issues mentioned in the new release of the new release.
+    Example:
+
+    .. code-block:: text
+
+        This is included in v7.0.0.
+
 
 
 Links

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -123,8 +123,15 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
           tags:
           - v*
 
-#.  When cutting a new release that you'll tag and want to be considered "stable" on Read the Docs, update the Sphinx configuration file :file:`docs/conf.py` to hide the version warning banner.
-    Later during clean up, you'll revert this setting on ``main``, so that the "latest" version on Read the Docs continues to display the version warning banner.
+.. _hide-version-warning-banner::
+
+#.  Hide the version warning banner on the "stable" version on Read the Docs.
+    Update the Sphinx configuration file :file:`docs/conf.py`, which you'll commit and tag.
+    Then Read the Docs will recognize the highest version tag as the "stable" version.
+
+    ..  note::
+
+        Toward the end of this process, you'll revert this setting on ``main``, so that the "latest" version on Read the Docs continues to display the version warning banner.
 
     .. code-block:: python
 
@@ -184,16 +191,23 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
     .. note::
 
-        The remaining steps may be performed after the release because they pertain exclusively to documentation, which isn't included in the release.
+        This file is configured in :file:`docs/conf.py` on *all* branches to use the version in ``main``, which is "latest" on Read the Docs.
+
+        ..  code-block:: python
+
+            json_url = "https://icalendar.readthedocs.io/en/latest/_static/version-switcher.json"
+
         The following examples were used for the 7.0.0 release.
 
-    #.  When cutting a new *major release* version, checkout the ``main`` branch, and update :file:`docs/_static/version-switcher.json` to match that version.
-    
+    #.  Check out the ``main`` branch and update it.
+
         ..  code-block:: shell
-        
+
             git checkout main
             git pull
 
+    #.  When cutting a new *major release* version, and update :file:`docs/_static/version-switcher.json` to match that version.
+    
         #.  Duplicate the second previous major version stanza and renumber it to the first previous version.
             In other words, duplicate the ``5.x`` stanza, and renumber the copy to ``6.x``.
 
@@ -207,6 +221,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         #.  Next, edit the array item for the previous version to reflect the current major release.
 
             .. code-block:: json
+                :emphasize-lines: 2-3
 
                 {
                     "name": "7.x (stable)",
@@ -214,11 +229,11 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
                     "url": "https://icalendar.readthedocs.io/en/stable/",
                     "preferred": "true"
                 },
-    
 
-    #.  When cutting a *minor or patch release* version, on the ``main`` branch, update :file:`docs/_static/version-switcher.json` to match that version's tag name.
+    #.  When cutting a *minor or patch release* version, update :file:`docs/_static/version-switcher.json` to match that version's tag name.
 
         .. code-block:: json
+            :emphasize-lines: 2-3
 
             {
                 "name": "7.x (stable)",
@@ -226,18 +241,41 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
                 "url": "https://icalendar.readthedocs.io/en/stable/",
                 "preferred": "true"
             },
-        
+
+    #.  For all releases, add, commit, and push the changes.
+
         .. code-block:: shell
 
-            git checkout main
-            git pull
             git add docs/_static/version-switcher.json
             git commit -m "Update version switcher for $VERSION"
-            git push # to collective/icalendar
+            git push  # to collective/icalendar
 
-#.  When cutting a new *major stable release* version, update the Sphinx configuration file :file:`docs/conf.py` as shown.
-    On the previous numbered major release branch, show the warning banner.
+#.  Revert the change in the :ref:`earlier step <hide-version-warning-banner>` by updating the Sphinx configuration file :file:`docs/conf.py` to show the version warning banner on the ``main`` branch, which is "latest" on Read the Docs.
+
+    ..  code-block:: shell
+
+        git checkout main
+        git pull
+
+    ..  code-block:: python
+
+        html_theme_options = {
+            # ...
+            "show_version_warning_banner": True,
+
+    ..  code-block:: shell
+
+        git add docs/conf.py
+        git commit -m "Restore version warning banner for 'latest' on Read the Docs"
+        git push  # to collective/icalendar
+
+#.  If you cut a new *major release* version, update the Sphinx configuration file :file:`docs/conf.py` on the *previous* numbered major release branch to show the version warning banner.
     For example, when releasing 7.0.0, checkout ``6.x``, and update it as shown.
+
+    .. code-block:: shell
+
+        git checkout 6.x
+        git pull
 
     .. code-block:: python
 
@@ -245,8 +283,20 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
             # ...
             "show_version_warning_banner": True,
 
-#.  After a *major release*, configure `Read the Docs <https://app.readthedocs.org/projects/icalendar/>`_.
-    Verify that the version was activated automatically on Read the Docs.
+    ..  code-block:: shell
+
+        git add docs/conf.py
+        git commit -m "Show version warning banner for previous major version 6.x on Read the Docs"
+        git push  # to collective/icalendar
+
+#.  Configure `Read the Docs <https://app.readthedocs.org/projects/icalendar/>`_.
+
+    #.  Verify that the "stable" version was activated automatically on Read the Docs.
+
+    #.  Deactivate previous releases in that current stable release line.
+        Click on the ellipsis icon, and select :guilabel:`Configure version`.
+        Toggle the :guilabel:`Active` switch to deactivate the version.
+
 
 #.  Add a comment to each of the issues mentioned in the new release of the new release.
     Example:

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -226,7 +226,6 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         -   Next, edit the array item for the previous version to reflect the current major release.
 
             .. code-block:: json
-                :emphasize-lines: 2-3
 
                 {
                     "name": "7.x (stable)",
@@ -238,7 +237,6 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
     #.  When cutting a *minor* or *patch* release version, update :file:`docs/_static/version-switcher.json` to match that version's tag name.
 
         .. code-block:: json
-            :emphasize-lines: 2-3
 
             {
                 "name": "7.x (stable)",

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -213,7 +213,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
     #.  When cutting a new *major* release version, update :file:`docs/_static/version-switcher.json` to match that version.
     
-        #.  Duplicate the second previous major version stanza and renumber it to the first previous version.
+        -   Duplicate the second previous major version stanza and renumber it to the first previous version.
             In other words, duplicate the ``5.x`` stanza, and renumber the copy to ``6.x``.
 
             .. code-block:: json
@@ -223,7 +223,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
                     "url": "https://icalendar.readthedocs.io/en/6.x/"
                 },
 
-        #.  Next, edit the array item for the previous version to reflect the current major release.
+        -   Next, edit the array item for the previous version to reflect the current major release.
 
             .. code-block:: json
                 :emphasize-lines: 2-3

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -112,9 +112,19 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         git checkout main
         git pull
 
-#.  When cutting any new release that you'll tag and want to be considered "stable" on either the ``main`` or development branch, update the Sphinx configuration file :file:`docs/conf.py` to match that version.
+#.  If you create a new *major* release, update :file:`.github/workflows/tests.yml` to include the new release branch in the list of branches that trigger the CI tests.
 
-    Hide the warning banner.
+    .. code-block:: yaml
+
+        push:
+          branches:
+          - main
+          - 7.x  # Update the major version
+          tags:
+          - v*
+
+#.  When cutting a new release that you'll tag and want to be considered "stable" on Read the Docs, update the Sphinx configuration file :file:`docs/conf.py` to hide the version warning banner.
+    Later during clean up, you'll revert this setting on ``main``, so that the "latest" version on Read the Docs continues to display the version warning banner.
 
     .. code-block:: python
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -140,7 +140,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
             # ...
             "show_version_warning_banner": False,
 
-#.  Update the change log :file:`CHANGES.rst` with the change log entries in :file:`/news` with `towncrier <https://pypi.org/project/towncrier/>`_.
+#.  Update the change log :file:`CHANGES.rst` with the change log entries in :file:`/news` using `towncrier <https://pypi.org/project/towncrier/>`_.
 
     ..  code-block:: shell
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -196,7 +196,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
     .. note::
 
-        This file is configured in :file:`docs/conf.py` on *all* branches to use the version in ``main``, which is "latest" on Read the Docs.
+        This file is configured in :file:`docs/conf.py` on *all* branches to use the version on the ``main`` branch, which is "latest" on Read the Docs.
 
         ..  code-block:: python
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -112,7 +112,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         git checkout main
         git pull
 
-#.  If you create a new *major* release, update :file:`.github/workflows/tests.yml` to include the new release branch in the list of branches that trigger the CI tests.
+#.  If you'll create a new *major* release, update :file:`.github/workflows/tests.yml` to include the new release branch in the list of branches that trigger the CI tests.
 
     .. code-block:: yaml
 
@@ -145,7 +145,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
         make changes
 
-#.  Create a commit on the ``main`` branch to release this version.
+#.  Add the changes, create a commit on the ``main`` branch, and push the changes to prepare a release of this version.
 
     .. code-block:: shell
 

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -159,7 +159,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
     If they are not running, no new release can be issued.
     If the CI passes, go ahead.
 
-#.  Create a tag for the release on its release branch ``*.x`` and see if the `CI tests`_ are running.
+#.  Create a tag for the release on its release branch ``*.x``, push, and make sure the `CI tests`_ are running.
 
     .. code-block:: shell
 

--- a/news/1293.documentation
+++ b/news/1293.documentation
@@ -1,0 +1,1 @@
+Updated release process documentation. @niccokunzmann @stevepiercy @SashankBhamidi


### PR DESCRIPTION
## Closes issue

- Closes #1293

## Description

This updates the release process to what I actually did. It should work like this for the next releases.

I could remove some sections about the version switcher.

Readthedocs does not create a version for the tag, so that step can also be removed.

<img width="962" height="757" alt="grafik" src="https://github.com/user-attachments/assets/9332d390-9eca-4997-8f26-dccc853e6092" />

A commit on branch 7.x has been created that shall be carried forth through the merges of main that keeps the version switcher disabled.

release branch steps are done on main now.

## How to proceed

Please correct the formatting or text if you need to and merge: This is a living document, and it should be merged before the next release. If there are procedural mistakes (**content**), they will be corrected with the next release. You can point them out in an issue or make edits here. If you want to adjust the **style**, not the content, please go ahead and do that and then merge.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1350.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->