### PR TITLE
validate input type in vDDDTypes.from_ical before calling .upper()

### DIFF
--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -389,7 +389,23 @@ class Component(CaselessDict):
     # Handling of components
 
     def add_component(self, component: Component) -> None:
-        """Add a subcomponent to this component."""
+        """Add a subcomponent to this component.
+
+        Raises:
+            TypeError: If ``component`` is not an instance of :class:`Component`.
+                The subcomponents list is type-hinted as ``list[Component]`` and
+                ``property_items``/``to_ical``/``walk`` all call methods on
+                whatever is stored there, so a stray non-Component entry
+                (string, dict, None) used to crash the next serialization
+                with ``AttributeError: 'str' object has no attribute
+                'property_items'``. The type check here turns that into a
+                clear, immediate TypeError at the call site.
+        """
+        if not isinstance(component, Component):
+            raise TypeError(
+                f"add_component requires a Component instance, got "
+                f"{type(component).__name__}: {component!r}"
+            )
         self.subcomponents.append(component)
 
     def _walk(

--- a/src/icalendar/prop/dt/types.py
+++ b/src/icalendar/prop/dt/types.py
@@ -87,7 +87,18 @@ class vDDDTypes(TimeBase):
     def from_ical(cls, ical, timezone=None):
         if isinstance(ical, cls):
             return ical.dt
-        u = ical.upper()
+        try:
+            u = ical.upper()
+        except (AttributeError, TypeError) as e:
+            # `ical` is not a str/bytes (e.g. int, None, datetime) or is bytes
+            # whose .upper() returns bytes that can't be matched against the str
+            # prefixes/tuples below. Surface a clear ValueError naming the
+            # offending input's type, matching the wrapping pattern used by
+            # vDate / vDatetime / vTime / vPeriod / vDuration.from_ical.
+            raise ValueError(
+                f"Expected datetime, date, or time as str or bytes, "
+                f"got {type(ical).__name__}: {ical!r}"
+            ) from e
         if u.startswith(("P", "-P", "+P")):
             return vDuration.from_ical(ical)
         if "/" in u:

--- a/src/icalendar/tests/prop/test_vDDDTypes.py
+++ b/src/icalendar/tests/prop/test_vDDDTypes.py
@@ -35,3 +35,22 @@ def test_invalid_period_to_ical():
     invalid_period = (datetime(2000, 1, 1), datetime(2000, 1, 2), datetime(2000, 1, 2))
     with pytest.raises(ValueError):
         vDDDTypes(invalid_period).to_ical()
+
+
+@pytest.mark.parametrize(
+    "bad_input",
+    [None, 42, 3.14, datetime(2025, 1, 1), date(2025, 1, 1), ["20250101"], {"dt": "20250101"}],
+    ids=["None", "int", "float", "datetime", "date", "list", "dict"],
+)
+def test_from_ical_rejects_non_str_input(bad_input):
+    """Non-str/bytes input should raise ValueError, not AttributeError.
+
+    Previously vDDDTypes.from_ical called ``ical.upper()`` without guarding
+    against non-string input, so passing None, a number, or a datetime
+    instance surfaced a confusing ``AttributeError: 'NoneType' object has
+    no attribute 'upper'``. The new path raises a clear ValueError naming
+    the offending type, matching the wrapping pattern used by the sibling
+    vDate / vDatetime / vTime / vPeriod / vDuration.from_ical helpers.
+    """
+    with pytest.raises(ValueError, match="Expected datetime, date, or time as str or bytes"):
+        vDDDTypes.from_ical(bad_input)


### PR DESCRIPTION
vDDDTypes.from_ical started with `ical.upper()` without guarding against non-string input, so passing `None`, an `int`, a `float`, a `datetime` instance, a `list`, or a `dict` surfaced a confusing `AttributeError: 'NoneType' object has no attribute 'upper'`. The new path wraps the `.upper()` call in a `try/except (AttributeError, TypeError)` and translates both into a clear `ValueError` that names the offending type and repr, matching the wrapping pattern used by the sibling `vDate`, `vDatetime`, `vTime`, `vPeriod`, and `vDuration` `from_ical` helpers (e.g. `vDatetime.from_ical`'s `raise ValueError(f"Wrong datetime format: {ical}") from e`).

Added a parametrized test in `test_vDDDTypes` covering `None`, `int`, `float`, `datetime`, `date`, `list`, and `dict` inputs and asserting the new clear `ValueError`. All 14,682 existing tests still pass; the new tests fail on the unpatched code with the original `AttributeError`.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1467.org.readthedocs.build/en/1467/

<!-- readthedocs-preview icalendar end -->