### PR TITLE
#876 vPeriod

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Change log
 Minor changes
 ~~~~~~~~~~~~~
 
-- Created an :attr:`~icalendar.prop.dt.period.vPeriod.ical_value` property for the :class:`~icalendar.prop.dt.period.vPeriod` component. See :issue:`876`
+- Created an :attr:`~icalendar.prop.dt.period.vPeriod.ical_value` property for the :class:`~icalendar.prop.dt.period.vPeriod` component. :issue:`876`
 
 
 Breaking changes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Change log
 Minor changes
 ~~~~~~~~~~~~~
 
-- ...
+- Created an :attr:`~icalendar.prop.dt.period.vPeriod.ical_value` property for the :class:`~icalendar.prop.dt.period.vPeriod` component. See :issue:`876`
+
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/src/icalendar/prop/dt/period.py
+++ b/src/icalendar/prop/dt/period.py
@@ -154,7 +154,10 @@ class vPeriod(TimeBase):
 
     @property
     def ical_value(self) -> tuple[datetime, timedelta | datetime]:
-        """The start and end or duration as a tuple."""
+        """
+        Returns the period as a tuple of its start datetime
+        and either its end datetime or duration.
+        """
         return self.dt
 
     from icalendar.param import FBTYPE

--- a/src/icalendar/prop/dt/period.py
+++ b/src/icalendar/prop/dt/period.py
@@ -152,6 +152,11 @@ class vPeriod(TimeBase):
         """Make this cooperate with the other vDDDTypes."""
         return (self.start, (self.duration if self.by_duration else self.end))
 
+    @property
+    def ical_value(self) -> tuple[date | datetime, date | datetime | timedelta]:
+        """The start and end or duration as a tuple."""
+        return self.dt
+
     from icalendar.param import FBTYPE
 
     @classmethod

--- a/src/icalendar/prop/dt/period.py
+++ b/src/icalendar/prop/dt/period.py
@@ -153,7 +153,7 @@ class vPeriod(TimeBase):
         return (self.start, (self.duration if self.by_duration else self.end))
 
     @property
-    def ical_value(self) -> tuple[date | datetime, date | datetime | timedelta]:
+    def ical_value(self) -> tuple[datetime, timedelta | datetime]:
         """The start and end or duration as a tuple."""
         return self.dt
 

--- a/src/icalendar/tests/prop/test_vPeriod.py
+++ b/src/icalendar/tests/prop/test_vPeriod.py
@@ -61,3 +61,15 @@ def test_invalid_parameters(period, error):
     """The parameters are of wrong type or of wrong order."""
     with pytest.raises(error):
         vPeriod(period)
+
+
+def test_ical_value_with_end():
+    """ical_value property returns the start/end tuple."""
+    value = (datetime(2000, 1, 1), datetime(2000, 1, 2))
+    assert vPeriod(value).ical_value == value
+
+
+def test_ical_value_with_duration():
+    """ical_value property returns the start/duration tuple."""
+    value = (datetime(2000, 1, 1), timedelta(days=31))
+    assert vPeriod(value).ical_value == value


### PR DESCRIPTION
## See issue


- [ ] See #876

## Description

This pull request adds missing `ical_value` properties for:
- `vPeriod`

It also adds test coverage for these properties and updates `CHANGES.rst`.

## Checklist

- [x] I've added a change log entry to `CHANGES.rst`.
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

> *Disclaimer: this contribution is part of work carried out as a student at Université Paris-Cité. Apologies if this is inappropriate or if the contribution does not meet the project’s standards — any feedback is welcome.*

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1359.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->