### PR TITLE
Update maintenance docs and fix version switcher for "stable"

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -35,4 +35,5 @@ build:
       then
         exit 183;
       fi
+    - git fetch --tags || true
     - make rtd-pr-preview

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -337,14 +337,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         git commit -m "Show version warning banner for previous major version 6.x on Read the Docs"
         git push  # to collective/icalendar
 
-#.  Configure `Read the Docs <https://app.readthedocs.org/projects/icalendar/>`_.
-
-    a.  Verify that the "stable" version was activated automatically on Read the Docs.
-
-    #.  Deactivate previous releases in that current stable release line.
-        Click on the ellipsis icon, and select :guilabel:`Configure version`.
-        Toggle the :guilabel:`Active` switch to deactivate the version.
-
+#.  Verify that the "stable" version was activated automatically on `Read the Docs <https://app.readthedocs.org/projects/icalendar/>`_.
 
 #.  Add a comment to each of the issues mentioned in the new release.
     Example:

--- a/news/1352.documentation
+++ b/news/1352.documentation
@@ -1,0 +1,1 @@
+Update maintenance documentation. Fix the version switcher on "stable" on Read the Docs. @stevepiercy


### PR DESCRIPTION
## Closes issue

If this is successful, then close the related issue.

- See #1352

## Description

Update maintenance docs and fix version switcher for "stable".

## Checklist

- [x] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1393.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->