### PR TITLE
docs: apply Google style to _format_name docstring

### DIFF
--- a/news/1456.documentation
+++ b/news/1456.documentation
@@ -1,0 +1,1 @@
+Converted docstring of :func:`~icalendar.cli._format_name` to Google style. @pradeep-builds

--- a/news/news/1456.documentation
+++ b/news/news/1456.documentation
@@ -1,1 +1,0 @@
-Converted docstring of :func:`~icalendar.cli._format_name` to Google style. @pradeep-builds

--- a/news/news/1456.documentation
+++ b/news/news/1456.documentation
@@ -1,0 +1,1 @@
+Converted docstring of :func:`~icalendar.cli._format_name` to Google style. @pradeep-builds

--- a/src/icalendar/cli.py
+++ b/src/icalendar/cli.py
@@ -12,14 +12,16 @@ from icalendar.cal.event import Event
 
 
 def _format_name(address: str) -> str:
-    """Format a display name and email from an address string.
+    """Format a display name and email address.
 
-    Parameters:
-        address: An address object, such as mailto:name@example.com.
+    Args:
+        address: Address string such as
+        ``mailto:name@example.com``.
 
     Returns:
-        A formatted string, like 'name <name@example.com>',
-        or an empty string if no email is found.
+        Formatted string like
+        ``name <name@example.com>``.
+        Returns an empty string if no email is found.
     """
     email = address.rsplit(":", maxsplit=1)[-1]
     name = email.split("@")[0]


### PR DESCRIPTION
## Linked issue

- [x] See #1072

## Description

Updated the `_format_name()` docstring in `src/icalendar/cli.py` to follow the project's Google Style documentation guidelines.

### Changes made

- Replaced `Parameters` with `Args`.
- Reformatted the `Returns` section.
- Improved docstring consistency with the project style guide.

## Checklist

- [ ] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [ ] I've added or updated tests if applicable.
- [ ] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

Part of the ongoing docstring standardization effort in #1072.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1456.org.readthedocs.build/en/1456/

<!-- readthedocs-preview icalendar end -->