### PR TITLE
Fix broken documentation links in `icalendar.cal.availability` module

### DIFF
--- a/news/1158.documentation.6
+++ b/news/1158.documentation.6
@@ -1,0 +1,1 @@
+Fixed broken documentation links in :mod:`icalendar.cal.availability`. @lcampanella98

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -1226,7 +1226,7 @@ Returns:
 
 Description:
     This property is used to specify the default busy time
-    type. The values correspond to those used by the FBTYPE"
+    type. The values correspond to those used by the "FBTYPE"
     parameter used on a "FREEBUSY" property, with the exception that
     the "FREE" value is not used in this property.  If not specified
     on a component that allows this property, the default is "BUSY-
@@ -1509,7 +1509,8 @@ rfc_7953_dtstart_property = timezone_datetime_property(
     "DTSTART",
     """Start of the component.
 
-    This is almost the same as :attr:`Event.DTSTART` with one exception:
+    This is almost the same as
+    :attr:`Event.DTSTART <icalendar.cal.event.Event.DTSTART>` with one exception:
     The values MUST have a timezone and DATE is not allowed.
 
     Description:
@@ -1525,7 +1526,8 @@ rfc_7953_dtend_property = timezone_datetime_property(
     "DTEND",
     """Start of the component.
 
-    This is almost the same as :attr:`Event.DTEND` with one exception:
+    This is almost the same as
+    :attr:`Event.DTEND <icalendar.cal.event.Event.DTEND>` with one exception:
     The values MUST have a timezone and DATE is not allowed.
 
     Description:

--- a/src/icalendar/cal/availability.py
+++ b/src/icalendar/cal/availability.py
@@ -271,26 +271,26 @@ class Availability(Component):
             busy_type: The :attr:`busy_type` of the availability.
             categories: The :attr:`categories` of the availability.
             classification: The :attr:`classification` of the availability.
-            comments: The :attr:`comments` of the availability.
-            concepts: The :attr:`concepts` of the availability.
+            comments: The :attr:`~icalendar.cal.component.Component.comments` of the availability.
+            concepts: The :attr:`~icalendar.cal.component.Component.concepts` of the availability.
             contacts: The :attr:`contacts` of the availability.
-            created: The :attr:`created` of the availability.
+            created: The :attr:`~icalendar.cal.component.Component.created` of the availability.
             description: The :attr:`description` of the availability.
             end: The :attr:`end` of the availability.
-            last_modified: The :attr:`last_modified` of the
+            last_modified: The :attr:`~icalendar.cal.component.Component.last_modified` of the
                 availability.
-            links: The :attr:`links` of the availability.
+            links: The :attr:`~icalendar.cal.component.Component.links` of the availability.
             location: The :attr:`location` of the availability.
             organizer: The :attr:`organizer` of the availability.
-            refids: :attr:`refids` of the availability.
-            related_to: :attr:`related_to` of the availability.
+            refids: :attr:`~icalendar.cal.component.Component.refids` of the availability.
+            related_to: :attr:`~icalendar.cal.component.Component.related_to` of the availability.
             sequence: The :attr:`sequence` of the availability.
-            stamp: The :attr:`stamp` of the availability.
+            stamp: The :attr:`~icalendar.cal.component.Component.stamp` of the availability.
                 If None, this is set to the current time.
             start: The :attr:`start` of the availability.
-            subcomponents: The :attr:`subcomponents` of the availability.
+            subcomponents: The :attr:`~icalendar.cal.component.Component.subcomponents` of the availability.
             summary: The :attr:`summary` of the availability.
-            uid: The :attr:`uid` of the availability.
+            uid: The :attr:`~icalendar.cal.component.Component.uid` of the availability.
                 If ``None``, this is set to a new :func:`uuid.uuid4`.
             url: The :attr:`url` of the availability.
 


### PR DESCRIPTION
## Linked issue

- [x] See #1158 

## Description

- Fix broken links in [`icalendar.cal.availability` module](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.availability.html)
- This includes links to `Event.DTSTART` and `Event.DTEND` in [`icalendar.cal.availability.Availability.DTEND`](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.availability.html#icalendar.cal.availability.Availability.DTEND) and [`icalendar.cal.availability.Availability.DTSTART`](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.availability.html#icalendar.cal.availability.Availability.DTSTART) which needed to happen in `attr.py` which consequently also affects [`icalendar.cal.available` module](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.available.html#icalendar.cal.available.Available.DTEND) `DTSTART` and `DTEND` properties, which I've tested using `make livehtml`

## Checklist

- [x] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I've added or updated tests if applicable. (N/A)
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

https://icalendar--1427.org.readthedocs.build/en/1427/reference/api/icalendar.cal.availability.html

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1427.org.readthedocs.build/en/1427/

<!-- readthedocs-preview icalendar end -->