### PR TITLE
Bump PyPy from 3.10 to 3.11

### DIFF
--- a/.github/workflows/generate_matrix.py
+++ b/.github/workflows/generate_matrix.py
@@ -130,7 +130,7 @@ def generate_matrix(git_ref, review):
     matrix.insert(
         0,
         {
-            "python_version": "pypy3.10",
+            "python_version": "pypy3.11",
             "test_name": "pypy3",
             "skip": not run_all_jobs,
         },

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Change log
 Minor changes
 ~~~~~~~~~~~~~
 
-- ...
+- Bump PyPy from 3.10 to 3.11 for testing. :pr:`1383`
 
 Breaking changes
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
See https://github.com/collective/icalendar/actions/runs/25789456168/job/75750960663?pr=1359#step:5:231

Blocking merge of https://github.com/collective/icalendar/pull/1359.