### PR TITLE
Expose and document Calendar.from_ical classmethod

### DIFF
--- a/docs/how-to/custom-components.rst
+++ b/docs/how-to/custom-components.rst
@@ -20,7 +20,7 @@ icalendar preserves all custom components through dynamic component creation usi
 Parse custom components
 =======================
 
-Parse custom components using either :meth:`Component.from_ical() <icalendar.cal.component.Component.from_ical>` or :meth:`Calendar.from_ical() <icalendar.cal.calendar.Calendar.from_ical>`.
+Parse custom components using either :meth:`Component.from_ical() <icalendar.cal.component.Component.from_ical>` or :meth:`Calendar.from_ical() <icalendar.cal.component.Component.from_ical>`.
 
 
 ``Component.from_ical()``
@@ -316,7 +316,7 @@ Related content
 :meth:`Component.from_ical <icalendar.cal.component.Component.from_ical>`
     Parse components
 
-:meth:`Calendar.from_ical <icalendar.cal.calendar.Calendar.from_ical>`
+:meth:`Calendar.from_ical <icalendar.cal.component.Component.from_ical>`
     Parse calendars
 
 :rfc:`5545`

--- a/news/+fix-custom-components-links.documentation
+++ b/news/+fix-custom-components-links.documentation
@@ -1,1 +1,0 @@
-Fixed the broken ``Calendar.from_ical`` links in the custom components how-to guide to point to their correct definition on :meth:`~icalendar.cal.component.Component.from_ical`. AI disclosure: I used Gemini 3.5 Flash to identify the broken references, locate the target definition, and draft the fix. @aniketaggarwal

--- a/news/+fix-custom-components-links.documentation
+++ b/news/+fix-custom-components-links.documentation
@@ -1,0 +1,1 @@
+Fixed the broken ``Calendar.from_ical`` links in the custom components how-to guide to point to their correct definition on :meth:`~icalendar.cal.component.Component.from_ical`. AI disclosure: I used Gemini 3.5 Flash to identify the broken references, locate the target definition, and draft the fix. @aniketaggarwal

--- a/news/1430.documentation
+++ b/news/1430.documentation
@@ -1,0 +1,1 @@
+Added a documented and type-annotated :meth:`~icalendar.cal.calendar.Calendar.from_ical` classmethod to the :class:`~icalendar.cal.calendar.Calendar` class, resolving broken links in the documentation. AI disclosure: I used Gemini 3.5 Flash to identify the missing method definition on Calendar, implement it, and document the change. @aniketaggarwal

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -109,7 +109,8 @@ class Calendar(Component):
 
         Parameters:
             st: iCalendar data as bytes, string, or a path to an iCalendar file.
-            multiple: If ``True``, returns list. If ``False``, returns single Calendar.
+            multiple: If ``True``, returns a list of components.
+                If ``False``, returns a calendar.
 
         Returns:
             Calendar or list of components

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, overload
 
 from icalendar.attr import (
     CONCEPTS_TYPE_SETTER,
@@ -28,6 +28,7 @@ from icalendar.version import __version__
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
     from datetime import date, datetime
+    from pathlib import Path
 
     from icalendar.cal.availability import Availability
     from icalendar.cal.event import Event
@@ -89,6 +90,31 @@ class Calendar(Component):
     def example(cls, name: str = "example") -> Calendar:
         """Return the calendar example with the given name."""
         return cls.from_ical(get_example("calendars", name))
+
+    @overload
+    @classmethod
+    def from_ical(
+        cls, st: str | bytes, multiple: Literal[False] = False
+    ) -> Calendar: ...
+
+    @overload
+    @classmethod
+    def from_ical(cls, st: str | bytes, multiple: Literal[True]) -> list[Component]: ...
+
+    @classmethod
+    def from_ical(
+        cls, st: str | bytes | Path, multiple: bool = False
+    ) -> Calendar | list[Component]:
+        """Parse iCalendar data into a Calendar instance.
+
+        Parameters:
+            st: iCalendar data as bytes, string, or a path to an iCalendar file.
+            multiple: If ``True``, returns list. If ``False``, returns single Calendar.
+
+        Returns:
+            Calendar or list of components
+        """
+        return super().from_ical(st, multiple)
 
     @classmethod
     def _get_ical_parser(cls, st: str | bytes) -> ComponentIcalParser:


### PR DESCRIPTION
## Linked issue

- [x] Closes #1430

## Description

This pull request addresses the missing documentation for `Calendar.from_ical`. By explicitly defining `from_ical` on the `Calendar` class as a type-annotated `@classmethod` wrapping `super().from_ical`, we generate the proper Sphinx API reference. This automatically resolves all broken `:meth:`Calendar.from_ical`` cross-references (such as in `custom-components.rst` and `attendees.rst`) and provides more precise type-checking for users.

AI disclosure: I used Gemini 3.5 Flash to analyze the missing documentation problem, implement the type-annotated wrapper in the `Calendar` class, and draft the news entry.

## Checklist

- [x] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [ ] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

- Documented `Calendar.from_ical` with correct return typing annotations.
- Verified build succeeds locally with zero warnings for guides referencing `Calendar.from_ical`.
