### PR TITLE
Reorganize change log entry format section

### DIFF
--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -137,7 +137,37 @@ Change log entry format
 
 To create a change log entry or news item, create a file in the :file:`news` directory, located in the root of the package.
 
-The change log entry's format must be ``#.type``, where ``#`` is the referenced GitHub issue or pull request number, ``.`` is the literal extension delimiter, and ``type`` is one of the following strings.
+..  important::
+
+    Never edit a change log entry that you didn't create.
+
+The change log entry's format must be ``#.type``, where ``#`` is the referenced GitHub issue or pull request number, ``.`` is the literal extension delimiter, and ``type`` is one of the following strings described in the next section, :ref:`change-log-types`
+
+To avoid a filename conflict with an existing file or another pull request for the same issue number, append a period (``.``) and an integer to the filename, incrementing it as needed to make the entire filename unique.
+
+..  code-block:: text
+
+    1158.documentation
+    1158.documentation.1
+    1158.documentation.2
+
+For orphan change log entries—that is, those that don't need to be linked to any issue ID or other identifier—start the file name with ``+``.
+The content will still be included in the change log, at the end of the category corresponding to the file extension.
+
+..  code-block:: text
+
+    +anything.bugfix
+
+.. note::
+
+    icalendar uses `towncrier <https://pypi.org/project/towncrier/>`_ to automatically update the :doc:`../reference/changelog` from entries stored in the :file:`/news` directory at the root of the project.
+    It generates links to the issue numbers and organizes the change log entries according to their filename issue numbers and types for each release.
+
+
+..  _change-log-types:
+
+Change log types
+````````````````
 
 ``breaking``
     For changes that break the existing API.
@@ -162,24 +192,6 @@ The change log entry's format must be ``#.type``, where ``#`` is the referenced 
 
 ``chore``
     For routine tasks that shouldn't be published, but will satisfy the checker for the presence of a change log entry.
-
-To avoid a conflict with another pull request for the same issue number, append an integer to the filename.
-Don't edit a change log entry from another pull request.
-
-..  code-block:: text
-
-    1158.documentation.1
-
-For orphan change log entries—that is, those that don't need to be linked to any issue ID or other identifier—start the file name with ``+``.
-The content will still be included in the change log, at the end of the category corresponding to the file extension.
-
-..  code-block:: text
-
-    +anything.bugfix
-
-.. note::
-
-    icalendar uses `towncrier <https://pypi.org/project/towncrier/>`_ to automatically update the change log from entries stored in the :file:`/news` directory at the root of the project.
 
 
 .. _write-a-good-change-log-entry-label:

--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -119,9 +119,8 @@ Pull request requirements
 
 Before submitting your pull request, ensure you have met the following requirements.
 
-#.  Add a changelog entry to :file:`CHANGES.rst`.
+#.  Add a change log entry as described in :ref:`change-log`.
     This is required and enforced by GitHub checks.
-    See :ref:`change-log` for details.
 #.  Add a test which proves your fix and passes.
 #.  Run all tests to ensure your changes don't break any existing functionality.
 #.  :doc:`Add or edit documentation <documentation/index>`, both as docstrings to be rendered in the :doc:`API reference documentation <../reference/api/icalendar>` and narrative documentation, as necessary.

--- a/news/+contribute-filename-conflict-revision.chore
+++ b/news/+contribute-filename-conflict-revision.chore
@@ -1,0 +1,1 @@
+Revised instructions to :ref:`change-log` in Contribute documentation for how to avoid a filename conflict when adding a change log entry. @stevepiercy


### PR DESCRIPTION
- Contributors either look on the "stable" branch, where this is not clarified, or think it's OK to edit an existing news item. This PR attempts to direct readers to avoid making that mistake.
- The change log entry doesn't link to an issue, and it won't appear in the change log, as it would just create noise, since there hasn't been a recent release to include the first revision.

After approval and merge, it would be good to have another minor release to get this published on "stable".

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1424.org.readthedocs.build/en/1424/

<!-- readthedocs-preview icalendar end -->