### PR TITLE
docs: replace print() with direct expressions in documentationFix/use to unicode in escape char

### DIFF
--- a/docs/explanation/api-design.rst
+++ b/docs/explanation/api-design.rst
@@ -138,7 +138,7 @@ They are automatically added.
     ...     summary="New Year's Day Celebration",
     ...     start=date(2022, 1, 1)
     ... )
-    >>> print(event.to_ical())
+    >>> event.to_ical()
     BEGIN:VEVENT
     SUMMARY:New Year's Day Celebration
     DTSTART;VALUE=DATE:20220101
@@ -151,9 +151,9 @@ Based on the created event above, the following example shows how to access valu
 
 .. code-block:: pycon
 
-    >>> print(event.summary)
+    >>> event.summary
     New Year's Day Celebration
-    >>> print(event.start)
+    >>> event.start
     2022-01-01
 
 Property naming convention
@@ -176,7 +176,7 @@ Continuing from the previous example, the next example shows how to access value
 
 .. code-block:: pycon
 
-    >>> print(event.summary)
+    >>> event.summary
     New Year's Day Celebration
 
 While some values are not set, they can be calculated from other values.
@@ -208,9 +208,9 @@ They can be accessed as attributes.
 
     >>> event.DTSTART
     datetime.date(2022, 1, 1)
-    >>> print(event.DURATION)
+    >>> event.DURATION
     None
-    >>> print(event.DTEND)
+    >>> event.DTEND
     None
 
 .. _parameter-properties:
@@ -230,16 +230,16 @@ The following example creates a new attendee for the previously created event fr
     ...     cn="Max Rasmussen",
     ...     role=ROLE.REQ_PARTICIPANT
     ... )
-    >>> print(attendee.ROLE)
+    >>> attendee.ROLE
     REQ-PARTICIPANT
 
 Similar to the casing of names of properties, lower case parameters calculate the property, whereas upper case parameters directly access the iCalendar property.
 
 .. code-block:: pycon
     
-    >>> print(attendee.email)  # calculated
+    >>> attendee.email  # calculated
     maxm@example.com
-    >>> print(attendee.CN)  # direct access
+    >>> attendee.CN  # direct access
     Max Rasmussen
 
 The parameters turn up the iCal representation.
@@ -247,7 +247,7 @@ The parameters turn up the iCal representation.
 .. code-block:: pycon
     
     >>> event.attendees = [attendee]
-    >>> print(event.to_ical())
+    >>> event.to_ical()
     BEGIN:VEVENT
     SUMMARY:New Year's Day Celebration
     DTSTART;VALUE=DATE:20220101
@@ -273,7 +273,7 @@ As mentioned in :ref:`property-access` above, some properties won't get set or v
     >>> calendar = Calendar()  # create and empty calendar
     >>> calendar.add("prodid", "-//My calendar product//mxm.dk//")
     >>> calendar.add("version", "2.0")
-    >>> print(calendar.to_ical())
+    >>> calendar.to_ical()
     BEGIN:VCALENDAR
     VERSION:2.0
     PRODID:-//My calendar product//mxm.dk//
@@ -314,7 +314,7 @@ The following example sets the ``DESCRIPTION`` from  :rfc:`7986#section-5.1`, an
     >>> description = vText("This is my personal calendar.")
     >>> description.params["language"] = "en"  # set language to English
     >>> calendar["description"] = description
-    >>> print(calendar.to_ical())
+    >>> calendar.to_ical()
     BEGIN:VCALENDAR
     VERSION:2.0
     PRODID:-//My calendar product//mxm.dk//

--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -64,7 +64,7 @@ You can set multiple properties, as shown in the following example.
 
     >>> cal = Calendar()
     >>> cal["attendee"] = ["MAILTO:maxm@mxm.dk","MAILTO:test@example.com"]
-    >>> print(display(cal))
+    >>> display(cal)
     BEGIN:VCALENDAR
     ATTENDEE:MAILTO:maxm@mxm.dk
     ATTENDEE:MAILTO:test@example.com
@@ -79,7 +79,7 @@ Here is an example.
     >>> cal = Calendar()
     >>> cal.add("attendee", "MAILTO:maxm@mxm.dk")
     >>> cal.add("attendee", "MAILTO:test@example.com")
-    >>> print(display(cal))
+    >>> display(cal)
     BEGIN:VCALENDAR
     ATTENDEE:MAILTO:maxm@mxm.dk
     ATTENDEE:MAILTO:test@example.com
@@ -118,7 +118,7 @@ Then append it to a parent.
 .. code-block:: pycon
 
     >>> cal.add_component(event)
-    >>> print(display(cal))
+    >>> display(cal)
     BEGIN:VCALENDAR
     ATTENDEE:MAILTO:maxm@mxm.dk
     ATTENDEE:MAILTO:test@example.com
@@ -272,7 +272,7 @@ After loading the example file, edit and save it.
 .. code-block:: pycon
 
     >>> calendar.calendar_name = "My Modified Calendar"  # modify
-    >>> print(calendar.to_ical()[:121])  # save modification
+    >>> calendar.to_ical()[:121]  # save modification
     BEGIN:VCALENDAR
     VERSION:2.0
     PRODID:collective/icalendar
@@ -366,7 +366,7 @@ To demonstrate icalendar's flexibility, the following example creates an event t
     >>> e["X-DT-USE-PYTZ"] = icalendar.vDatetime(datetime.datetime(2024, 6, 19, 10, 1, tzinfo=tz))
     >>> tz = zoneinfo.ZoneInfo("Europe/London")
     >>> e["X-DT-ZONEINFO"] = icalendar.vDatetime(datetime.datetime(2024, 6, 19, 10, 1, tzinfo=tz))
-    >>> print(e.to_ical())  # the libraries yield the same result
+    >>> e.to_ical()  # the libraries yield the same result
     BEGIN:VEVENT
     X-DT-DATEUTIL;TZID=Europe/London:20240619T100100
     X-DT-USE-PYTZ;TZID=Europe/London:20240619T100100
@@ -594,7 +594,7 @@ The following example filters through all subcomponents of the calendar, and if 
     >>> find_christmas = lambda c: "christmas" in c.get("SUMMARY", "").lower()
     >>> for component in calendar.walk(select=find_christmas):
     ...     component["SUMMARY"] = component["SUMMARY"].upper()
-    >>> print(calendar.events[1].summary)
+    >>> calendar.events[1].summary
     ORTHODOX CHRISTMAS
 
 Add timezones to a calendar

--- a/news/1257.documentation
+++ b/news/1257.documentation
@@ -1,0 +1,1 @@
+Replace print() with direct expressions in documentation examples (usage.rst and api-design.rst). 


### PR DESCRIPTION
- [x] See #1257

## Description
Replaced `print()` calls with direct expressions in documentation examples:
- `docs/how-to/usage.rst`
- `docs/explanation/api-design.rst`

In Python doctests, values are displayed automatically without needing `print()`. 
Using `print()` is unnecessary and inconsistent with Python doctest conventions.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1423.org.readthedocs.build/en/1423/

<!-- readthedocs-preview icalendar end -->