### PR TITLE
docs(boolean): improve vBoolean docstring

### DIFF
--- a/news/1244.documentation
+++ b/news/1244.documentation
@@ -1,0 +1,1 @@
+Replaced the RFC quotation in the docstring for :class:`vBoolean <icalendar.prop.boolean.vBoolean>` with a Pythonic description, including parsing behavior, a conformance reference, and a working example. @tsai135

--- a/src/icalendar/prop/boolean.py
+++ b/src/icalendar/prop/boolean.py
@@ -9,42 +9,32 @@ from icalendar.parser import Parameters
 
 
 class vBoolean(int):
-    """Boolean
+    """An iCalendar boolean value.
 
-    Value Name:  BOOLEAN
+    Converts between iCalendar ``BOOLEAN`` value types and Python boolean values.
+    In iCalendar data, boolean values are represented as "TRUE" or "FALSE". Values
+    parsed from iCalendar text are case insensitive. ``True``, ``true``, and ``TRUE``
+    are all accepted when converting from iCalendar to Python.
 
-    Purpose:  This value type is used to identify properties that contain
-      either a "TRUE" or "FALSE" Boolean value.
+    Comforming with :rfc:`5545#section-3.3.2`, boolean values are represented in
+    iCalendar data as either ``TRUE`` or ``FALSE``.
 
-    Format Definition:  This value type is defined by the following
-      notation:
+    Example:
+        Parse and create iCalendar boolean values.
 
-    .. code-block:: text
+        .. code-block:: pycon
 
-        boolean    = "TRUE" / "FALSE"
+            >>> from icalendar.prop import vBoolean
+            >>> boolean = vBoolean.from_ical('TRUE')
+            >>> boolean
+            True
 
-    Description:  These values are case-insensitive text.  No additional
-      content value encoding is defined for this value type.
+            >>> boolean = vBoolean.from_ical('fAlse')
+            >>> boolean
+            False
 
-    Example:  The following is an example of a hypothetical property that
-      has a BOOLEAN value type:
-
-    .. code-block:: python
-
-        TRUE
-
-    .. code-block:: pycon
-
-        >>> from icalendar.prop import vBoolean
-        >>> boolean = vBoolean.from_ical('TRUE')
-        >>> boolean
-        True
-        >>> boolean = vBoolean.from_ical('FALSE')
-        >>> boolean
-        False
-        >>> boolean = vBoolean.from_ical('True')
-        >>> boolean
-        True
+            >>> vBoolean(True).to_ical()
+            b'TRUE'
     """
 
     default_value: ClassVar[str] = "BOOLEAN"

--- a/src/icalendar/prop/boolean.py
+++ b/src/icalendar/prop/boolean.py
@@ -16,7 +16,7 @@ class vBoolean(int):
     parsed from iCalendar text are case insensitive. ``True``, ``true``, and ``TRUE``
     are all accepted when converting from iCalendar to Python.
 
-    Comforming with :rfc:`5545#section-3.3.2`, boolean values are represented in
+    Conforming with :rfc:`5545#section-3.3.2`, boolean values are represented in
     iCalendar data as either ``TRUE`` or ``FALSE``.
 
     Example:


### PR DESCRIPTION
## Closes issue

- [x] Refs #1244

This PR addresses one of the unchecked items in the #1244 checklist: `vBoolean`. It does not close the umbrella issue.

## Description

The existing class docstring for `vBoolean` contains RFC-style documentation copied from RFC 5545, including sections such as “Value Name,” “Purpose,” “Format Definition,” and “Description.” The umbrella issue asks for these copied RFC sections to be rewritten as Pythonic docstrings.

This PR follows the pattern used in recent #1338 docstring PR:

- Lead with a summary of what `vBoolean` does in Python terms.
- Explain that `vBoolean` converts between Python boolean values and the iCalendar `BOOLEAN` value type.
- Note that iCalendar boolean values are represented as `TRUE` or `FALSE`, and that values parsed from iCalendar text are case-insensitive.
- Reference the RFC section via a `:rfc:` directive so Sphinx renders a linked reference instead of copying RFC text.
- End with a working `pycon` example showing parsing from iCalendar text and serializing back to iCalendar bytes.

The RFC text itself is no longer copied into the class docstring; the `:rfc:` link is used as the canonical reference.

The `CHANGES.rst` entry slots in next to the other `:issue:` 1244 entries under the 7.0.4 Documentation section.

## Checklist

- [x] I've added a change log entry to CHANGES.rst. 
- [x] I've added or updated tests if applicable. 
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests). 
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

The doctest suite (`uv run pytest src/icalendar/tests/test_with_doctest.py`) passes locally with the new example.

## Additional information

The other unchecked items under `vBoolean` in #1244 are intentionally left for separate PRs to keep this change reviewable.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1386.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->