### PR TITLE
Fix broken links in `icalendar.cal.calendar.Calendar` documentation

### DIFF
--- a/news/1158.documentation
+++ b/news/1158.documentation
@@ -1,0 +1,1 @@
+Fixed broken links and removed `:py` prefix in :class:`icalendar.cal.calendar.Calendar` documentation. @lcampanella98

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -101,7 +101,7 @@ class Calendar(Component):
 
         This is a shortcut to get all events.
         Modifications do not change the calendar.
-        Use :py:meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
+        Use :meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
 
         >>> from icalendar import Calendar
         >>> calendar = Calendar.example()
@@ -119,7 +119,7 @@ class Calendar(Component):
 
         This is a shortcut to get all todos.
         Modifications do not change the calendar.
-        Use :py:meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
+        Use :meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
         """
         return self.walk("VTODO")
 
@@ -129,7 +129,7 @@ class Calendar(Component):
 
         This is a shortcut to get all journals.
         Modifications do not change the calendar.
-        Use :py:meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
+        Use :meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
         """
         return self.walk("VJOURNAL")
 
@@ -139,7 +139,7 @@ class Calendar(Component):
 
         This is a shortcut to get all availabilities.
         Modifications do not change the calendar.
-        Use :py:meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
+        Use :meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
         """
         return self.walk("VAVAILABILITY")
 
@@ -149,7 +149,7 @@ class Calendar(Component):
 
         This is a shortcut to get all FreeBusy.
         Modifications do not change the calendar.
-        Use :py:meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
+        Use :meth:`Component.add_component <icalendar.cal.component.Component.add_component>`.
         """
         return self.walk("VFREEBUSY")
 
@@ -537,19 +537,19 @@ Description:
             calscale: The :attr:`calscale` of the calendar.
             categories: The :attr:`categories` of the calendar.
             color: The :attr:`color` of the calendar.
-            concepts: The :attr:`~icalendar.Component.concepts` of the calendar.
+            concepts: The :attr:`~icalendar.cal.component.Component.concepts` of the calendar.
             description: The :attr:`description` of the calendar.
             language: The language for the calendar. Used to generate localized `prodid`.
-            last_modified: The :attr:`~icalendar.Component.last_modified` of the calendar.
-            links: The :attr:`~icalendar.Component.links` of the calendar.
+            last_modified: The :attr:`~icalendar.cal.component.Component.last_modified` of the calendar.
+            links: The :attr:`~icalendar.cal.component.Component.links` of the calendar.
             method: The :attr:`method` of the calendar.
             name: The :attr:`calendar_name` of the calendar.
             organization: The organization name. Used to generate `prodid` if not provided.
             prodid: The :attr:`prodid` of the component. If None and organization is provided,
                 generates a `prodid` in format "-//organization//name//language".
             refresh_interval: The :attr:`refresh_interval` of the calendar.
-            refids: :attr:`~icalendar.Component.refids` of the calendar.
-            related_to: :attr:`~icalendar.Component.related_to` of the calendar.
+            refids: :attr:`~icalendar.cal.component.Component.refids` of the calendar.
+            related_to: :attr:`~icalendar.cal.component.Component.related_to` of the calendar.
             source: The :attr:`source` of the calendar.
             subcomponents: The subcomponents of the calendar.
             uid: The :attr:`uid` of the calendar.


### PR DESCRIPTION
## Part of issue

- [x] Part of #1158 

## Description

Fully checked the documentation of [icalendar.cal.calendar module](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.calendar.html#) and found a few broken links. 

Specifically there are several broken links in [icalendar.cal.calendar.Calendar.new](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.calendar.html#icalendar.cal.calendar.Calendar.new)

Also removed unnecessary `:py` sphinx prefix in the same file. 

Verified the broken links are fixed and `:py` links are unaffected using `make livehtml`

## Checklist

- [x] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I've added or updated tests if applicable. (N/A documentation only)
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

https://icalendar--1398.org.readthedocs.build/en/1398/reference/api/icalendar.cal.calendar.html