### PR TITLE
Add gh-profiler CI workflow

### DIFF
--- a/.github/workflows/profile-contributors.yml
+++ b/.github/workflows/profile-contributors.yml
@@ -1,0 +1,73 @@
+# Run gh-profiler against the author of each new issue and PR.
+# See https://github.com/ehmatthes/gh-profiler
+
+name: Profile contributors
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  profile-author:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff  # v6
+
+      - name: Install gh-profiler
+        run: uv tool install gh-profiler==0.8.3
+
+      - name: Determine target login and issue number
+        id: meta
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            echo "login=${{ github.event.issue.user.login }}" >> "$GITHUB_OUTPUT"
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "login=${{ github.event.pull_request.user.login }}" >> "$GITHUB_OUTPUT"
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run gh-profiler
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh-profiler "${{ steps.meta.outputs.login }}" --concise > concise.txt
+          gh-profiler "${{ steps.meta.outputs.login }}" > full.txt
+
+      - name: Comment on issue or PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          {
+            echo "Profile summary:"
+            echo
+            echo '```text'
+            cat concise.txt
+            echo '```'
+            echo
+            echo '<details>'
+            echo '<summary>Full profile</summary>'
+            echo
+            echo '```text'
+            cat full.txt
+            echo '```'
+            echo
+            echo '</details>'
+          } > body.txt
+
+          jq -Rs '{body: .}' body.txt > payload.json
+
+          gh api \
+            repos/${{ github.repository }}/issues/${{ steps.meta.outputs.number }}/comments \
+            --input payload.json

--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -111,6 +111,7 @@ Report suspected violations
 ```````````````````````````
 
 To report a suspected violation of this AI policy, see the `Reporting an issue <https://pycal.org/code-of-conduct/#reporting-an-issue>`_ section in the Python Calendaring Ecosystem's Code of Conduct.
+The maintainers will investigate and collect information from various sources, including but not limited to the use of automated GitHub workflows to identify suspected AI use.
 The maintainers may close pull requests without providing feedback that they deem to be spam, AI slop, abuse, or that do not comply with :ref:`pull request requirements <pull-request-requirements>`.
 The maintainers may also take further action, including suspend, ban, or report GitHub users, as described in Python Calendaring Ecosystem's `Code of Conduct <https://pycal.org/code-of-conduct/>`_.
 

--- a/news/1484.internal
+++ b/news/1484.internal
@@ -1,0 +1,1 @@
+Add gh-profiler workflow to help triage AI-generated contributions.

--- a/news/1484.internal
+++ b/news/1484.internal
@@ -1,1 +1,1 @@
-Add gh-profiler workflow to help triage AI-generated contributions.
+Add gh-profiler workflow to help triage AI-generated contributions. @SashankBhamidi


### PR DESCRIPTION
Closes #1484

Adds the link-only variant of the gh-profiler workflow so we get a contributor profile link on every new PR and issue.