### PR TITLE
DOC: Remove print() calls from tutorial documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,9 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-- ...
+- Remove ``print()`` calls from the create-event-with-attendees tutorial,
+  replacing them with direct expression calls for cleaner output.
+  :issue:`1257`
 
 7.1.0 (2026-04-30)
 ------------------

--- a/docs/tutorials/create-event-with-attendees.rst
+++ b/docs/tutorials/create-event-with-attendees.rst
@@ -20,7 +20,7 @@ After creating a new calendar, you can view its properties by using :meth:`~ical
 
 ..  code-block:: pycon
 
-    >>> print(calendar.to_ical().decode())
+    >>> calendar.to_ical().decode()
     BEGIN:VCALENDAR
     VERSION:2.0
     PRODID:-//collective//icalendar//7.0.0//EN
@@ -40,7 +40,7 @@ The output confirms the change:
 
 .. code-block:: pycon
 
-    >>> print(calendar.to_ical().decode())
+    >>> calendar.to_ical().decode()
     BEGIN:VCALENDAR
     VERSION:2.0
     PRODID:-//icalendar//example.com//EN
@@ -70,7 +70,7 @@ The output shows your new event:
 
 .. code-block:: pycon
 
-    >>> print(event.to_ical().decode())
+    >>> event.to_ical().decode()
     BEGIN:VEVENT
     DTSTART:20260321T063000Z
     DTEND:20260321T073000Z
@@ -100,7 +100,7 @@ Now print the calendar to verify everything that it contains:
 
 .. code-block:: pycon
 
-    >>> print(calendar.to_ical().decode())
+    >>> calendar.to_ical().decode()
     BEGIN:VCALENDAR
     VERSION:2.0
     PRODID:-//icalendar//example.com//EN
@@ -139,7 +139,7 @@ The output confirms your additions:
 
 .. code-block:: pycon
 
-    >>> print(ride_event.to_ical().decode())
+    >>> ride_event.to_ical().decode()
     BEGIN:VEVENT
     SUMMARY:Morning ride with the team.
     DTSTART:20260328T070000Z
@@ -168,7 +168,7 @@ Now print the calendar to view everything you've added so far, this should inclu
 
 .. code-block:: pycon
 
-    >>> print(calendar.to_ical().decode())
+    >>> calendar.to_ical().decode()
     BEGIN:VCALENDAR
     VERSION:2.0
     PRODID:-//icalendar//example.com//EN


### PR DESCRIPTION
## Closes issue

Closes #1257

## Description

Replace print() statements with direct expression calls 
in create-event-with-attendees tutorial documentation.
This makes the code examples cleaner and more consistent
with Python's interactive shell output style.

## Checklist
- [x] I've added or edited documentation, both as docstrings 
to be rendered in the API documentation and narrative 
documentation, as necessary.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1354.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->