### PR TITLE
Fix: Use deprecation function wrapper for private string methods (#1405)

### DIFF
--- a/news/1405.removal
+++ b/news/1405.removal
@@ -1,0 +1,1 @@
+Deprecated :func:`icalendar.parser.string.escape_char`, :func:`icalendar.parser.string.unescape_char`, :func:`icalendar.parser.string.escape_string`, and :func:`icalendar.parser.string.unescape_string` using the standard ``deprecate_for_version_8`` wrapper as per issue #1405.

--- a/src/icalendar/parser/string.py
+++ b/src/icalendar/parser/string.py
@@ -1,7 +1,6 @@
 """Functions for manipulating strings and bytes."""
 
 import re
-import warnings
 
 from icalendar.compatibility import deprecate_for_version_8
 from icalendar.parser_tools import DEFAULT_ENCODING, to_unicode
@@ -44,42 +43,14 @@ def _escape_char(text: str | bytes) -> str:
     )
 
 
-def escape_char(text: str | bytes) -> str:
-    r"""Format value according to iCalendar TEXT escaping rules.
+escape_char = deprecate_for_version_8(_escape_char)
+"""Format value according to iCalendar TEXT escaping rules.
 
-    .. deprecated:: 7.0.0
-        Use the private :func:`_escape_char` internally. For external use,
-        this function is deprecated. Please use alternative escaping methods
-        or contact the maintainers.
-
-    Escapes special characters in text values according to :rfc:`5545#section-3.3.11`
-    rules.
-    The order of replacements matters to avoid double-escaping.
-
-    Parameters:
-        text: The text to escape.
-
-    Returns:
-        The escaped text with special characters escaped.
-
-    Note:
-        The replacement order is critical:
-
-        1. ``\N`` -> ``\n`` (normalize newlines to lowercase)
-        2. ``\`` -> ``\\`` (escape backslashes)
-        3. ``;`` -> ``\;`` (escape semicolons)
-        4. ``,`` -> ``\,`` (escape commas)
-        5. ``\r\n`` -> ``\n`` (normalize line endings)
-        6. ``"\n"`` -> ``r"\n"`` (transform a newline character to a literal, or raw,
-           newline character)
-    """
-    warnings.warn(
-        "escape_char is deprecated and will be removed in a future version. "
-        "If you are using this function externally, please contact the maintainers.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _escape_char(text)
+.. deprecated:: 7.0.0
+    Use the private :func:`_escape_char` internally. For external use,
+    this function is deprecated. Please use alternative escaping methods
+    or contact the maintainers.
+"""
 
 
 def _unescape_char(text: str | bytes) -> str | bytes | None:
@@ -127,44 +98,19 @@ def _unescape_char(text: str | bytes) -> str | bytes | None:
     return None
 
 
-def unescape_char(text: str | bytes) -> str | bytes | None:
-    r"""Unescape iCalendar TEXT values.
+unescape_char = deprecate_for_version_8(_unescape_char)
+"""Unescape iCalendar TEXT values.
 
-    .. deprecated:: 7.0.0
-        Use the private :func:`_unescape_char` internally. For external use,
-        this function is deprecated. Please use alternative unescaping methods
-        or contact the maintainers.
-
-    Reverses the escaping applied by :func:`escape_char` according to
-    :rfc:`5545#section-3.3.11` TEXT escaping rules.
-
-    Parameters:
-        text: The escaped text.
-
-    Returns:
-        The unescaped text, or ``None`` if ``text`` is neither ``str`` nor ``bytes``.
-
-    Note:
-        The replacement order is critical to avoid double-unescaping:
-
-        1. ``\N`` -> ``\n`` (intermediate step)
-        2. ``\r\n`` -> ``\n`` (normalize line endings)
-        3. ``\n`` -> newline (unescape newlines)
-        4. ``\,`` -> ``,`` (unescape commas)
-        5. ``\;`` -> ``;`` (unescape semicolons)
-        6. ``\\`` -> ``\`` (unescape backslashes last)
-    """
-    warnings.warn(
-        "unescape_char is deprecated and will be removed in a future version. "
-        "If you are using this function externally, please contact the maintainers.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _unescape_char(text)
+.. deprecated:: 7.0.0
+    Use the private :func:`_unescape_char` internally. For external use,
+    this function is deprecated. Please use alternative unescaping methods
+    or contact the maintainers.
+"""
 
 
 def _foldline(line: str, limit: int = 75, fold_sep: str = "\r\n ") -> str:
