### PR TITLE
Add ical_value property to vMonth

### DIFF
--- a/src/icalendar/prop/recur/month.py
+++ b/src/icalendar/prop/recur/month.py
@@ -57,6 +57,34 @@ class vMonth(int):
         self.params = Parameters(params)
         return self
 
+    @property
+    def ical_value(self) -> int:
+        """Return the Python int value.
+
+        This property provides access to the underlying month number as an integer.
+        The leap month indicator is not included in the integer value; use the
+        :attr:`leap` property to check if this is a leap month.
+
+        Returns:
+            int: The month number (1-12 for standard months).
+
+        Example:
+            >>> from icalendar.prop import vMonth
+            >>> m = vMonth(5)
+            >>> m.ical_value
+            5
+            >>> m_leap = vMonth("5L")
+            >>> m_leap.ical_value
+            5
+            >>> m_leap.leap
+            True
+
+        See Also:
+            :rfc:`5545#section-3.3.10` for the BYMONTH value type specification.
+            :rfc:`7529` for leap month support.
+        """
+        return int(self)
+
     def to_ical(self) -> bytes:
         """The ical representation."""
         return str(self).encode("utf-8")

--- a/src/icalendar/tests/prop/test_vMonth.py
+++ b/src/icalendar/tests/prop/test_vMonth.py
@@ -1,0 +1,61 @@
+"""Test vMonth ical_value property."""
+
+from icalendar.prop import vMonth
+
+
+def test_ical_value_basic():
+    """ical_value property returns int for month number."""
+    m = vMonth(5)
+    assert m.ical_value == 5
+    assert isinstance(m.ical_value, int)
+
+
+def test_ical_value_all_months():
+    """ical_value property works for all month numbers."""
+    for month_num in range(1, 13):
+        m = vMonth(month_num)
+        assert m.ical_value == month_num
+
+
+def test_ical_value_leap_month():
+    """ical_value property returns int for leap month (without L)."""
+    m = vMonth("5L")
+    assert m.ical_value == 5
+    assert m.leap is True
+    # ical_value returns just the number, not the L suffix
+
+
+def test_ical_value_from_string():
+    """ical_value property works with month created from string."""
+    m = vMonth("3")
+    assert m.ical_value == 3
+    assert m.leap is False
+
+
+def test_ical_value_from_ical():
+    """ical_value property works with month parsed from ical string."""
+    m = vMonth.from_ical("7")
+    assert m.ical_value == 7
+
+    m_leap = vMonth.from_ical("2L")
+    assert m_leap.ical_value == 2
+    assert m_leap.leap is True
+
+
+def test_ical_value_january():
+    """ical_value property returns 1 for January."""
+    m = vMonth(1)
+    assert m.ical_value == 1
+
+
+def test_ical_value_december():
+    """ical_value property returns 12 for December."""
+    m = vMonth(12)
+    assert m.ical_value == 12
+
+
+def test_ical_value_arithmetic():
+    """ical_value can be used in arithmetic operations."""
+    m = vMonth(6)
+    assert m.ical_value + 1 == 7
+    assert m.ical_value * 2 == 12


### PR DESCRIPTION
This PR adds the `ical_value` property to `vMonth`, contributing to Issue #876.

## Changes

- Added `ical_value` property to `vMonth` (src/icalendar/prop/recur/month.py)
  - Returns: `int` - The month number
  - Type hint: `int`
  - RFC reference: :rfc:`5545#section-3.3.10` and :rfc:`7529`
  - Includes comprehensive docstring with examples
  - Supports both regular months (1-12) and leap months (e.g., "5L")
  - The int value excludes the "L" suffix; use `.leap` property to check leap status

## Tests

- Created `test_vMonth.py` with 8 comprehensive test cases:
  - `test_ical_value_basic` - Tests basic month number
  - `test_ical_value_all_months` - Tests all 12 months
  - `test_ical_value_leap_month` - Tests leap month (RFC 7529)
  - `test_ical_value_from_string` - Tests string input
  - `test_ical_value_from_ical` - Tests parsed ical strings
  - `test_ical_value_january` - Tests January (1)
  - `test_ical_value_december` - Tests December (12)
  - `test_ical_value_arithmetic` - Tests arithmetic operations
- All tests pass: 8 passed

## Quality Checks

- [x] Add type hint
- [x] Add docstring with RFC reference
- [x] Add tests for all code paths
- [x] Pass ruff format check
- [x] Pass ruff lint check
- [x] All tests pass

Relates to #876