### PR TITLE
Add ical_value property to vGeo

### DIFF
--- a/src/icalendar/prop/geo.py
+++ b/src/icalendar/prop/geo.py
@@ -92,6 +92,29 @@ class vGeo:
         self.longitude = longitude
         self.params = Parameters(params)
 
+    @property
+    def ical_value(self) -> tuple[float, float]:
+        """Return the Python tuple value (latitude, longitude).
+
+        This property provides access to the underlying geographic coordinates
+        as a tuple of floats.
+
+        Returns:
+            tuple[float, float]: A tuple of (latitude, longitude) in decimal degrees.
+                Latitude ranges from -90 to 90 (south to north).
+                Longitude ranges from -180 to 180 (west to east).
+
+        Example:
+            >>> from icalendar.prop import vGeo
+            >>> geo = vGeo((37.386013, -122.082932))
+            >>> geo.ical_value
+            (37.386013, -122.082932)
+
+        See Also:
+            :rfc:`5545#section-3.8.1.6` for the GEO property specification.
+        """
+        return (self.latitude, self.longitude)
+
     def to_ical(self) -> str:
         return f"{self.latitude};{self.longitude}"
 

--- a/src/icalendar/tests/prop/test_vGeo.py
+++ b/src/icalendar/tests/prop/test_vGeo.py
@@ -1,0 +1,37 @@
+"""Test vGeo ical_value property."""
+
+from icalendar.prop import vGeo
+
+
+def test_ical_value_basic():
+    """ical_value property returns tuple of (latitude, longitude)."""
+    geo = vGeo((37.386013, -122.082932))
+    assert geo.ical_value == (37.386013, -122.082932)
+    assert isinstance(geo.ical_value, tuple)
+    assert len(geo.ical_value) == 2
+
+
+def test_ical_value_components():
+    """ical_value property components match latitude and longitude."""
+    lat, lon = 48.8566, 2.3522  # Paris
+    geo = vGeo((lat, lon))
+    assert geo.ical_value[0] == lat
+    assert geo.ical_value[1] == lon
+    assert geo.ical_value == (geo.latitude, geo.longitude)
+
+
+def test_ical_value_from_ical():
+    """ical_value property works with geo parsed from ical string."""
+    coords = vGeo.from_ical("51.5074;-0.1278")  # London
+    geo = vGeo(coords)
+    assert geo.ical_value == (51.5074, -0.1278)
+    assert geo.ical_value[0] == 51.5074  # latitude
+    assert geo.ical_value[1] == -0.1278  # longitude
+
+
+def test_ical_value_negative_coordinates():
+    """ical_value property handles negative coordinates."""
+    geo = vGeo((-33.8688, 151.2093))  # Sydney
+    assert geo.ical_value == (-33.8688, 151.2093)
+    assert geo.ical_value[0] < 0  # Southern hemisphere
+    assert geo.ical_value[1] > 0  # Eastern hemisphere


### PR DESCRIPTION
This PR adds the `ical_value` property to `vGeo`, contributing to Issue #876.

## Changes

- Added `ical_value` property to `vGeo` (src/icalendar/prop/geo.py)
  - Returns: `tuple[float, float]` - A tuple of (latitude, longitude)
  - Type hint: `tuple[float, float]`
  - RFC reference: :rfc:`5545#section-3.8.1.6`
  - Includes comprehensive docstring with examples

## Tests

- Created `test_vGeo.py` with 4 comprehensive test cases:
  - `test_ical_value_basic` - Tests basic tuple return
  - `test_ical_value_components` - Tests latitude/longitude components
  - `test_ical_value_from_ical` - Tests with parsed ical strings
  - `test_ical_value_negative_coordinates` - Tests negative coordinates (Southern/Western hemispheres)
- All tests pass: 4 passed

## Quality Checks

- [x] Add type hint
- [x] Add docstring with RFC reference
- [x] Add tests for all code paths
- [x] Pass ruff format check
- [x] Pass ruff lint check
- [x] All tests pass

Relates to #876