### PR TITLE
Align workflow with .readthedocs.yaml

### DIFF
--- a/.github/workflows/rtd-pr-preview.yml
+++ b/.github/workflows/rtd-pr-preview.yml
@@ -9,7 +9,7 @@ on:
     # documentation files.
     paths:
       - "docs/**"
-      - "src/icalendar/*.py"
+      - "src/icalendar/**/*.py"
       - .github/workflows/documentation.yml
       - .github/workflows/rtd-pr-preview.yml
       - .readthedocs.yaml

--- a/.github/workflows/rtd-pr-preview.yml
+++ b/.github/workflows/rtd-pr-preview.yml
@@ -12,7 +12,7 @@ on:
       - "src/icalendar/**/*.py"
       - .github/workflows/documentation.yml
       - .github/workflows/rtd-pr-preview.yml
-      - .readthedocs.yaml
+      - .readthedocs.yml
       - .vale.ini
       - CHANGES.rst
       - Makefile

--- a/.github/workflows/rtd-pr-preview.yml
+++ b/.github/workflows/rtd-pr-preview.yml
@@ -1,4 +1,5 @@
 # .github/workflows/rtd-pr-preview.yml
+# Usage: https://github.com/readthedocs/actions/blob/v1/preview/README.md
 name: readthedocs/actions
 on:
   pull_request_target:
@@ -8,10 +9,17 @@ on:
     # documentation files.
     paths:
       - "docs/**"
-      - "*.rst"
       - "src/icalendar/*.py"
+      - .github/workflows/documentation.yml
+      - .github/workflows/rtd-pr-preview.yml
       - .readthedocs.yaml
-      - requirements_docs.txt
+      - .vale.ini
+      - CHANGES.rst
+      - Makefile
+      - pyproject.toml
+      - "!src/icalendar/fuzzing"
+      - "!src/icalendar/tests"
+      - "!src/icalendar/timezone"
 
 permissions:
   pull-requests: write
@@ -23,4 +31,3 @@ jobs:
       - uses: readthedocs/actions/preview@v1
         with:
           project-slug: "icalendar"
-          single-version: "true"

--- a/.github/workflows/rtd-pr-preview.yml
+++ b/.github/workflows/rtd-pr-preview.yml
@@ -17,9 +17,9 @@ on:
       - CHANGES.rst
       - Makefile
       - pyproject.toml
-      - "!src/icalendar/fuzzing"
-      - "!src/icalendar/tests"
-      - "!src/icalendar/timezone"
+      - "!src/icalendar/fuzzing/**"
+      - "!src/icalendar/tests/**"
+      - "!src/icalendar/timezone/**"
 
 permissions:
   pull-requests: write

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,7 +24,7 @@ build:
         src/icalendar/**/*.py \
         .github/workflows/documentation.yml
         .github/workflows/rtd-pr-preview.yml
-        .readthedocs.yaml \
+        .readthedocs.yml \
         .vale.ini \
         CHANGES.rst \
         Makefile \

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,8 +22,8 @@ build:
     - |
       if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- . docs/ \
         src/icalendar/**/*.py \
-        .github/workflows/documentation.yml
-        .github/workflows/rtd-pr-preview.yml
+        .github/workflows/documentation.yml \
+        .github/workflows/rtd-pr-preview.yml \
         .readthedocs.yml \
         .vale.ini \
         CHANGES.rst \

--- a/news/1396.internal
+++ b/news/1396.internal
@@ -1,0 +1,1 @@
+Trigger the creation of a comment with links to Read the Docs of the changed files to review in a pull request preview build. @stevepiercy


### PR DESCRIPTION
- This workflow creates a link as a comment in the pull request. Sometimes it fired when it shouldn't have, or didn't fire when it should.

## Checklist

- [x] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.
