### PR TITLE
docs: convert Component.add docstring to Google Style

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -108,7 +108,6 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
-- Convert docstring of :meth:`~icalendar.cal.component.Component.add` to Google style. :issue:`1072`
 - Convert docstring of :func:`~icalendar.param.string_parameter` to Google style. :issue:`1072`, :pr:`1316`
 - Run ``sphinx-build`` with ``-W`` to turn warnings into errors. :issue:`1306`
 - Added `sphinx-llms-txt <https://sphinx-llms-txt.readthedocs.io/en/stable/>`_ extension to generate :file:`llms.txt` and :file:`llms-full.txt` files for AI/LLM documentation consumption. :issue:`1302`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -108,6 +108,7 @@ Bug fixes
 Documentation
 ~~~~~~~~~~~~~
 
+- Convert docstring of :meth:`~icalendar.cal.component.Component.add` to Google style. :issue:`1072`
 - Convert docstring of :func:`~icalendar.param.string_parameter` to Google style. :issue:`1072`, :pr:`1316`
 - Run ``sphinx-build`` with ``-W`` to turn warnings into errors. :issue:`1306`
 - Added `sphinx-llms-txt <https://sphinx-llms-txt.readthedocs.io/en/stable/>`_ extension to generate :file:`llms.txt` and :file:`llms-full.txt` files for AI/LLM documentation consumption. :issue:`1302`

--- a/news/1072.documentation
+++ b/news/1072.documentation
@@ -1,0 +1,1 @@
+Converted docstring of :meth:`~icalendar.cal.component.Component.add` to Google style. @mvanhorn

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -286,25 +286,35 @@ class Component(CaselessDict):
         parameters: dict[str, str] | Parameters = None,
         encode: bool = True,
     ):
-        """Add a property.
+        """Add a property to this component.
 
-        :param name: Name of the property.
-        :type name: string
+        If the property already exists, the new value is appended so the
+        property carries a list of values rather than replacing the previous
+        one. When ``name`` is ``DTSTAMP``, ``CREATED``, or ``LAST-MODIFIED``
+        and ``value`` is a ``datetime``, the value is converted to UTC as the
+        RFC requires.
 
-        :param value: Value of the property. Either of a basic Python type of
-                      any of the icalendar's own property types.
-        :type value: Python native type or icalendar property type.
+        Parameters:
+            name: Name of the property.
+            value:
+                Value of the property. Either a basic Python type or any of
+                icalendar's own property types.
+            parameters:
+                Property parameter dictionary for the value. Only consulted
+                when ``encode`` is ``True``.
+            encode:
+                ``True`` if the value should be encoded to one of icalendar's
+                own property types (fallback is ``vText``); ``False`` to
+                store the value as-is.
 
-        :param parameters: Property parameter dictionary for the value. Only
-                           available, if encode is set to True.
-        :type parameters: Dictionary
+        Example:
 
-        :param encode: True, if the value should be encoded to one of
-                       icalendar's own property types (Fallback is "vText")
-                       or False, if not.
-        :type encode: Boolean
+            >>> from icalendar import Event
+            >>> event = Event()
+            >>> event.add("summary", "Team sync")
+            >>> event["summary"]
+            vText(b'Team sync')
 
-        :returns: None
         """
         if isinstance(value, datetime) and name.lower() in (
             "dtstamp",

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -285,7 +285,7 @@ class Component(CaselessDict):
         value,
         parameters: dict[str, str] | Parameters = None,
         encode: bool = True,
-    ):
+    ) -> None:
         """Add a property to this component.
 
         If the property already exists, the new value is appended so the
@@ -306,6 +306,9 @@ class Component(CaselessDict):
                 ``True`` if the value should be encoded to one of icalendar's
                 own property types (fallback is ``vText``); ``False`` to
                 store the value as-is.
+
+        Returns:
+            ``None``
 
         Example:
 


### PR DESCRIPTION
## Summary

Contributes to #1072.

Converts the `Component.add` docstring in `src/icalendar/cal/component.py` from reStructuredText `:param:` / `:returns:` syntax to Google Style with `Parameters:`, `Returns` (omitted, returns nothing), and an `Example:` block. Follows the pattern set by #1316 (`string_parameter`) and #1309 (`caselessdict`).

The Example block adds a runnable doctest that verifies `Component.add` correctly stores the value as a `vText` (`Team sync` → `vText(b'Team sync')`).

Also adds a CHANGES.rst entry under the Documentation section.

## Why these changes

The original docstring used `:param name: ... :type name: string :returns: None`. The project's style guide now expects Google Style headings and inline type information. This PR is one more step toward the consistent format described in #1072.

## Verification

- `python3 -m doctest src/icalendar/cal/component.py` (run from `src/`): the new `Component.add` example block passes. (Three unrelated pre-existing failures in `links`, `to_jcal`, and `uid` are about hardcoded UIDs/timestamps and are not touched by this PR.)
- No code behavior change — docstring only.

## Documentation preview

The Read the Docs preview will be linked by the bot after this PR is opened. The function shows up at `icalendar.cal.component.Component.add`.


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1390.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->