### PR TITLE
Add vFrequency.ical_value for the Component.decoded() polymorphy

### DIFF
--- a/news/876.feature
+++ b/news/876.feature
@@ -1,0 +1,1 @@
+Created a :attr:`~icalendar.prop.recur.frequency.vFrequency.ical_value` property for the :class:`~icalendar.prop.recur.frequency.vFrequency` component, mirroring the existing pattern on :class:`~icalendar.prop.recur.weekday.vWeekday`. @mvanhorn

--- a/news/876.feature
+++ b/news/876.feature
@@ -1,1 +1,1 @@
-Created a :attr:`~icalendar.prop.recur.frequency.vFrequency.ical_value` property for the :class:`~icalendar.prop.recur.frequency.vFrequency` component, mirroring the existing pattern on :class:`~icalendar.prop.recur.weekday.vWeekday`. @mvanhorn
+Created an :attr:`~icalendar.prop.recur.frequency.vFrequency.ical_value` property for the :class:`~icalendar.prop.recur.frequency.vFrequency` component, mirroring the existing pattern on :class:`~icalendar.prop.recur.weekday.vWeekday`. @mvanhorn

--- a/src/icalendar/prop/recur/frequency.py
+++ b/src/icalendar/prop/recur/frequency.py
@@ -66,5 +66,15 @@ class vFrequency(str):
                 "The value must be a valid frequency.", cls, value=value
             ) from e
 
+    @property
+    def ical_value(self) -> str:
+        """Returns the frequency value as a string, for example, ``WEEKLY`` or ``DAILY``.
+
+        See Also:
+
+            :rfc:`5545#section-3.3.10` for the ``FREQ`` rule grammar.
+        """
+        return str(self)
+
 
 __all__ = ["vFrequency"]

--- a/src/icalendar/tests/prop/test_vFrequency.py
+++ b/src/icalendar/tests/prop/test_vFrequency.py
@@ -1,0 +1,40 @@
+import pytest
+
+from icalendar.prop import vFrequency
+
+
+def test_valid_frequencies():
+    """vFrequency accepts every RFC 5545 frequency value."""
+    for freq in (
+        "SECONDLY",
+        "MINUTELY",
+        "HOURLY",
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY",
+        "YEARLY",
+    ):
+        assert vFrequency(freq).to_ical() == freq.encode("utf-8")
+
+
+def test_case_insensitive():
+    """vFrequency accepts lowercase input and uppercases it on serialization."""
+    assert vFrequency.from_ical("weekly").to_ical() == b"WEEKLY"
+
+
+def test_roundtrip():
+    assert vFrequency.from_ical(vFrequency("DAILY").to_ical()) == "DAILY"
+
+
+def test_error():
+    """Error: Expected frequency, got: BOGUS"""
+    with pytest.raises(ValueError):
+        vFrequency.from_ical("BOGUS")
+
+
+def test_ical_value():
+    """ical_value property returns the frequency string value."""
+    assert vFrequency("WEEKLY").ical_value == "WEEKLY"
+    assert vFrequency("DAILY").ical_value == "DAILY"
+    assert vFrequency("YEARLY").ical_value == "YEARLY"
+    assert isinstance(vFrequency("WEEKLY").ical_value, str)


### PR DESCRIPTION
## Linked issue

- [x] See #876

(See, not Closes, because #876 is the meta-issue tracking `ical_value` across every value type.)

## Description

Adds the `ical_value` property to `vFrequency`, mirroring the same one-line pattern recently merged for `vWeekday` (#1360) and `vPeriod` (#1359). With this, `Component.decoded()` can read every frequency value uniformly via `getattr(value, "ical_value", fallback)` once the meta-issue's transition lands.

The body of the property just returns `str(self)`, matching `vWeekday.ical_value`: `vFrequency` is already a `str` subclass that the constructor validates against the seven RFC 5545 frequency tokens, so `str(self)` is the same value that `to_ical()` would emit minus the bytes wrapper.

## Checklist

- [x] I've added a change log entry to `/news/876.feature`.
- [x] I've added tests in `src/icalendar/tests/prop/test_vFrequency.py` covering valid frequencies, case-insensitive parsing, roundtrip, error, and the new `ical_value` property.
- [x] I've run all tests locally: `pytest src/icalendar/tests/prop/` -- 798 passed, 1 skipped.
- [x] Docstring on the new property cites :rfc:`5545#section-3.3.10` for the `FREQ` rule grammar.

## Additional information

Diff stat: `+51 / -0` across three files (one property, one test file, one news fragment).

Followup work in #876 is independent per-type, so this PR doesn't change `Component.decoded()` or remove the existing if/else dispatch -- consistent with how vWeekday/vPeriod shipped.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1409.org.readthedocs.build/en/1409/

<!-- readthedocs-preview icalendar end -->