### PR TITLE
chore: add type hints to error.py

### DIFF
--- a/news/938.chore_error
+++ b/news/938.chore_error
@@ -1,1 +1,1 @@
-Added type hints to error.py all methods. @Priyanshu-pulak
+Added type hints to all methods in error.py. @Priyanshu-pulak

--- a/news/938.chore_error
+++ b/news/938.chore_error
@@ -1,0 +1,1 @@
+Added type hints to error.py all methods. @Priyanshu-pulak

--- a/news/938.chore_error
+++ b/news/938.chore_error
@@ -1,1 +1,1 @@
-Added type hints to all methods in error.py. @Priyanshu-pulak
+Added type hints to all methods in the module :mod:`~icalendar.error`. @Priyanshu-pulak

--- a/src/icalendar/error.py
+++ b/src/icalendar/error.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import contextlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 class InvalidCalendar(ValueError):
@@ -81,7 +85,7 @@ class JCalParsingError(ValueError):
         parser: str | type = "",
         path: list[str | int] | None | str | int = None,
         value: object = _default_value,
-    ):
+    ) -> None:
         """Create a new JCalParsingError."""
         self.path = self._get_path(path)
         if not isinstance(parser, str):
@@ -103,7 +107,10 @@ class JCalParsingError(ValueError):
 
     @classmethod
     @contextlib.contextmanager
-    def reraise_with_path_added(cls, *path_components: int | str):
+    def reraise_with_path_added(
+        cls,
+        *path_components: int | str,
+    ) -> Generator[None, None, None]:
         """Automatically re-raise the exception with path components added.
 
         Raises:
@@ -131,10 +138,10 @@ class JCalParsingError(ValueError):
     @classmethod
     def validate_property(
         cls,
-        jcal_property,
+        jcal_property: list,
         parser: str | type,
         path: list[str | int] | None | str | int = None,
-    ):
+    ) -> None:
         """Validate a jCal property.
 
         Raises:
@@ -177,12 +184,12 @@ class JCalParsingError(ValueError):
     @classmethod
     def validate_value_type(
         cls,
-        jcal,
+        jcal: str | float | bool,
         expected_type: type[str | int | float | bool]
         | tuple[type[str | int | float | bool], ...],
         parser: str | type = "",
         path: list[str | int] | None | str | int = None,
-    ):
+    ) -> None:
         """Validate the type of a jCal value."""
         if not isinstance(jcal, expected_type):
             type_name = (
@@ -200,11 +207,11 @@ class JCalParsingError(ValueError):
     @classmethod
     def validate_list_type(
         cls,
-        jcal,
+        jcal: list,
         expected_type: type[str | int | float | bool],
         parser: str | type = "",
         path: list[str | int] | None | str | int = None,
-    ):
+    ) -> None:
         """Validate the type of each item in a jCal list."""
         path = cls._get_path(path)
         if not isinstance(jcal, list):

--- a/src/icalendar/error.py
+++ b/src/icalendar/error.py
@@ -138,7 +138,7 @@ class JCalParsingError(ValueError):
     @classmethod
     def validate_property(
         cls,
-        jcal_property: list,
+        jcal_property: list[object],
         parser: str | type,
         path: list[str | int] | None | str | int = None,
     ) -> None:
@@ -207,7 +207,7 @@ class JCalParsingError(ValueError):
     @classmethod
     def validate_list_type(
         cls,
-        jcal: list,
+        jcal: object,
         expected_type: type[str | int | float | bool],
         parser: str | type = "",
         path: list[str | int] | None | str | int = None,

--- a/src/icalendar/error.py
+++ b/src/icalendar/error.py
@@ -184,7 +184,7 @@ class JCalParsingError(ValueError):
     @classmethod
     def validate_value_type(
         cls,
-        jcal: str | float | bool,
+        jcal: object,
         expected_type: type[str | int | float | bool]
         | tuple[type[str | int | float | bool], ...],
         parser: str | type = "",


### PR DESCRIPTION
## Refs issue 938

Used Gemini AI to assist with drafting the PR, and finding the method where type hinting is missing

- [x] Refs #938

## Description
This PR adds type annotations to several methods in `src.error.py`.

Added type annotations for:
* `__init__`
* `validate_property`
* `validate_value_type`
* `validate_list_type`


## Checklist

- [x] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [ ] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

Upload screenshots, videos, links to documentation, or any other relevant information.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1452.org.readthedocs.build/en/1452/

<!-- readthedocs-preview icalendar end -->