### PR TITLE
Fix RTD admin instructions in maintenance documentation

### DIFF
--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -338,6 +338,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         git push  # to collective/icalendar
 
 #.  Manually trigger the "latest" version on `Read the Docs <https://app.readthedocs.org/projects/icalendar/>`_.
+    To the right in the row for "latest", click the ellipsis :guilabel:`…`, and from the pop-up menu select :guilabel:`Rebuild version`.
 
 #.  Add a comment to each of the issues mentioned in the new release.
     Example:

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -338,7 +338,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         git push  # to collective/icalendar
 
 #.  Manually trigger the "latest" version on `Read the Docs <https://app.readthedocs.org/projects/icalendar/>`_.
-    To the right in the row for "latest", click the ellipsis :guilabel:`…`, and from the pop-up menu select :guilabel:`Rebuild version`.
+    To the right in the row for "latest," click the ellipsis :guilabel:`…`, and from the pop-up menu select :guilabel:`Rebuild version`.
 
 #.  Add a comment to each of the issues mentioned in the new release.
     Example:

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -337,7 +337,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
         git commit -m "Show version warning banner for previous major version 6.x on Read the Docs"
         git push  # to collective/icalendar
 
-#.  Verify that the "stable" version was activated automatically on `Read the Docs <https://app.readthedocs.org/projects/icalendar/>`_.
+#.  Manually trigger the "latest" version on `Read the Docs <https://app.readthedocs.org/projects/icalendar/>`_.
 
 #.  Add a comment to each of the issues mentioned in the new release.
     Example:

--- a/news/1397.documentation
+++ b/news/1397.documentation
@@ -1,0 +1,1 @@
+Fix Read the Docs administrative instructions in maintenance documentation by removing the obsolete step to check the default branch and adding a step to manually trigger the "latest" version. @stevepiercy


### PR DESCRIPTION
- Remove the step to ensure that "stable" is the default branch, because the automation rule no longer sets the new tag as default. It hides the tagged version now.
- Add a step to manually trigger the "latest" version on RTD. This will publish the update to the `version-switcher.json` file on `main`.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1397.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->