### PR TITLE
docs: add redirects for moved and renamed pages (#1337)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -225,16 +225,34 @@ issues_github_path = "collective/icalendar"
 redirects = {
     "about": "index.html",
     "api": "reference/api/icalendar.html",
+    "api/index": "../reference/api/icalendar.html",
     "changelog": "reference/changelog.html",
     "cli": "how-to/cli.html",
-    "credits": "contribute/credits.html",
+    "contribute": "contribute/index.html",
+    "contribute/documentation": "documentation/index.html",
     "contributing": "contribute/index.html",
+    "credits": "contribute/credits.html",
+    "development": "contribute/development.html",
+    "examples": "how-to/usage.html",
+    "explanation": "explanation/index.html",
+    "how-to": "how-to/index.html",
     "install": "how-to/install.html",
     "license": "https://github.com/collective/icalendar/blob/main/LICENSE.rst",
     "maintenance": "contribute/maintenance.html",
+    "reference": "reference/index.html",
+    "reference/api/modules": "icalendar.html",
+    "reference/component-api": "../explanation/api-design.html",
+    "reference/design": "rfc-support.html",
     "security": "https://github.com/collective/icalendar/blob/main/SECURITY.md",
+    "tutorials": "tutorials/index.html",
+    "upgrade": "how-to/upgrade.html",
     "usage": "how-to/usage.html",
 }
+
+# Do not apply redirects to the latest branch, as it is not considered a stable target.
+# https://github.com/collective/icalendar/issues/1337
+if os.environ.get("READTHEDOCS_VERSION") == "latest":
+    redirects = {}
 
 man_pages = [("index", "icalendar", "icalendar Documentation", ["Plone Foundation"], 1)]
 

--- a/news/1337.documentation
+++ b/news/1337.documentation
@@ -1,0 +1,1 @@
+Added more redirects for moved documentation pages to improve navigation and SEO, addressing the most important stable links identified.


### PR DESCRIPTION
This PR adds redirects for key documentation pages that were moved or renamed during recent restructurings to improve navigation and SEO for stable links.

Follows constraints from issue #1337:
- Disables redirects when building the 'latest' version on Read the Docs.
- Covers most important stable links identified from codebase history and common entry points.
- Includes a news fragment for the changelog.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1440.org.readthedocs.build/en/1440/

<!-- readthedocs-preview icalendar end -->