### PR TITLE
Add ical_value property to vTime, vGeo, and vUTCOffset

### DIFF
--- a/src/icalendar/prop/dt/time.py
+++ b/src/icalendar/prop/dt/time.py
@@ -148,6 +148,11 @@ class vTime(TimeBase):
             value += "Z"
         return value
 
+    @property
+    def ical_value(self) -> time:
+        """TIME property type according to :rfc:`5545#section-3.3.12`"""
+        return self.dt
+
     def is_utc(self) -> bool:
         """Whether this time is UTC."""
         return self.params.is_utc() or is_utc(self.dt)

--- a/src/icalendar/prop/dt/utc_offset.py
+++ b/src/icalendar/prop/dt/utc_offset.py
@@ -80,6 +80,11 @@ class vUTCOffset:
         """Return the ical representation."""
         return self.format("")
 
+    @property
+    def ical_value(self) -> timedelta:
+        """UTC-OFFSET property type according to :rfc:`5545#section-3.3.14`"""
+        return self.td
+
     def format(self, divider: str = "") -> str:
         """Represent the value with a possible divider.
 

--- a/src/icalendar/prop/geo.py
+++ b/src/icalendar/prop/geo.py
@@ -95,6 +95,11 @@ class vGeo:
     def to_ical(self) -> str:
         return f"{self.latitude};{self.longitude}"
 
+    @property
+    def ical_value(self) -> tuple[float, float]:
+        """GEO property type according to :rfc:`5545#section-3.4.1`"""
+        return (self.latitude, self.longitude)
+
     @staticmethod
     def from_ical(ical: str) -> tuple[float, float]:
         try:

--- a/src/icalendar/tests/prop/test_vGeo.py
+++ b/src/icalendar/tests/prop/test_vGeo.py
@@ -1,0 +1,11 @@
+"""Test vGeo ical_value property."""
+
+from icalendar.prop import vGeo
+
+
+def test_ical_value():
+    """ical_value property returns the (latitude, longitude) tuple."""
+    geo = vGeo((37.386013, -122.082932))
+    assert geo.ical_value == (37.386013, -122.082932)
+    assert isinstance(geo.ical_value, tuple)
+    assert len(geo.ical_value) == 2

--- a/src/icalendar/tests/prop/test_vUTCOffset.py
+++ b/src/icalendar/tests/prop/test_vUTCOffset.py
@@ -1,0 +1,13 @@
+"""Test vUTCOffset ical_value property."""
+
+from datetime import timedelta
+
+from icalendar.prop import vUTCOffset
+
+
+def test_ical_value():
+    """ical_value property returns the timedelta value."""
+    td = timedelta(hours=-5)
+    offset = vUTCOffset(td)
+    assert offset.ical_value == td
+    assert isinstance(offset.ical_value, timedelta)

--- a/src/icalendar/tests/test_time.py
+++ b/src/icalendar/tests/test_time.py
@@ -75,3 +75,11 @@ def test_localized_time_utc(tzp):
 
     assert isinstance(localized, time)
     assert str(localized.tzinfo) == "UTC"
+
+
+def test_ical_value():
+    """ical_value property returns the time value."""
+    t = time(17, 20, 10)
+    vt = vTime(t)
+    assert vt.ical_value == t
+    assert isinstance(vt.ical_value, time)


### PR DESCRIPTION
This PR adds the `ical_value` property to three value type classes as part of Issue #876.

## Changes

### Added `ical_value` property to:
1. **vTime** (src/icalendar/prop/dt/time.py)
   - Returns `self.dt` (time object)
   - Type hint: `time`
   - RFC reference: :rfc:`5545#section-3.3.12`

2. **vGeo** (src/icalendar/prop/geo.py)
   - Returns `(self.latitude, self.longitude)`
   - Type hint: `tuple[float, float]`
   - RFC reference: :rfc:`5545#section-3.4.1`

3. **vUTCOffset** (src/icalendar/prop/dt/utc_offset.py)
   - Returns `self.td` (timedelta object)
   - Type hint: `timedelta`
   - RFC reference: :rfc:`5545#section-3.3.14`

### Tests
- Added `test_ical_value()` to `test_time.py`
- Created `test_vGeo.py` with ical_value test
- Created `test_vUTCOffset.py` with ical_value test
- All tests pass: 9446 passed

## Implementation Details
- All properties use `@property` decorator
- Include type hints for return values
- Include docstrings with RFC references
- Follow the same pattern as existing implementations (vBoolean, vInt, vFloat)

Contributes to #876