### PR TITLE
docs: add NixOS installation instructions

### DIFF
--- a/docs/how-to/install.rst
+++ b/docs/how-to/install.rst
@@ -69,3 +69,12 @@ You can install the `python3-icalendar package <https://packages.fedoraproject.o
 .. code-block:: shell
 
     sudo dnf install python3-icalendar
+
+NixOS
+-----
+
+You can install the icalendar package on NixOS using ``nix-env``:
+
+.. code-block:: shell
+
+    nix-env -iA nixpkgs.python3Packages.icalendar

--- a/news/+nixos-installation.documentation
+++ b/news/+nixos-installation.documentation
@@ -1,0 +1,1 @@
+Added NixOS installation instructions to the documentation.

--- a/news/+nixos-installation.documentation
+++ b/news/+nixos-installation.documentation
@@ -1,1 +1,1 @@
-Added NixOS installation instructions to the documentation.
+Added NixOS installation instructions to the documentation. @MichaelFehdrau0205


### PR DESCRIPTION
## Linked issue

Replace `ISSUE_NUMBER` with the issue number that your pull request addresses. This links the pull request to the related issue. Choose the appropriate form.

If you completely resolve the issue, then use `"Closes"`.
GitHub will automatically close the related issue when the PR gets merged.

- [ ] Closes #ISSUE_NUMBER

If you resolve only a part of the issue, then use `"See"`.
This form keeps the issue open for future work. 

- [ ] See #ISSUE_NUMBER

## Description

Added NixOS installation instructions to the installation 
documentation. This helps NixOS users install icalendar 
using the nix package manager.

## Checklist

- [ ] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [ ] I've added or updated tests if applicable.
- [ ] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

Upload screenshots, videos, links to documentation, or any other relevant information.


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1428.org.readthedocs.build/en/1428/

<!-- readthedocs-preview icalendar end -->