### PR TITLE
Add `vWeekday.ical_value` for the `Component.decoded()` polymorphy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Breaking changes
 New features
 ~~~~~~~~~~~~
 
-- ...
+- Created a :meth:`~icalendar.prop.recur.weekday.vWeekday.ical_value` property for the :class:`~icalendar.prop.recur.weekday.vWeekday` component, mirroring the existing pattern on :class:`~icalendar.prop.boolean.vBoolean`. :pr:`1360`
 
 Bug fixes
 ~~~~~~~~~

--- a/src/icalendar/prop/recur/weekday.py
+++ b/src/icalendar/prop/recur/weekday.py
@@ -93,6 +93,14 @@ class vWeekday(str):
         except Exception as e:
             raise ValueError(f"Expected weekday abbreviation, got: {ical}") from e
 
+    @property
+    def ical_value(self) -> str:
+        """The weekday value (e.g. ``MO``, ``+2TH``, ``-1SU``).
+
+        See :rfc:`5545#section-3.3.10` for the ``BYDAY`` rule grammar.
+        """
+        return str(self)
+
     @classmethod
     def parse_jcal_value(cls, value: Any) -> Self:
         """Parse a jCal value for vWeekday.

--- a/src/icalendar/prop/recur/weekday.py
+++ b/src/icalendar/prop/recur/weekday.py
@@ -95,9 +95,11 @@ class vWeekday(str):
 
     @property
     def ical_value(self) -> str:
-        """The weekday value (e.g. ``MO``, ``+2TH``, ``-1SU``).
+        """Returns the weekday value as a string, for example, ``MO``, ``+2TH``, or ``-1SU``.
 
-        See :rfc:`5545#section-3.3.10` for the ``BYDAY`` rule grammar.
+        See Also:
+
+            :rfc:`5545#section-3.3.10` for the ``BYDAY`` rule grammar.
         """
         return str(self)
 

--- a/src/icalendar/tests/prop/test_vWeekday.py
+++ b/src/icalendar/tests/prop/test_vWeekday.py
@@ -25,3 +25,11 @@ def test_error():
     """Error: Expected weekday abbrevation, got: -100MO"""
     with pytest.raises(ValueError):
         vWeekday.from_ical("-100MO")
+
+
+def test_ical_value():
+    """ical_value property returns the weekday string value."""
+    assert vWeekday("MO").ical_value == "MO"
+    assert vWeekday("+2TH").ical_value == "+2TH"
+    assert vWeekday("-1SU").ical_value == "-1SU"
+    assert isinstance(vWeekday("MO").ical_value, str)


### PR DESCRIPTION
Refs #876

## Why

Continuing the polymorphy work tracked in #876, this adds `ical_value` to `vWeekday` so `Component.decoded()` can keep getting smaller. After this, the BYDAY/BYWEEKDAY/WKST values produced via `Component.decoded()` look like every other RFC 5545 value type instead of needing an `if isinstance(..., vWeekday)` branch.

`vWeekday` extends `str`, so `ical_value` is just `str(self)` -- the same shape vText, vUri, vCalAddress, vUid already use.

## Behaviour

```pycon
>>> from icalendar import vWeekday
>>> vWeekday("MO").ical_value
'MO'
>>> vWeekday("+2TH").ical_value
'+2TH'
>>> vWeekday("-1SU").ical_value
'-1SU'
```

## Tests

`pytest src/icalendar/tests/prop/test_vWeekday.py` now runs 5 tests (was 4):

```
src/icalendar/tests/prop/test_vWeekday.py::test_simple PASSED
src/icalendar/tests/prop/test_vWeekday.py::test_relative PASSED
src/icalendar/tests/prop/test_vWeekday.py::test_roundtrip PASSED
src/icalendar/tests/prop/test_vWeekday.py::test_error PASSED
src/icalendar/tests/prop/test_vWeekday.py::test_ical_value PASSED
```

## Checklist (per #876)

- [x] type hint (`-> str`)
- [x] doc string (mentions ``MO``, ``+2TH``, ``-1SU`` and links to RFC 5545 § 3.3.10 BYDAY)
- [x] test for the value
- [x] consistent with `vText`/`vUri`/`vCalAddress` (which return `str(self)`)