### PR TITLE
Add ical_value property to vUTCOffset

### DIFF
--- a/src/icalendar/prop/dt/utc_offset.py
+++ b/src/icalendar/prop/dt/utc_offset.py
@@ -76,6 +76,32 @@ class vUTCOffset:
         self.td = td
         self.params = Parameters(params)
 
+    @property
+    def ical_value(self) -> timedelta:
+        """Return the Python timedelta value.
+
+        This property provides access to the underlying :class:`datetime.timedelta`
+        object representing the UTC offset.
+
+        Returns:
+            timedelta: The UTC offset as a timedelta object.
+                Positive values indicate offsets ahead of UTC (east).
+                Negative values indicate offsets behind UTC (west).
+
+        Example:
+            >>> from icalendar.prop import vUTCOffset
+            >>> from datetime import timedelta
+            >>> offset = vUTCOffset(timedelta(hours=-5))
+            >>> offset.ical_value
+            datetime.timedelta(days=-1, seconds=68400)
+            >>> offset.ical_value.total_seconds() / 3600
+            -5.0
+
+        See Also:
+            :rfc:`5545#section-3.3.14` for the UTC-OFFSET value type specification.
+        """
+        return self.td
+
     def to_ical(self) -> str:
         """Return the ical representation."""
         return self.format("")

--- a/src/icalendar/tests/prop/test_vUTCOffset.py
+++ b/src/icalendar/tests/prop/test_vUTCOffset.py
@@ -1,0 +1,48 @@
+"""Test vUTCOffset ical_value property."""
+
+from datetime import timedelta
+
+from icalendar.prop import vUTCOffset
+
+
+def test_ical_value_positive_offset():
+    """ical_value property returns timedelta for positive UTC offset."""
+    td = timedelta(hours=1)  # +01:00 (Geneva)
+    offset = vUTCOffset(td)
+    assert offset.ical_value == td
+    assert offset.ical_value.total_seconds() == 3600
+
+
+def test_ical_value_negative_offset():
+    """ical_value property returns timedelta for negative UTC offset."""
+    td = timedelta(hours=-5)  # -05:00 (New York)
+    offset = vUTCOffset(td)
+    assert offset.ical_value == td
+    assert offset.ical_value.total_seconds() == -18000
+
+
+def test_ical_value_from_ical():
+    """ical_value property works with offset parsed from ical string."""
+    td = vUTCOffset.from_ical("-0500")
+    offset = vUTCOffset(td)
+    assert offset.ical_value == timedelta(hours=-5)
+
+    td_positive = vUTCOffset.from_ical("+0100")
+    offset_positive = vUTCOffset(td_positive)
+    assert offset_positive.ical_value == timedelta(hours=1)
+
+
+def test_ical_value_with_minutes():
+    """ical_value property handles offsets with minutes."""
+    td = timedelta(hours=5, minutes=30)  # +05:30 (India)
+    offset = vUTCOffset(td)
+    assert offset.ical_value == td
+    assert offset.ical_value.total_seconds() == 19800
+
+
+def test_ical_value_zero_offset():
+    """ical_value property handles zero offset (UTC)."""
+    td = timedelta(0)
+    offset = vUTCOffset(td)
+    assert offset.ical_value == td
+    assert offset.ical_value.total_seconds() == 0


### PR DESCRIPTION
This PR adds the `ical_value` property to `vUTCOffset`, contributing to Issue #876.

## Changes

- Added `ical_value` property to `vUTCOffset` (src/icalendar/prop/dt/utc_offset.py)
  - Returns: `timedelta` - The UTC offset as a timedelta object
  - Type hint: `timedelta`
  - RFC reference: :rfc:`5545#section-3.3.14`
  - Includes comprehensive docstring with examples

## Tests

- Created `test_vUTCOffset.py` with 5 comprehensive test cases:
  - `test_ical_value_positive_offset` - Tests positive UTC offset
  - `test_ical_value_negative_offset` - Tests negative UTC offset
  - `test_ical_value_from_ical` - Tests with parsed ical strings
  - `test_ical_value_with_minutes` - Tests offsets with minutes
  - `test_ical_value_zero_offset` - Tests zero offset (UTC)
- All tests pass: 5 passed

## Quality Checks

- [x] Add type hint
- [x] Add docstring with RFC reference
- [x] Add tests for all code paths
- [x] Pass ruff format check
- [x] Pass ruff lint check
- [x] All tests pass

Relates to #876