### PR TITLE
make vGeo.to_ical() return bytes like every other vDataType

### DIFF
--- a/src/icalendar/prop/geo.py
+++ b/src/icalendar/prop/geo.py
@@ -92,8 +92,8 @@ class vGeo:
         self.longitude = longitude
         self.params = Parameters(params)
 
-    def to_ical(self) -> str:
-        return f"{self.latitude};{self.longitude}"
+    def to_ical(self) -> bytes:
+        return f"{self.latitude};{self.longitude}".encode()
 
     @staticmethod
     def from_ical(ical: str) -> tuple[float, float]:

--- a/src/icalendar/tests/prop/test_unit.py
+++ b/src/icalendar/tests/prop/test_unit.py
@@ -249,15 +249,15 @@ class TestProp(unittest.TestCase):
         from icalendar.prop import vGeo
 
         # Pass a list
-        assert vGeo([1.2, 3.0]).to_ical() == "1.2;3.0"
+        assert vGeo([1.2, 3.0]).to_ical() == b"1.2;3.0"
 
         # Pass a tuple
-        assert vGeo((1.2, 3.0)).to_ical() == "1.2;3.0"
+        assert vGeo((1.2, 3.0)).to_ical() == b"1.2;3.0"
 
         g = vGeo.from_ical("37.386013;-122.082932")
         assert g == (float("37.386013"), float("-122.082932"))
 
-        assert vGeo(g).to_ical() == "37.386013;-122.082932"
+        assert vGeo(g).to_ical() == b"37.386013;-122.082932"
 
         assert hash(vGeo(g)) == hash(g)
 

--- a/src/icalendar/tests/prop/test_vGeo.py
+++ b/src/icalendar/tests/prop/test_vGeo.py
@@ -1,0 +1,54 @@
+"""Tests for the vGeo property type."""
+
+import pytest
+
+from icalendar.prop.geo import vGeo
+
+
+def test_to_ical_returns_bytes():
+    """vGeo.to_ical() must return bytes, not str, to match every other vDataType.
+
+    Every other vDataType's to_ical() (vFloat, vInt, vText, vBoolean, vUri,
+    vBinary, vDate, vDatetime, vDuration, vPeriod, vRecur, vTime,
+    vUTCOffset) returns bytes.  vGeo was the lone str-returning outlier,
+    which broke callers that concatenated `b"\\r\\n".join(x.to_ical() for x in lines)`
+    (e.g. Contentlines.to_ical in parser/content_line.py) once any property
+    held a vGeo.
+    """
+    assert isinstance(vGeo((37.386013, -122.082932)).to_ical(), bytes)
+
+
+def test_to_ical_value_bytes():
+    """vGeo.to_ical() returns the encoded lat;lon string."""
+    assert vGeo((37.386013, -122.082932)).to_ical() == b"37.386013;-122.082932"
+
+
+def test_to_ical_list_and_tuple_both_bytes():
+    """Both list and tuple inputs produce the same bytes output."""
+    assert vGeo([1.2, 3.0]).to_ical() == b"1.2;3.0"
+    assert vGeo((1.2, 3.0)).to_ical() == b"1.2;3.0"
+
+
+def test_from_ical_roundtrip():
+    """from_ical -> vGeo -> to_ical roundtrips back to the original bytes."""
+    original = "37.386013;-122.082932"
+    parsed = vGeo.from_ical(original)
+    assert vGeo(parsed).to_ical() == original.encode()
+
+
+def test_negative_coordinates_bytes():
+    """Negative latitude or longitude serialises to bytes with the minus sign."""
+    assert vGeo((-37.5, 122.0)).to_ical() == b"-37.5;122.0"
+
+
+def test_integer_inputs_serialise_as_floats():
+    """Integer latitude/longitude inputs serialise with a decimal point.
+
+    Without a decimal, the output would be ``b"37;-122"``, which `from_ical`
+    still parses correctly but is inconsistent with the float format
+    documented in RFC 5545 (``(["+"] / "-") 1*DIGIT ["." 1*DIGIT]`` is
+    recommended).
+    """
+    result = vGeo((37, -122)).to_ical()
+    assert result == b"37.0;-122.0"
+    assert isinstance(result, bytes)


### PR DESCRIPTION
vGeo.to_ical() currently returns a Python str (e.g. "37.0;-122.0"), while every other vDataType in src/icalendar/prop/ (vFloat, vInt, vText, vBoolean, vUri, vBinary, vDate, vDatetime, vDuration, vPeriod, ...) returns bytes. The prop/__init__.py module docstring documents that calling val.to_ical() on a vDataType renders it in the iCalendar format, and every other type does that as bytes.

The str return is inconsistent and can break any caller that concatenates bytes with to_ical() output, e.g. during custom serialization or when building content lines by hand. The Component.to_ical() codepath happens to coerce through to_unicode() before joining, which is why this hasn't surfaced in the existing tests — but that doesn't change the fact that the contract is bytes.

## Change

```python
def to_ical(self) -> bytes:
    return f"{self.latitude};{self.longitude}".encode()
```

Test expectations in test_prop_vGeo updated from str to bytes, and a new test file src/icalendar/tests/prop/test_vGeo.py covers the bytes return type, list-vs-tuple input, negative coordinates, integer inputs serialised as floats, and a full from_ical → to_ical round trip.

All 14,682 existing tests still pass.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1478.org.readthedocs.build/en/1478/

<!-- readthedocs-preview icalendar end -->