### PR TITLE
Added instructions to Contribute for how to avoid a filename conflict…

### DIFF
--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -163,6 +163,13 @@ The change log entry's format must be ``#.type``, where ``#`` is the referenced 
 ``chore``
     For routine tasks that shouldn't be published, but will satisfy the checker for the presence of a change log entry.
 
+To avoid a conflict with another pull request for the same issue number, append an integer to the filename.
+Don't edit a change log entry from another pull request.
+
+..  code-block:: text
+
+    1158.documentation.1
+
 For orphan change log entries—that is, those that don't need to be linked to any issue ID or other identifier—start the file name with ``+``.
 The content will still be included in the change log, at the end of the category corresponding to the file extension.
 

--- a/news/+contribute-filename-conflict.documentation
+++ b/news/+contribute-filename-conflict.documentation
@@ -1,0 +1,1 @@
+Added instructions to :ref:`change-log` in Contribute documentation for how to avoid a filename conflict when adding a change log entry. @stevepiercy


### PR DESCRIPTION
… when adding a change log entry

- See https://github.com/collective/icalendar/pull/1369#discussion_r3294330498


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1410.org.readthedocs.build/en/1410/

<!-- readthedocs-preview icalendar end -->