### PR TITLE
docs(free_busy): Fix broken documentation links in `icalendar.cal.free_busy`

### DIFF
--- a/news/1158.documentation.4
+++ b/news/1158.documentation.4
@@ -1,0 +1,1 @@
+Fixed broken links in :mod:`icalendar.cal.free_busy` documentation by using fully qualified :class:`icalendar.cal.component.Component` attribute targets. @tsai135

--- a/src/icalendar/cal/free_busy.py
+++ b/src/icalendar/cal/free_busy.py
@@ -111,15 +111,15 @@ class FreeBusy(Component):
         This creates a new Alarm in accordance with :rfc:`5545`.
 
         Parameters:
-            comments: The :attr:`~icalendar.Component.comments` of the component.
-            concepts: The :attr:`~icalendar.Component.concepts` of the component.
+            comments: The :attr:`~icalendar.cal.component.Component.comments` of the component.
+            concepts: The :attr:`~icalendar.cal.component.Component.concepts` of the component.
             contacts: The :attr:`contacts` of the component.
             end: The :attr:`end` of the component.
-            links: The :attr:`~icalendar.Component.links` of the component.
+            links: The :attr:`~icalendar.cal.component.Component.links` of the component.
             organizer: The :attr:`organizer` of the component.
-            refids: :attr:`~icalendar.Component.refids` of the component.
-            related_to: :attr:`~icalendar.Component.related_to` of the component.
-            stamp: The :attr:`DTSTAMP` of the component.
+            refids: :attr:`~icalendar.cal.component.Component.refids` of the component.
+            related_to: :attr:`~icalendar.cal.component.Component.related_to` of the component.
+            stamp: The :attr:`~icalendar.cal.component.Component.DTSTAMP` of the component.
                 If None, this is set to the current time.
             start: The :attr:`start` of the component.
             uid: The :attr:`uid` of the component.


### PR DESCRIPTION
## Linked issue

- [x] See #1158 

## Description

Checked the [icalendar.cal.free_busy module](https://icalendar.readthedocs.io/en/stable/reference/api/icalendar.cal.free_busy.html) and found broken links.

Verified the broken links are fixed using `make livehtml`

## Checklist

- [x] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

[https://icalendar--1414.org.readthedocs.build/en/1414/reference/api/icalendar.cal.free_busy.html](https://icalendar--1414.org.readthedocs.build/en/1414/reference/api/icalendar.cal.free_busy.html)

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1414.org.readthedocs.build/en/1414/

<!-- readthedocs-preview icalendar end -->