### PR TITLE
Add ical_value property to vFrequency, vMonth, and vInline

### DIFF
--- a/src/icalendar/prop/inline.py
+++ b/src/icalendar/prop/inline.py
@@ -29,6 +29,11 @@ class vInline(str):
     def to_ical(self) -> bytes:
         return self.encode(DEFAULT_ENCODING)
 
+    @property
+    def ical_value(self) -> str:
+        """Inline value type (unparsed text)"""
+        return str(self)
+
     @classmethod
     def from_ical(cls, ical: ICAL_TYPE) -> Self:
         return cls(ical)

--- a/src/icalendar/prop/recur/frequency.py
+++ b/src/icalendar/prop/recur/frequency.py
@@ -44,6 +44,11 @@ class vFrequency(str):
     def to_ical(self):
         return self.encode(DEFAULT_ENCODING).upper()
 
+    @property
+    def ical_value(self) -> str:
+        """FREQ value type according to :rfc:`5545#section-3.3.10`"""
+        return str(self)
+
     @classmethod
     def from_ical(cls, ical):
         try:

--- a/src/icalendar/prop/recur/month.py
+++ b/src/icalendar/prop/recur/month.py
@@ -61,6 +61,11 @@ class vMonth(int):
         """The ical representation."""
         return str(self).encode("utf-8")
 
+    @property
+    def ical_value(self) -> int:
+        """BYMONTH value type according to :rfc:`5545#section-3.3.10` and :rfc:`7529`"""
+        return int(self)
+
     @classmethod
     def from_ical(cls, ical: str):
         return cls(ical)

--- a/src/icalendar/tests/prop/test_vFrequency.py
+++ b/src/icalendar/tests/prop/test_vFrequency.py
@@ -1,0 +1,13 @@
+"""Test vFrequency ical_value property."""
+
+from icalendar.prop import vFrequency
+
+
+def test_ical_value():
+    """ical_value property returns the string value."""
+    freq = vFrequency("DAILY")
+    assert freq.ical_value == "DAILY"
+    assert isinstance(freq.ical_value, str)
+    
+    freq2 = vFrequency("WEEKLY")
+    assert freq2.ical_value == "WEEKLY"

--- a/src/icalendar/tests/prop/test_vInline.py
+++ b/src/icalendar/tests/prop/test_vInline.py
@@ -1,0 +1,13 @@
+"""Test vInline ical_value property."""
+
+from icalendar.prop import vInline
+
+
+def test_ical_value():
+    """ical_value property returns the string value."""
+    inline = vInline("some raw text")
+    assert inline.ical_value == "some raw text"
+    assert isinstance(inline.ical_value, str)
+    
+    inline2 = vInline("another value")
+    assert inline2.ical_value == "another value"

--- a/src/icalendar/tests/prop/test_vMonth.py
+++ b/src/icalendar/tests/prop/test_vMonth.py
@@ -1,0 +1,15 @@
+"""Test vMonth ical_value property."""
+
+from icalendar.prop import vMonth
+
+
+def test_ical_value():
+    """ical_value property returns the int value."""
+    month = vMonth(1)
+    assert month.ical_value == 1
+    assert isinstance(month.ical_value, int)
+    
+    # Test with leap month
+    leap_month = vMonth("5L")
+    assert leap_month.ical_value == 5
+    assert isinstance(leap_month.ical_value, int)


### PR DESCRIPTION
This PR adds the `ical_value` property to three more value type classes as part of Issue #876.

## Changes

### Added `ical_value` property to:
1. **vFrequency** (src/icalendar/prop/recur/frequency.py)
   - Returns `str(self)` (frequency string)
   - Type hint: `str`
   - RFC reference: :rfc:`5545#section-3.3.10`
   - Example: `vFrequency("DAILY").ical_value == "DAILY"`

2. **vMonth** (src/icalendar/prop/recur/month.py)
   - Returns `int(self)` (month number)
   - Type hint: `int`
   - RFC references: :rfc:`5545#section-3.3.10` and :rfc:`7529`
   - Example: `vMonth(1).ical_value == 1`, `vMonth("5L").ical_value == 5`

3. **vInline** (src/icalendar/prop/inline.py)
   - Returns `str(self)` (unparsed text)
   - Type hint: `str`
   - Example: `vInline("text").ical_value == "text"`

### Tests
- Created `test_vFrequency.py` with ical_value test
- Created `test_vMonth.py` with ical_value test (including leap month case)
- Created `test_vInline.py` with ical_value test
- All tests pass: 9447 passed

## Implementation Details
- All properties use `@property` decorator
- Include type hints for return values
- Include docstrings with RFC references where applicable
- Follow the same pattern as existing implementations (vBoolean, vInt, vFloat)
- These classes inherit from basic Python types (str, int), so ical_value returns the converted value

Contributes to #876