### PR TITLE
Document Calendar.from_ical API

### DIFF
--- a/news/+calendar-from-ical.documentation
+++ b/news/+calendar-from-ical.documentation
@@ -1,0 +1,1 @@
+Documented :meth:`Calendar.from_ical <icalendar.cal.calendar.Calendar.from_ical>` as a direct :class:`~icalendar.cal.calendar.Calendar` API member so Sphinx can link to it from the custom components guide. Prepared with AI assistance. @xjn2005

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -116,11 +116,11 @@ class Calendar(Component):
 
         Parameters:
             st: iCalendar data as bytes or string, or a path to an iCalendar file.
-            multiple: If ``True``, returns a list. If ``False``, returns a single
-                calendar.
+            multiple: If ``True``, returns a list of calendars.
+                If ``False``, returns a single calendar.
 
         Returns:
-            Calendar or list of calendars
+            Calendar or list of calendars.
         """
         return cast(
             "Calendar | list[Calendar]", super().from_ical(st, multiple=multiple)

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast, overload
 
 from icalendar.attr import (
     CONCEPTS_TYPE_SETTER,
@@ -28,6 +28,7 @@ from icalendar.version import __version__
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
     from datetime import date, datetime
+    from pathlib import Path
 
     from icalendar.cal.availability import Availability
     from icalendar.cal.event import Event
@@ -94,6 +95,36 @@ class Calendar(Component):
     def _get_ical_parser(cls, st: str | bytes) -> ComponentIcalParser:
         """Get the iCal parser for the given input string."""
         return CalendarIcalParser(st, cls._get_component_factory(), cls.types_factory)
+
+    @overload
+    @classmethod
+    def from_ical(
+        cls, st: str | bytes | Path, multiple: Literal[False] = False
+    ) -> Calendar: ...
+
+    @overload
+    @classmethod
+    def from_ical(
+        cls, st: str | bytes | Path, multiple: Literal[True]
+    ) -> list[Calendar]: ...
+
+    @classmethod
+    def from_ical(
+        cls, st: str | bytes | Path, multiple: bool = False
+    ) -> Calendar | list[Calendar]:
+        """Parse iCalendar data into calendar instances.
+
+        Parameters:
+            st: iCalendar data as bytes or string, or a path to an iCalendar file.
+            multiple: If ``True``, returns a list. If ``False``, returns a single
+                calendar.
+
+        Returns:
+            Calendar or list of calendars
+        """
+        return cast(
+            "Calendar | list[Calendar]", super().from_ical(st, multiple=multiple)
+        )
 
     @property
     def events(self) -> list[Event]:

--- a/src/icalendar/tests/test_issue_756_read_calendar_from_file.py
+++ b/src/icalendar/tests/test_issue_756_read_calendar_from_file.py
@@ -44,3 +44,14 @@ def test_reading_cal_from_long_string(dummy_cal):
     actual_cal = Calendar.from_ical(long_string)
 
     assert actual_cal.to_ical() == expected_cal.to_ical()
+
+
+def test_calendar_from_ical_is_declared_for_api_documentation():
+    """Test Calendar.from_ical is documented as a Calendar API method."""
+    cal_bytes = get_example("calendars", "example")
+
+    assert "from_ical" in Calendar.__dict__
+    assert (
+        Calendar.from_ical(cal_bytes).to_ical()
+        == Calendar.from_ical(cal_bytes).to_ical()
+    )


### PR DESCRIPTION
This PR adds a Calendar.from_ical() wrapper method to improve Sphinx autodoc support.

Changes included:

- Add a Calendar.from_ical() wrapper method.
- Add regression tests covering the new wrapper.
- Add a changelog entry under /news.
- Update the documentation to ensure the method is properly exposed in the generated API documentation.