### PR TITLE
Add ical_value property to vDate

### DIFF
--- a/src/icalendar/prop/dt/date.py
+++ b/src/icalendar/prop/dt/date.py
@@ -70,6 +70,30 @@ class vDate(TimeBase):
         self.dt = dt
         self.params = Parameters(params or {})
 
+    @property
+    def ical_value(self) -> date:
+        """Return the Python date value.
+
+        This property provides access to the underlying :class:`datetime.date`
+        object that this iCalendar DATE value wraps.
+
+        Returns:
+            date: The Python date object.
+
+        Example:
+            >>> from icalendar.prop import vDate
+            >>> from datetime import date
+            >>> d = vDate(date(1997, 7, 14))
+            >>> d.ical_value
+            datetime.date(1997, 7, 14)
+            >>> d.ical_value.year
+            1997
+
+        See Also:
+            :rfc:`5545#section-3.3.4` for the DATE value type specification.
+        """
+        return self.dt
+
     def to_ical(self):
         s = f"{self.dt.year:04}{self.dt.month:02}{self.dt.day:02}"
         return s.encode("utf-8")

--- a/src/icalendar/tests/prop/test_vDate.py
+++ b/src/icalendar/tests/prop/test_vDate.py
@@ -1,0 +1,50 @@
+"""Test vDate ical_value property."""
+
+from datetime import date
+
+from icalendar.prop import vDate
+
+
+def test_ical_value_basic():
+    """ical_value property returns date object."""
+    d = date(1997, 7, 14)
+    vd = vDate(d)
+    assert vd.ical_value == d
+    assert isinstance(vd.ical_value, date)
+
+
+def test_ical_value_components():
+    """ical_value property components match year, month, day."""
+    d = date(2026, 5, 8)
+    vd = vDate(d)
+    assert vd.ical_value.year == 2026
+    assert vd.ical_value.month == 5
+    assert vd.ical_value.day == 8
+
+
+def test_ical_value_from_ical():
+    """ical_value property works with date parsed from ical string."""
+    d = vDate.from_ical("19970714")
+    vd = vDate(d)
+    assert vd.ical_value == date(1997, 7, 14)
+
+
+def test_ical_value_leap_year():
+    """ical_value property handles leap year dates."""
+    d = date(2024, 2, 29)  # Leap year
+    vd = vDate(d)
+    assert vd.ical_value == d
+    assert vd.ical_value.day == 29
+
+
+def test_ical_value_year_boundaries():
+    """ical_value property handles year boundaries."""
+    # First day of year
+    d1 = date(2026, 1, 1)
+    vd1 = vDate(d1)
+    assert vd1.ical_value == d1
+
+    # Last day of year
+    d2 = date(2026, 12, 31)
+    vd2 = vDate(d2)
+    assert vd2.ical_value == d2


### PR DESCRIPTION
This PR adds the `ical_value` property to `vDate`, contributing to Issue #876.

## Changes

- Added `ical_value` property to `vDate` (src/icalendar/prop/dt/date.py)
  - Returns: `date` - The Python date object
  - Type hint: `date`
  - RFC reference: :rfc:`5545#section-3.3.4`
  - Includes comprehensive docstring with examples

## Tests

- Created `test_vDate.py` with 5 comprehensive test cases:
  - `test_ical_value_basic` - Tests basic date return
  - `test_ical_value_components` - Tests year/month/day components
  - `test_ical_value_from_ical` - Tests with parsed ical strings
  - `test_ical_value_leap_year` - Tests leap year dates
  - `test_ical_value_year_boundaries` - Tests first/last day of year
- All tests pass: 5 passed

## Quality Checks

- [x] Add type hint
- [x] Add docstring with RFC reference
- [x] Add tests for all code paths
- [x] Pass ruff format check
- [x] Pass ruff lint check
- [x] All tests pass

Relates to #876