### PR TITLE
Add type hints to vFrequency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Change log
 Minor changes
 ~~~~~~~~~~~~~
 
-- ...
+- Add type hints to :class:`~icalendar.prop.recur.frequency.vFrequency`. :issue:`938`
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/src/icalendar/prop/recur/frequency.py
+++ b/src/icalendar/prop/recur/frequency.py
@@ -29,11 +29,11 @@ class vFrequency(str):
 
     def __new__(
         cls,
-        value,
-        encoding=DEFAULT_ENCODING,
+        value: Any,
+        encoding: str = DEFAULT_ENCODING,
         /,
         params: dict[str, Any] | None = None,
-    ):
+    ) -> Self:
         value = to_unicode(value, encoding=encoding)
         self = super().__new__(cls, value)
         if self not in vFrequency.frequencies:
@@ -41,11 +41,11 @@ class vFrequency(str):
         self.params = Parameters(params)
         return self
 
-    def to_ical(self):
+    def to_ical(self) -> bytes:
         return self.encode(DEFAULT_ENCODING).upper()
 
     @classmethod
-    def from_ical(cls, ical):
+    def from_ical(cls, ical: Any) -> Self:
         try:
             return cls(ical.upper())
         except Exception as e:


### PR DESCRIPTION
## Summary
- Adds explicit type hints to `vFrequency.__new__`, `to_ical`, and `from_ical`.
- Keeps runtime behavior unchanged while continuing the rolling type-hinting work from #938.

Refs #938

## Testing
- `python3 -m pytest src/icalendar/tests/prop/test_constructors.py src/icalendar/tests/prop/test_unit.py src/icalendar/tests/rfc_7265_jcal/test_invalid_jcal.py -q` — 751 passed

Note: I also tried `python3 -m mypy src/icalendar/prop/recur/frequency.py`, but mypy is not installed in this local environment.
