### PR TITLE
docs(alarm): rewrite REPEAT and DURATION docstrings (refs #1244)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,6 +101,7 @@ Documentation
 - Reorganize Design documentation. :issue:`1292`
 - Improve docstring for ``categories_property``, which renders to HTML in :attr:`Calendar.categories <icalendar.cal.calendar.Calendar.categories>`, :attr:`Event.categories <icalendar.cal.event.Event.categories>`, :attr:`Journal.categories <icalendar.cal.journal.Journal.categories>`, and :attr:`Todo.categories <icalendar.cal.todo.Todo.categories>`. :issue:`1244`
 - Fixed Python object cross-references in ``icalendar.cal.component.Component._infer_value_type``. :issue:`1158`, :pr:`1344`
+- Replace the RFC quotations in the docstrings for :attr:`Alarm.REPEAT <icalendar.cal.alarm.Alarm.REPEAT>` and :attr:`Alarm.DURATION <icalendar.cal.alarm.Alarm.DURATION>` with Pythonic descriptions, including parameter notes, conformance references, and worked examples. :issue:`1244`
 
 7.0.3 (2026-03-03)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,7 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-- ...
+- Replace the RFC quotations in the docstrings for :attr:`Alarm.REPEAT <icalendar.cal.alarm.Alarm.REPEAT>` and :attr:`Alarm.DURATION <icalendar.cal.alarm.Alarm.DURATION>` with Pythonic descriptions, including parameter notes, conformance references, and worked examples. :issue:`1244`
 
 7.1.0 (2026-04-30)
 ------------------
@@ -102,7 +102,6 @@ Documentation
 - Reorganize Design documentation. :issue:`1292`
 - Improve docstring for ``categories_property``, which renders to HTML in :attr:`Calendar.categories <icalendar.cal.calendar.Calendar.categories>`, :attr:`Event.categories <icalendar.cal.event.Event.categories>`, :attr:`Journal.categories <icalendar.cal.journal.Journal.categories>`, and :attr:`Todo.categories <icalendar.cal.todo.Todo.categories>`. :issue:`1244`
 - Fixed Python object cross-references in ``icalendar.cal.component.Component._infer_value_type``. :issue:`1158`, :pr:`1344`
-- Replace the RFC quotations in the docstrings for :attr:`Alarm.REPEAT <icalendar.cal.alarm.Alarm.REPEAT>` and :attr:`Alarm.DURATION <icalendar.cal.alarm.Alarm.DURATION>` with Pythonic descriptions, including parameter notes, conformance references, and worked examples. :issue:`1244`
 
 7.0.3 (2026-03-03)
 ------------------

--- a/src/icalendar/cal/alarm.py
+++ b/src/icalendar/cal/alarm.py
@@ -97,10 +97,9 @@ class Alarm(Component):
         triggers, so a ``REPEAT`` of ``2`` produces three alarms in total
         (the initial trigger plus two repeats).
 
-        Conformance:
-            Defined by :rfc:`5545#section-3.8.6.2`. The property can appear
-            once in a "VALARM" component and must be paired with
-            :attr:`DURATION`.
+        Conforming with :rfc:`5545#section-3.8.6.2`, this property can appear
+        once in an :class:`~icalendar.cal.alarm.Alarm` component and must be
+        paired with :attr:`DURATION`.
 
         Example:
             Build an alarm that fires once and then repeats twice at
@@ -126,7 +125,7 @@ class Alarm(Component):
         """The delay between repeated triggers of a repeating alarm.
 
         Returns a :class:`datetime.timedelta` or ``None`` when the alarm
-        has no DURATION set. Setting this attribute accepts a
+        has no :attr:`DURATION` set. Setting this attribute accepts a
         :class:`~datetime.timedelta`; deleting it removes the property
         from the component.
 
@@ -135,9 +134,8 @@ class Alarm(Component):
         ``REPEAT`` additional triggers, each spaced by ``DURATION`` after
         the initial trigger.
 
-        Conformance:
-            Defined by :rfc:`5545#section-3.8.2.5`. The property can
-            appear once in a "VALARM" component.
+        Conforming with :rfc:`5545#section-3.8.2.5`, the ``DURATION`` property
+        can appear once in an :class:`~icalendar.cal.alarm.Alarm` component.
 
         Example:
             Pair :attr:`DURATION` with :attr:`REPEAT` to produce three

--- a/src/icalendar/cal/alarm.py
+++ b/src/icalendar/cal/alarm.py
@@ -89,15 +89,33 @@ class Alarm(Component):
     REPEAT = single_int_property(
         "REPEAT",
         0,
-        """The REPEAT property of an alarm component.
+        """The number of additional times the alarm is triggered after the initial trigger.
 
-        The alarm can be defined such that it triggers repeatedly.  A
-        definition of an alarm with a repeating trigger MUST include both
-        the "DURATION" and "REPEAT" properties.  The "DURATION" property
-        specifies the delay period, after which the alarm will repeat.
-        The "REPEAT" property specifies the number of additional
-        repetitions that the alarm will be triggered.  This repetition
-        count is in addition to the initial triggering of the alarm.
+        Defaults to ``0``, meaning the alarm fires once. To repeat the alarm,
+        set both :attr:`REPEAT` and :attr:`DURATION`. The :attr:`DURATION`
+        sets the gap between repetitions. ``REPEAT`` is the count of *additional*
+        triggers, so a ``REPEAT`` of ``2`` produces three alarms in total
+        (the initial trigger plus two repeats).
+
+        Conformance:
+            Defined by :rfc:`5545#section-3.8.6.2`. The property can appear
+            once in a "VALARM" component and must be paired with
+            :attr:`DURATION`.
+
+        Example:
+            Build an alarm that fires once and then repeats twice at
+            five-minute intervals.
+
+            .. code-block:: pycon
+
+                >>> from datetime import timedelta
+                >>> from icalendar import Alarm
+                >>> alarm = Alarm()
+                >>> alarm.TRIGGER = timedelta(minutes=-15)
+                >>> alarm.DURATION = timedelta(minutes=5)
+                >>> alarm.REPEAT = 2
+                >>> alarm.REPEAT
+                2
         """,
     )
 
