### PR TITLE
feat: add type hints to component class method

### DIFF
--- a/news/938.feature
+++ b/news/938.feature
@@ -1,0 +1,1 @@
+Added type hints to component methods. @Priyanshu-pulak

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -202,22 +202,22 @@ class Component(CaselessDict):
         self.errors = []  # If we ignored exception(s) while
         # parsing a property, contains error strings
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """Returns True, CaselessDict would return False if it had no items."""
         return True
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> Any:
         """Get property value from the component dictionary."""
         return super().__getitem__(key)
 
-    def get(self, key, default=None):
+    def get(self, key, default=None) -> Any:
         """Get property value with default."""
         try:
             return self[key]
         except KeyError:
             return default
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         """Returns True if Component has no items or subcomponents, else False."""
         return bool(not list(self.values()) + self.subcomponents)
 
@@ -602,7 +602,7 @@ class Component(CaselessDict):
         content_lines = self.content_lines(sorted=sorted)
         return content_lines.to_ical()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """String representation of class with all of its subcomponents.
 
         Implemented iteratively rather than recursively so that calendars
@@ -647,7 +647,7 @@ class Component(CaselessDict):
                     out.append(str(node))
         return "".join(out)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if len(self.subcomponents) != len(other.subcomponents):
             return False
 
@@ -755,7 +755,7 @@ class Component(CaselessDict):
         return any(attr.startswith("X-MOZ-") for attr in self.keys())
 
     @staticmethod
-    def _utc_now():
+    def _utc_now() -> datetime:
         """Return now as UTC value."""
         return datetime.now(timezone.utc)
 

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -206,7 +206,7 @@ class Component(CaselessDict):
         """Returns True, CaselessDict would return False if it had no items."""
         return True
 
-    def __getitem__(self, key) -> Any:
+    def __getitem__(self, key) -> VPROPERTY:
         """Get property value from the component dictionary."""
         return super().__getitem__(key)
 
@@ -647,7 +647,7 @@ class Component(CaselessDict):
                     out.append(str(node))
         return "".join(out)
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: Component) -> bool:
         if len(self.subcomponents) != len(other.subcomponents):
             return False
 


### PR DESCRIPTION
## Refs issue 938

Used Gemini AI to assist with drafting the PR

- [x] Refs #938

## Description
This PR adds type annotations to several methods in `src.icalendar.cal.component.py`.

Added type annotations for:
* `__bool__`
* `__getitem__`
* `get`
* `is_empty`
* `__repr__`
* `__eq__`
* `_utc_now`


## Checklist

- [x] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [ ] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

Upload screenshots, videos, links to documentation, or any other relevant information.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1451.org.readthedocs.build/en/1451/

<!-- readthedocs-preview icalendar end -->