### PR TITLE
fix: add type hints for encoding parameter in parser_tools

### DIFF
--- a/news/938.documentation
+++ b/news/938.documentation
@@ -1,1 +1,1 @@
-Added type hint for encoding parameter in :func:`~icalendar.parser_tools.data_encode`. @cybs-joe
+Added type hint for ``encoding`` parameter in :func:`~icalendar.parser_tools.data_encode`. @cybs-joe

--- a/news/938.documentation
+++ b/news/938.documentation
@@ -1,0 +1,1 @@
+Added type hint for encoding parameter in :func:`~icalendar.parser_tools.data_encode`. @cybs-joe

--- a/src/icalendar/parser_tools.py
+++ b/src/icalendar/parser_tools.py
@@ -3,7 +3,7 @@ DEFAULT_ENCODING = "utf-8"
 ICAL_TYPE = str | bytes
 
 
-def from_unicode(value: ICAL_TYPE, encoding="utf-8") -> bytes:
+def from_unicode(value: ICAL_TYPE, encoding: str = "utf-8") -> bytes:
     """Converts a value to bytes, even if it is already bytes.
 
     Parameters:
@@ -24,7 +24,7 @@ def from_unicode(value: ICAL_TYPE, encoding="utf-8") -> bytes:
         return value
 
 
-def to_unicode(value: ICAL_TYPE, encoding="utf-8-sig") -> str:
+def to_unicode(value: ICAL_TYPE, encoding: str = "utf-8-sig") -> str:
     """Converts a value to Unicode, even if it is already a Unicode string.
 
     Parameters:

--- a/src/icalendar/parser_tools.py
+++ b/src/icalendar/parser_tools.py
@@ -43,7 +43,7 @@ def to_unicode(value: ICAL_TYPE, encoding="utf-8-sig") -> str:
 
 
 def data_encode(
-    data: ICAL_TYPE | dict | list, encoding=DEFAULT_ENCODING
+    data: ICAL_TYPE | dict | list, encoding: str = DEFAULT_ENCODING
 ) -> bytes | list[bytes] | dict:
     """Encode all datastructures to the given encoding.
 


### PR DESCRIPTION
Added 'str' type hint to the encoding parameter in from_unicode, to_unicode, and data_encode functions.

Used Claude (claude-sonnet-4-6) to identify untyped parameters and suggest the fix. Reviewed and validated all changes manually.

## Refs issue 938
- [x] Refs #938 

## Description

Added `str` type hint to the `encoding` parameter in `from_unicode`, 
`to_unicode`, and `data_encode` in `src/icalendar/parser_tools.py`.

## Checklist

- [x] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [ ] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

Upload screenshots, videos, links to documentation, or any other relevant information.


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1399.org.readthedocs.build/

<!-- readthedocs-preview icalendar end -->