-    """Make a string folded as defined in RFC5545
+    """Make a string folded as defined in RFC5545.
+
     Lines of text SHOULD NOT be longer than 75 octets, excluding the line
     break.  Long content lines SHOULD be split into a multiple line
     representations using a line "folding" technique.  That is, a long
@@ -199,6 +145,11 @@ def _foldline(line: str, limit: int = 75, fold_sep: str = "\r\n ") -> str:
 
 
 foldline = deprecate_for_version_8(_foldline)
+"""Make a string folded as defined in RFC5545.
+
+.. deprecated:: 7.0.0
+    Use the private :func:`_foldline` internally.
+"""
 
 
 def _escape_string(val: str) -> str:
@@ -231,20 +182,13 @@ def _escape_string(val: str) -> str:
     )
 
 
-def escape_string(val: str) -> str:
-    r"""Escape backslash sequences to URL-encoded hex values.
+escape_string = deprecate_for_version_8(_escape_string)
+"""Escape backslash sequences to URL-encoded hex values.
 
-    .. deprecated:: 7.0.0
-        Use the private :func:`_escape_string` internally. For external use,
-        this function is deprecated.
-    """
-    warnings.warn(
-        "escape_string is deprecated and will be removed in icalendar 8. "
-        "If you are using this function externally, please contact the maintainers.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _escape_string(val)
+.. deprecated:: 7.0.0
+    Use the private :func:`_escape_string` internally. For external use,
+    this function is deprecated.
+"""
 
 
 def _unescape_string(val: str) -> str:
@@ -275,20 +219,13 @@ def _unescape_string(val: str) -> str:
     )
 
 
-def unescape_string(val: str) -> str:
-    r"""Unescape URL-encoded hex values to their original characters.
+unescape_string = deprecate_for_version_8(_unescape_string)
+"""Unescape URL-encoded hex values to their original characters.
 
-    .. deprecated:: 7.0.0
-        Use the private :func:`_unescape_string` internally. For external use,
-        this function is deprecated.
-    """
-    warnings.warn(
-        "unescape_string is deprecated and will be removed in icalendar 8. "
-        "If you are using this function externally, please contact the maintainers.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return _unescape_string(val)
+.. deprecated:: 7.0.0
+    Use the private :func:`_unescape_string` internally. For external use,
+    this function is deprecated.
+"""
 
 
 # [\w-] because of the iCalendar RFC

--- a/src/icalendar/tests/test_issue_1226.py
+++ b/src/icalendar/tests/test_issue_1226.py
@@ -1,3 +1,5 @@
+import pytest
+
 from icalendar.parser.string import _escape_char, escape_char
 
 
@@ -6,4 +8,8 @@ def test__escape_char_accepts_bytes():
 
 
 def test_escape_char_accepts_bytes():
-    assert escape_char(b"hello,world;test") == r"hello\,world\;test"
+    with pytest.warns(
+        DeprecationWarning,
+        match="escape_char is deprecated and will be removed in icalendar 8",
+    ):
+        assert escape_char(b"hello,world;test") == r"hello\,world\;test"


### PR DESCRIPTION
This pull request addresses issue #1405. It converts the four deprecated private methods in \icalendar.parser.string\ (\escape_char\, \unescape_char\, \escape_string\, and \unescape_string\) to use the \deprecate_for_version_8\ decorator instead of relying on manual \warnings.warn\ calls. This ensures consistency with the \oldline\ implementation introduced in PR #1391. Tests have been updated and verified.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1416.org.readthedocs.build/en/1416/

<!-- readthedocs-preview icalendar end -->