### PR TITLE
docs: fix unqualified class references in enums.py

### DIFF
--- a/news/1158.documentation
+++ b/news/1158.documentation
@@ -1,0 +1,1 @@
+Fully qualify :class:`~icalendar.enums.FBTYPE` and :class:`~icalendar.enums.BUSYTYPE` cross-references in :class:`~icalendar.enums.FBTYPE` and :class:`~icalendar.enums.BUSYTYPE` docstrings so Sphinx can resolve the links correctly. @Godzilaa

--- a/src/icalendar/enums.py
+++ b/src/icalendar/enums.py
@@ -118,7 +118,7 @@ class FBTYPE(StrEnum):
         ``BUSY_UNAVAILABLE``,
         ``BUSY_TENTATIVE``
 
-    See also :class:`BUSYTYPE`.
+    See also :class:`~icalendar.enums.BUSYTYPE`.
 
     Purpose:
         To specify the free or busy time type.
@@ -415,12 +415,12 @@ class BUSYTYPE(StrEnum):
         ``BUSY_TENTATIVE``
 
     Description:
-        This property is used to specify the default busy time
-        type.  The values correspond to those used by the :class:`FBTYPE`
-        parameter used on a "FREEBUSY" property, with the exception that
-        the "FREE" value is not used in this property.  If not specified
-        on a component that allows this property, the default is "BUSY-
-        UNAVAILABLE".
+        This property is used to specify the default busy time type.
+        The values correspond to those used by the
+        :class:`~icalendar.enums.FBTYPE` parameter used on a "FREEBUSY"
+        property, with the exception that the "FREE" value is not used in
+        this property.  If not specified on a component that allows this
+        property, the default is "BUSY-UNAVAILABLE".
 
     Example:
         The following is an example of this property:


### PR DESCRIPTION
Fix unqualified `:class:`FBTYPE`` and `:class:`BUSYTYPE`` references
in `enums.py` docstrings by adding fully qualified paths so Sphinx
can resolve the links correctly.

Contributes to #1158

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1388.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->