### PR TITLE
Add ical_value property to vFrequency

### DIFF
--- a/src/icalendar/prop/recur/frequency.py
+++ b/src/icalendar/prop/recur/frequency.py
@@ -41,6 +41,31 @@ class vFrequency(str):
         self.params = Parameters(params)
         return self
 
+    @property
+    def ical_value(self) -> str:
+        """Return the Python string value.
+
+        This property provides access to the underlying frequency string value,
+        which must be one of the valid recurrence frequencies defined in RFC 5545.
+
+        Returns:
+            str: The frequency string value (SECONDLY, MINUTELY, HOURLY, DAILY,
+                WEEKLY, MONTHLY, or YEARLY).
+
+        Example:
+            >>> from icalendar.prop import vFrequency
+            >>> freq = vFrequency("DAILY")
+            >>> freq.ical_value
+            'DAILY'
+            >>> freq2 = vFrequency("WEEKLY")
+            >>> freq2.ical_value
+            'WEEKLY'
+
+        See Also:
+            :rfc:`5545#section-3.3.10` for the FREQ value type specification.
+        """
+        return str(self)
+
     def to_ical(self):
         return self.encode(DEFAULT_ENCODING).upper()
 

--- a/src/icalendar/tests/prop/test_vFrequency.py
+++ b/src/icalendar/tests/prop/test_vFrequency.py
@@ -1,0 +1,64 @@
+"""Test vFrequency ical_value property."""
+
+import pytest
+
+from icalendar.prop import vFrequency
+
+
+def test_ical_value_daily():
+    """ical_value property returns string for DAILY frequency."""
+    freq = vFrequency("DAILY")
+    assert freq.ical_value == "DAILY"
+    assert isinstance(freq.ical_value, str)
+
+
+def test_ical_value_all_frequencies():
+    """ical_value property works for all valid frequencies."""
+    frequencies = [
+        "SECONDLY",
+        "MINUTELY",
+        "HOURLY",
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY",
+        "YEARLY",
+    ]
+    for f in frequencies:
+        freq = vFrequency(f)
+        assert freq.ical_value == f
+
+
+def test_ical_value_from_ical():
+    """ical_value property works with frequency parsed from ical string."""
+    freq = vFrequency.from_ical("WEEKLY")
+    assert freq.ical_value == "WEEKLY"
+
+    freq2 = vFrequency.from_ical("MONTHLY")
+    assert freq2.ical_value == "MONTHLY"
+
+
+def test_ical_value_case_insensitive():
+    """ical_value property handles case-insensitive input."""
+    freq_lower = vFrequency("daily")
+    freq_upper = vFrequency("DAILY")
+    # Both should normalize to uppercase
+    assert freq_lower.ical_value.upper() == "DAILY"
+    assert freq_upper.ical_value == "DAILY"
+
+
+def test_ical_value_invalid_frequency():
+    """vFrequency raises ValueError for invalid frequency."""
+    with pytest.raises(ValueError, match="Expected frequency"):
+        vFrequency("INVALID")
+
+
+def test_ical_value_weekly():
+    """ical_value property returns WEEKLY."""
+    freq = vFrequency("WEEKLY")
+    assert freq.ical_value == "WEEKLY"
+
+
+def test_ical_value_yearly():
+    """ical_value property returns YEARLY."""
+    freq = vFrequency("YEARLY")
+    assert freq.ical_value == "YEARLY"


### PR DESCRIPTION
This PR adds the `ical_value` property to `vFrequency`, contributing to Issue #876.

## Changes

- Added `ical_value` property to `vFrequency` (src/icalendar/prop/recur/frequency.py)
  - Returns: `str` - The frequency string value
  - Type hint: `str`
  - RFC reference: :rfc:`5545#section-3.3.10`
  - Includes comprehensive docstring with examples
  - Valid values: SECONDLY, MINUTELY, HOURLY, DAILY, WEEKLY, MONTHLY, YEARLY

## Tests

- Created `test_vFrequency.py` with 7 comprehensive test cases:
  - `test_ical_value_daily` - Tests DAILY frequency
  - `test_ical_value_all_frequencies` - Tests all 7 valid frequencies
  - `test_ical_value_from_ical` - Tests with parsed ical strings
  - `test_ical_value_case_insensitive` - Tests case handling
  - `test_ical_value_invalid_frequency` - Tests validation
  - `test_ical_value_weekly` - Tests WEEKLY frequency
  - `test_ical_value_yearly` - Tests YEARLY frequency
- All tests pass: 7 passed

## Quality Checks

- [x] Add type hint
- [x] Add docstring with RFC reference
- [x] Add tests for all code paths
- [x] Pass ruff format check
- [x] Pass ruff lint check
- [x] All tests pass

Relates to #876