### PR TITLE
test: cover deprecate_for_version_8

### DIFF
--- a/news/1407.feature
+++ b/news/1407.feature
@@ -1,0 +1,1 @@
+Added test coverage for :func:`icalendar.compatibility.deprecate_for_version_8`. AI disclosure: I used GPT-5 Codex to help draft and refine the test and pull request text. I reviewed the output and validated the change locally. @iccccccccccccc

--- a/src/icalendar/tests/test_compatibility.py
+++ b/src/icalendar/tests/test_compatibility.py
@@ -1,0 +1,22 @@
+"""Tests for compatibility helpers."""
+
+import pytest
+
+from icalendar.compatibility import deprecate_for_version_8
+
+
+def test_deprecate_for_version_8_warns_and_delegates() -> None:
+    """The wrapper should warn while preserving the wrapped behavior."""
+
+    def _join_parts(left: str, right: str = "") -> str:
+        return f"{left}-{right}"
+
+    deprecated = deprecate_for_version_8(_join_parts)
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="join_parts is deprecated and will be removed in icalendar 8",
+    ):
+        assert deprecated("left", right="right") == "left-right"
+
+    assert deprecated.__name__ == "join_parts"


### PR DESCRIPTION
Fixes #1407.

This adds a small focused test for `deprecate_for_version_8`. It checks that the wrapper emits the version-8 deprecation warning, still passes args/kwargs through to the wrapped function, and exposes the public name after stripping the private underscore.

I also added the internal news fragment for the test-only change.

Checks:
- `python -m pytest src/icalendar/tests/test_compatibility.py`
- `python -m pytest src/icalendar/tests/test_compatibility.py src/icalendar/tests/test_issue_1073_pyodide_import.py`
- `python -m ruff check src/icalendar/tests/test_compatibility.py`
- `python -m ruff format --check src/icalendar/tests/test_compatibility.py`