### PR TITLE
Add ical_value property to vRecur

### DIFF
--- a/src/icalendar/prop/recur/recur.py
+++ b/src/icalendar/prop/recur/recur.py
@@ -172,6 +172,32 @@ class vRecur(CaselessDict):
         super().__init__(*args, **kwargs)
         self.params = Parameters(params)
 
+    @property
+    def ical_value(self) -> dict[str, list[Any]]:
+        """Return the Python dict value.
+
+        This property provides access to the underlying recurrence rule as a dictionary.
+        Each key represents a recurrence rule part (FREQ, COUNT, INTERVAL, etc.) and
+        each value is a list of the corresponding values.
+
+        Returns:
+            dict[str, list[Any]]: The recurrence rule dictionary with rule parts as keys
+                and lists of values.
+
+        Example:
+            >>> from icalendar.prop import vRecur
+            >>> rrule = vRecur.from_ical('FREQ=DAILY;COUNT=10')
+            >>> rrule.ical_value
+            {'FREQ': ['DAILY'], 'COUNT': [10]}
+            >>> rrule2 = vRecur.from_ical('FREQ=WEEKLY;BYDAY=MO,WE,FR')
+            >>> rrule2.ical_value
+            {'FREQ': ['WEEKLY'], 'BYDAY': ['MO', 'WE', 'FR']}
+
+        See Also:
+            :rfc:`5545#section-3.3.10` for the RECUR value type specification.
+        """
+        return dict(self)
+
     def to_ical(self):
         result = []
         for key, vals in self.sorted_items():

--- a/src/icalendar/tests/prop/test_vRecur.py
+++ b/src/icalendar/tests/prop/test_vRecur.py
@@ -1,0 +1,72 @@
+"""Test vRecur ical_value property."""
+
+from icalendar.prop import vRecur
+
+
+def test_ical_value_basic():
+    """ical_value property returns dict for recurrence rule."""
+    rrule = vRecur.from_ical("FREQ=DAILY;COUNT=10")
+    value = rrule.ical_value
+    assert isinstance(value, dict)
+    assert "FREQ" in value
+    assert "COUNT" in value
+
+
+def test_ical_value_daily_count():
+    """ical_value property returns correct dict for DAILY with COUNT."""
+    rrule = vRecur.from_ical("FREQ=DAILY;COUNT=10")
+    value = rrule.ical_value
+    assert value["FREQ"] == ["DAILY"]
+    assert value["COUNT"] == [10]
+
+
+def test_ical_value_weekly_byday():
+    """ical_value property returns correct dict for WEEKLY with BYDAY."""
+    rrule = vRecur.from_ical("FREQ=WEEKLY;BYDAY=MO,WE,FR")
+    value = rrule.ical_value
+    assert value["FREQ"] == ["WEEKLY"]
+    assert "BYDAY" in value
+    assert len(value["BYDAY"]) == 3
+
+
+def test_ical_value_monthly_interval():
+    """ical_value property returns correct dict for MONTHLY with INTERVAL."""
+    rrule = vRecur.from_ical("FREQ=MONTHLY;INTERVAL=2")
+    value = rrule.ical_value
+    assert value["FREQ"] == ["MONTHLY"]
+    assert value["INTERVAL"] == [2]
+
+
+def test_ical_value_yearly_bymonth():
+    """ical_value property returns correct dict for YEARLY with BYMONTH."""
+    rrule = vRecur.from_ical("FREQ=YEARLY;BYMONTH=1,7")
+    value = rrule.ical_value
+    assert value["FREQ"] == ["YEARLY"]
+    assert "BYMONTH" in value
+    assert len(value["BYMONTH"]) == 2
+
+
+def test_ical_value_complex_rule():
+    """ical_value property returns correct dict for complex rule."""
+    rrule = vRecur.from_ical("FREQ=MONTHLY;BYDAY=MO;BYSETPOS=-1;COUNT=12")
+    value = rrule.ical_value
+    assert value["FREQ"] == ["MONTHLY"]
+    assert "BYDAY" in value
+    assert "BYSETPOS" in value
+    assert value["COUNT"] == [12]
+
+
+def test_ical_value_from_constructor():
+    """ical_value property works with vRecur created from constructor."""
+    rrule = vRecur(FREQ="DAILY", COUNT=5)
+    value = rrule.ical_value
+    assert value["FREQ"] == ["DAILY"]
+    assert value["COUNT"] == [5]
+
+
+def test_ical_value_wkst():
+    """ical_value property returns correct dict with WKST."""
+    rrule = vRecur.from_ical("FREQ=WEEKLY;WKST=MO")
+    value = rrule.ical_value
+    assert value["FREQ"] == ["WEEKLY"]
+    assert "WKST" in value


### PR DESCRIPTION
This PR adds the `ical_value` property to `vRecur`, contributing to Issue #876.

## Changes

- Added `ical_value` property to `vRecur` (src/icalendar/prop/recur/recur.py)
  - Returns: `dict[str, list[Any]]` - The recurrence rule dictionary
  - Type hint: `dict[str, list[Any]]`
  - RFC reference: :rfc:`5545#section-3.3.10`
  - Includes comprehensive docstring with examples
  - Each key represents a rule part (FREQ, COUNT, INTERVAL, BYDAY, etc.)
  - Each value is a list of the corresponding values

## Tests

- Created `test_vRecur.py` with 8 comprehensive test cases:
  - `test_ical_value_basic` - Tests basic structure
  - `test_ical_value_daily_count` - Tests DAILY with COUNT
  - `test_ical_value_weekly_byday` - Tests WEEKLY with BYDAY
  - `test_ical_value_monthly_interval` - Tests MONTHLY with INTERVAL
  - `test_ical_value_yearly_bymonth` - Tests YEARLY with BYMONTH
  - `test_ical_value_complex_rule` - Tests complex multi-part rule
  - `test_ical_value_from_constructor` - Tests constructor-created vRecur
  - `test_ical_value_wkst` - Tests WKST parameter
- All tests pass: 8 passed

## Quality Checks

- [x] Add type hint
- [x] Add docstring with RFC reference
- [x] Add tests for all code paths
- [x] Pass ruff format check
- [x] Pass ruff lint check
- [x] All tests pass

Relates to #876