### PR TITLE
Add tests for FreeBusy duration property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Change log
 7.1.1 (unreleased)
 ------------------
 
+- Added tests for ``FreeBusy.duration`` coverage. (@kyriakikrimitza)
+
 Minor changes
 ~~~~~~~~~~~~~
 

--- a/news/698.internal
+++ b/news/698.internal
@@ -1,0 +1,1 @@
+Added tests for ``FreeBusy.duration`` coverage. @kyriakikrimitza

--- a/news/698.internal
+++ b/news/698.internal
@@ -1,1 +1,1 @@
-Added tests for ``FreeBusy.duration`` coverage. @kyriakikrimitza
+Added tests for :attr:`FreeBusy.duration <icalendar.cal.free_busy.FreeBusy.duration>` coverage. @kyriakikrimitza

--- a/src/icalendar/tests/test_free_busy_duration.py
+++ b/src/icalendar/tests/test_free_busy_duration.py
@@ -1,0 +1,20 @@
+from datetime import datetime, timedelta
+
+from icalendar import FreeBusy
+
+
+def test_freebusy_duration_without_start_or_end():
+    """Duration should be None if DTSTART or DTEND is missing."""
+    freebusy = FreeBusy.new()
+
+    assert freebusy.duration is None
+
+
+def test_freebusy_duration_with_start_and_end():
+    """Duration should be computed from DTSTART and DTEND."""
+    start = datetime(2026, 4, 1, 10, 0)
+    end = datetime(2026, 4, 1, 12, 30)
+
+    freebusy = FreeBusy.new(start=start, end=end)
+
+    assert freebusy.duration == timedelta(hours=2, minutes=30)


### PR DESCRIPTION
## Linked issue
* [ ] Closes #ISSUE_NUMBER
* [x] See #698

## Description
Adds tests for the `FreeBusy.duration` property to improve coverage for the `VFREEBUSY` component.

The tests cover:
* returning `None` when `DTSTART` or `DTEND` is missing
* correct duration calculation when both values are present

## Checklist
* [ ] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
* [x] I've added or updated tests if applicable.
* [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
* [ ] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information
Local tests executed successfully with pytest.