### PR TITLE
Fix broken Calendar.from_ical links in custom components guide

### DIFF
--- a/docs/how-to/custom-components.rst
+++ b/docs/how-to/custom-components.rst
@@ -20,7 +20,7 @@ icalendar preserves all custom components through dynamic component creation usi
 Parse custom components
 =======================
 
-Parse custom components using either :meth:`Component.from_ical() <icalendar.cal.component.Component.from_ical>` or :meth:`Calendar.from_ical() <icalendar.cal.calendar.Calendar.from_ical>`.
+Parse custom components using either :meth:`Component.from_ical() <icalendar.cal.component.Component.from_ical>` or :meth:`Calendar.from_ical() <icalendar.cal.component.Component.from_ical>`.
 
 
 ``Component.from_ical()``
@@ -316,7 +316,7 @@ Related content
 :meth:`Component.from_ical <icalendar.cal.component.Component.from_ical>`
     Parse components
 
-:meth:`Calendar.from_ical <icalendar.cal.calendar.Calendar.from_ical>`
+:meth:`Calendar.from_ical <icalendar.cal.component.Component.from_ical>`
     Parse calendars
 
 :rfc:`5545`

--- a/news/+fix-custom-components-links.documentation
+++ b/news/+fix-custom-components-links.documentation
@@ -1,0 +1,1 @@
+Fixed the broken ``Calendar.from_ical`` links in the custom components how-to guide to point to their correct definition on :meth:`~icalendar.cal.component.Component.from_ical`. AI disclosure: I used Gemini 3.5 Flash to identify the broken references, locate the target definition, and draft the fix. @aniketaggarwal


### PR DESCRIPTION
## Linked issue

- [x] See #1158

## Description

This pull request corrects the broken Python object links in the custom components how-to guide (`docs/how-to/custom-components.rst`). The references to `Calendar.from_ical` have been updated to point to `Component.from_ical`, which is the class where the method is defined. This resolves the Sphinx warnings generated during the build.

AI disclosure: I used Gemini 3.5 Flash to scan documentation warnings, locate the correct target definition, and draft the fix.

## Checklist

- [x] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [ ] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

- Built and validated the documentation locally using `make html`.
- Verified that all warnings for `docs/how-to/custom-components.rst` are successfully resolved.


<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1429.org.readthedocs.build/en/1429/

<!-- readthedocs-preview icalendar end -->