### PR TITLE
docs: switch usage.rst to .. code-block:: pycon

### DIFF
--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -238,7 +238,7 @@ Read calendar from file
 
 Read a calendar from a local :file:`.ics` file and view its events.
 
-.. code:: pycon
+.. code-block:: pycon
 
     >>> import icalendar
     >>> from pathlib import Path
@@ -269,7 +269,7 @@ Modify content
 
 After loading the example file, edit and save it.
 
-.. code:: pycon
+.. code-block:: pycon
 
     >>> calendar.calendar_name = "My Modified Calendar"  # modify
     >>> print(calendar.to_ical()[:121])  # save modification
@@ -296,7 +296,7 @@ Events
 
 Show events.
 
-.. code:: pycon
+.. code-block:: pycon
 
     >>> icalendar.Event()
     VEVENT({})
@@ -307,7 +307,7 @@ Free/busy times
 
 Show free/busy times.
 
-.. code:: pycon
+.. code-block:: pycon
 
     >>> icalendar.FreeBusy()
     VFREEBUSY({})
@@ -318,7 +318,7 @@ To-do items
 
 Show to-do items.
 
-.. code:: pycon
+.. code-block:: pycon
 
     >>> icalendar.Todo()
     VTODO({})
@@ -330,7 +330,7 @@ Alarms
 
 Show alarms.
 
-.. code:: pycon
+.. code-block:: pycon
 
     >>> icalendar.Alarm()
     VALARM({})
@@ -341,7 +341,7 @@ Journal entries
 
 Show journal entries.
 
-.. code:: pycon
+.. code-block:: pycon
 
     >>> icalendar.Journal()
     VJOURNAL({})
@@ -355,7 +355,7 @@ You can localize your events to take place in different timezones.
 icalendar supports multiple timezone implementations, including :mod:`zoneinfo`, `dateutil.tz <https://dateutil.readthedocs.io/en/latest/tz.html>`_, and `pytz <https://pypi.org/project/pytz/>`_.
 To demonstrate icalendar's flexibility, the following example creates an event that uses all of the timezone implementations with the same result.
 
-.. code:: pycon
+.. code-block:: pycon
 
     >>> import pytz, zoneinfo, dateutil.tz  # timezone libraries
     >>> import datetime, icalendar
@@ -385,7 +385,7 @@ The functionality is extended and tested since 6.0.0 with both timezone implemen
 
 Since 6.0.0 by default, :mod:`zoneinfo` timezones are created.
 
-.. code:: pycon
+.. code-block:: pycon
 
     >>> dt = icalendar.Calendar.example("timezoned").events[0].start
     >>> dt.tzinfo
@@ -393,7 +393,7 @@ Since 6.0.0 by default, :mod:`zoneinfo` timezones are created.
 
 To continue to receive ``pytz`` timezones in parsed results, you can receive all the latest updates, and switch back to earlier behavior.
 
-.. code:: pycon
+.. code-block:: pycon
 
     >>> icalendar.use_pytz()
     >>> dt = icalendar.Calendar.example("timezoned").events[0].start

--- a/news/626.documentation
+++ b/news/626.documentation
@@ -1,0 +1,1 @@
+Switch :file:`docs/how-to/usage.rst` from the deprecated ``.. code:: pycon`` directive to ``.. code-block:: pycon`` for consistency with the rest of the documentation. @mvanhorn


### PR DESCRIPTION
Refs #626.

Switches the 10 remaining `.. code:: pycon` directives in `docs/how-to/usage.rst` to `.. code-block:: pycon`, matching the convention already used in the other 88 pycon blocks across the docs.

This is one of the items the issue lists ("Change all instances of `.. code:: pycon` to `.. code-block:: pycon`"). The maintainer asked for separate PRs per item, so the remaining checklist items are out of scope here.

### Doctest impact

`docs/how-to/usage.rst` is exercised by `tests/test_with_doctest.py::test_documentation_file`. The `>>>` prompts inside each block remain unchanged, so `doctest.testfile()` still picks them up (Python's `doctest` looks at the `>>>` prompts directly, independent of the surrounding Sphinx directive). CI will confirm.

### News

Added `news/626.documentation` per the towncrier convention in `pyproject.toml`.

AI was used for assistance.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1412.org.readthedocs.build/en/1412/

<!-- readthedocs-preview icalendar end -->