### PR TITLE
Fix broken link and remove `:py` prefix in unescape_backslash docstring

### DIFF
--- a/news/1158.documentation.1
+++ b/news/1158.documentation.1
@@ -1,0 +1,1 @@
+Fixed broken link and removed `:py` prefix in the :func:`~icalendar.parser.unescape_backslash` docstring. @vincere-mori

--- a/src/icalendar/parser/property.py
+++ b/src/icalendar/parser/property.py
@@ -28,7 +28,7 @@ _unescape_backslash_regex = re.compile(r"\\([\\,;:nN])")
 def unescape_backslash(val: str):
     r"""Unescape backslash sequences in iCalendar text.
 
-    Unlike :py:meth:`unescape_string`, this only handles actual backslash escapes
+    Unlike :func:`~icalendar.parser.string.unescape_string`, this only handles actual backslash escapes
     per :rfc:`5545`, not URL encoding. This preserves URL-encoded values
     like ``%3A`` in URLs.
 

--- a/src/icalendar/parser/property.py
+++ b/src/icalendar/parser/property.py
@@ -28,9 +28,9 @@ _unescape_backslash_regex = re.compile(r"\\([\\,;:nN])")
 def unescape_backslash(val: str):
     r"""Unescape backslash sequences in iCalendar text.
 
-    Unlike :func:`~icalendar.parser.string.unescape_string`, this only handles actual backslash escapes
-    per :rfc:`5545`, not URL encoding. This preserves URL-encoded values
-    like ``%3A`` in URLs.
+    Unlike :func:`~icalendar.parser.string.unescape_string`, this only handles
+    actual backslash escapes per :rfc:`5545`, not URL encoding. This preserves
+    URL-encoded values like ``%3A`` in URLs.
 
     Processes backslash escape sequences in a single pass using regex matching.
     """


### PR DESCRIPTION
## Part of issue

- [x] Part of #1158 

## Description

The docstring of `icalendar.parser.unescape_backslash` referenced `unescape_string` using `:py:meth:` with an unqualified target, which resulted in a broken cross-reference (also, `unescape_string` is a function, not a method).

This PR follows the established pattern from #1313 and #1398:

- Removes the `:py` prefix per the [style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html#cross-reference-python-objects)
- Switches `:py:meth:` to `:func:` since `unescape_string` is a module-level function
- Adds the fully qualified dotted path so the link resolves

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1403.org.readthedocs.build/en/1403/

<!-- readthedocs-preview icalendar end -->