### PR TITLE
Revise pull request template for issue linking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Closes issue
+## Linked issue
 
 Replace `ISSUE_NUMBER` with the issue number that your pull request addresses. This links the pull request to the related issue. Choose the appropriate form.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,16 @@
 ## Closes issue
 
-Replace `ISSUE_NUMBER` with the issue number that your pull request fixes. Then GitHub will link and automatically close the related issue.
+Replace `ISSUE_NUMBER` with the issue number that your pull request addresses. This links the pull request to the related issue. Choose the appropriate form.
+
+If you completely resolve the issue, then use `"Closes"`.
+GitHub will automatically close the related issue when the PR gets merged.
 
 - [ ] Closes #ISSUE_NUMBER
+
+If you resolve only a part of the issue, then use `"See"`.
+This form keeps the issue open for future work. 
+
+- [ ] See #ISSUE_NUMBER
 
 ## Description
 

--- a/news/1394.internal
+++ b/news/1394.internal
@@ -1,0 +1,1 @@
+Support keeping a linked issue open in the pull request template when the pull request fixes only a part of the original issue. @stevepiercy


### PR DESCRIPTION
With many first-time contributors, we don't tell them that they should use `See`, instead of `Closes`, when linking an issue that should remain open because their PR fixes only one or a few items in the original issue. This change supports that option. Example https://github.com/collective/icalendar/pull/1369#issuecomment-4447341005.