### PR TITLE
Add ical_value property to vDuration

### DIFF
--- a/src/icalendar/prop/dt/duration.py
+++ b/src/icalendar/prop/dt/duration.py
@@ -95,6 +95,32 @@ class vDuration(TimeBase):
         self.td = td
         self.params = Parameters(params)
 
+    @property
+    def ical_value(self) -> timedelta:
+        """Return the Python timedelta value.
+
+        This property provides access to the underlying :class:`datetime.timedelta`
+        object representing the duration.
+
+        Returns:
+            timedelta: The duration as a timedelta object.
+
+        Example:
+            >>> from icalendar.prop import vDuration
+            >>> from datetime import timedelta
+            >>> dur = vDuration(timedelta(days=15, hours=5, seconds=20))
+            >>> dur.ical_value
+            datetime.timedelta(days=15, seconds=18020)
+            >>> dur.ical_value.days
+            15
+            >>> dur.ical_value.total_seconds()
+            1314020.0
+
+        See Also:
+            :rfc:`5545#section-3.3.6` for the DURATION value type specification.
+        """
+        return self.td
+
     def to_ical(self):
         sign = ""
         td = self.td

--- a/src/icalendar/tests/prop/test_vDuration.py
+++ b/src/icalendar/tests/prop/test_vDuration.py
@@ -1,0 +1,58 @@
+"""Test vDuration ical_value property."""
+
+from datetime import timedelta
+
+from icalendar.prop import vDuration
+
+
+def test_ical_value_basic():
+    """ical_value property returns timedelta object."""
+    td = timedelta(days=15, hours=5, seconds=20)
+    dur = vDuration(td)
+    assert dur.ical_value == td
+    assert isinstance(dur.ical_value, timedelta)
+
+
+def test_ical_value_components():
+    """ical_value property components match days and seconds."""
+    td = timedelta(days=7, hours=3, minutes=30, seconds=45)
+    dur = vDuration(td)
+    assert dur.ical_value.days == 7
+    assert dur.ical_value.seconds == 12645  # 3*3600 + 30*60 + 45
+    assert dur.ical_value.total_seconds() == 617445.0
+
+
+def test_ical_value_from_ical():
+    """ical_value property works with duration parsed from ical string."""
+    td = vDuration.from_ical("P15DT5H0M20S")
+    dur = vDuration(td)
+    assert dur.ical_value == timedelta(days=15, hours=5, seconds=20)
+
+    # Weeks
+    td_weeks = vDuration.from_ical("P7W")
+    dur_weeks = vDuration(td_weeks)
+    assert dur_weeks.ical_value == timedelta(weeks=7)
+
+
+def test_ical_value_negative():
+    """ical_value property handles negative durations."""
+    td = timedelta(days=-5, hours=-2)
+    dur = vDuration(td)
+    assert dur.ical_value == td
+    assert dur.ical_value.days == -6  # timedelta normalizes to -6 days + 79200 seconds
+    assert dur.ical_value.total_seconds() == -439200.0  # -5*86400 - 2*3600 = -439200
+
+
+def test_ical_value_zero():
+    """ical_value property handles zero duration."""
+    td = timedelta(0)
+    dur = vDuration(td)
+    assert dur.ical_value == td
+    assert dur.ical_value.total_seconds() == 0.0
+
+
+def test_ical_value_from_string():
+    """ical_value property works when vDuration is created from string."""
+    dur = vDuration("P1DT12H")
+    assert dur.ical_value == timedelta(days=1, hours=12)
+    assert dur.ical_value.total_seconds() == 129600.0


### PR DESCRIPTION
This PR adds the `ical_value` property to `vDuration`, contributing to Issue #876.

## Changes

- Added `ical_value` property to `vDuration` (src/icalendar/prop/dt/duration.py)
  - Returns: `timedelta` - The duration as a timedelta object
  - Type hint: `timedelta`
  - RFC reference: :rfc:`5545#section-3.3.6`
  - Includes comprehensive docstring with examples

## Tests

- Created `test_vDuration.py` with 6 comprehensive test cases:
  - `test_ical_value_basic` - Tests basic timedelta return
  - `test_ical_value_components` - Tests days/seconds components
  - `test_ical_value_from_ical` - Tests with parsed ical strings
  - `test_ical_value_negative` - Tests negative durations
  - `test_ical_value_zero` - Tests zero duration
  - `test_ical_value_from_string` - Tests vDuration created from string
- All tests pass: 6 passed

## Quality Checks

- [x] Add type hint
- [x] Add docstring with RFC reference
- [x] Add tests for all code paths
- [x] Pass ruff format check
- [x] Pass ruff lint check
- [x] All tests pass

Relates to #876