@@ -105,13 +123,37 @@ class Alarm(Component):
         property_get_duration,
         property_set_duration,
         property_del_duration,
-        """The DURATION property of an alarm component.
+        """The delay between repeated triggers of a repeating alarm.
 
-    The alarm can be defined such that it triggers repeatedly.  A
-    definition of an alarm with a repeating trigger MUST include both
-    the "DURATION" and "REPEAT" properties.  The "DURATION" property
-    specifies the delay period, after which the alarm will repeat.
-    """,
+        Returns a :class:`datetime.timedelta` or ``None`` when the alarm
+        has no DURATION set. Setting this attribute accepts a
+        :class:`~datetime.timedelta`; deleting it removes the property
+        from the component.
+
+        :attr:`DURATION` is meaningful only for repeating alarms and must
+        be paired with :attr:`REPEAT`. The two together produce
+        ``REPEAT`` additional triggers, each spaced by ``DURATION`` after
+        the initial trigger.
+
+        Conformance:
+            Defined by :rfc:`5545#section-3.8.2.5`. The property can
+            appear once in a "VALARM" component.
+
+        Example:
+            Pair :attr:`DURATION` with :attr:`REPEAT` to produce three
+            triggers spaced ten minutes apart.
+
+            .. code-block:: pycon
+
+                >>> from datetime import timedelta
+                >>> from icalendar import Alarm
+                >>> alarm = Alarm()
+                >>> alarm.TRIGGER = timedelta(minutes=-30)
+                >>> alarm.DURATION = timedelta(minutes=10)
+                >>> alarm.REPEAT = 2
+                >>> alarm.DURATION
+                datetime.timedelta(seconds=600)
+        """,
     )
 
     ACKNOWLEDGED = single_utc_property(


### PR DESCRIPTION
## Closes issue

- [x] Refs #1244

This PR addresses two of the unchecked items in the #1244 checklist (`Alarm.REPEAT` and `Alarm.DURATION`). It does not close the umbrella issue.

## Description

The existing docstrings for `Alarm.REPEAT` and `Alarm.DURATION` are paragraph-style copy-paste from RFC 5545. The umbrella issue asks for these to be rewritten as Pythonic docstrings.

The pattern matches PR #1338 for `Calendar.categories`:

- Lead with a one-line summary of what the property does in Python terms (default value, accepted types, return type).
- Note that the two are paired: a repeating alarm sets both, and `REPEAT` counts additional triggers, not total triggers (worth calling out because the iCal wording is easy to misread).
- Reference the RFC sections via `:rfc:` directives so Sphinx renders linked anchors instead of bare quotation.
- End with a working `pycon` example that pairs `TRIGGER`, `DURATION`, and `REPEAT` to produce the same behavior described in the prose.

The RFC text itself is no longer copy-pasted into the docstring; the `:rfc:` link is the canonical reference.

The CHANGES entry slots in next to the other `:issue:` 1244 entries under the 7.0.4 Documentation section.

## Checklist

- [x] I've added a change log entry to `CHANGES.rst`.
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

The doctest suite (`pytest src/icalendar/tests/test_with_doctest.py`) passes locally with the new examples (343/343).

## Additional information

The other unchecked items under `Alarm` in #1244 (`ACKNOWLEDGED`, `TRIGGER`, `TRIGGER_RELATED`, `Triggers`, `attendees`, `description`, `triggers`, `uid`) are intentionally left for separate PRs to keep this one reviewable and to mirror the per-property cadence of #1338.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1357.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->