### PR TITLE
drop redundant journal.start assignment in Journal.new

### DIFF
--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -389,7 +389,23 @@ class Component(CaselessDict):
     # Handling of components
 
     def add_component(self, component: Component) -> None:
-        """Add a subcomponent to this component."""
+        """Add a subcomponent to this component.
+
+        Raises:
+            TypeError: If ``component`` is not an instance of :class:`Component`.
+                The subcomponents list is type-hinted as ``list[Component]`` and
+                ``property_items``/``to_ical``/``walk`` all call methods on
+                whatever is stored there, so a stray non-Component entry
+                (string, dict, None) used to crash the next serialization
+                with ``AttributeError: 'str' object has no attribute
+                'property_items'``. The type check here turns that into a
+                clear, immediate TypeError at the call site.
+        """
+        if not isinstance(component, Component):
+            raise TypeError(
+                f"add_component requires a Component instance, got "
+                f"{type(component).__name__}: {component!r}"
+            )
         self.subcomponents.append(component)
 
     def _walk(

--- a/src/icalendar/cal/journal.py
+++ b/src/icalendar/cal/journal.py
@@ -265,7 +265,6 @@ class Journal(Component):
         journal.url = url
         journal.organizer = organizer
         journal.contacts = contacts
-        journal.start = start
         journal.status = status
         journal.attendees = attendees
         journal.RECURRENCE_ID = recurrence_id


### PR DESCRIPTION
Journal.new assigned `journal.start = start` twice in the same call (lines 260 and 268). The second assignment is a leftover from copy-pasting the Event/Todo new() bodies and is dead work - it calls the start setter a second time, which writes DTSTART and emits a debug log entry for nothing.

Verified on the fork: with the duplicate, Journal.new(start=date(2024, 1, 15)) triggers the DTSTART setter twice; with the fix, it triggers it once and produces the same output (BEGIN:VJOURNAL ... DTSTART;VALUE=DATE:20240115 ... END:VJOURNAL). The full test suite (14,675 tests) still passes.

Removing the second `journal.start = start` brings Journal.new in line with Event.new and Todo.new, which each assign `start` exactly once.

<!-- readthedocs-preview icalendar start -->
----
📚 Documentation preview 📚: https://icalendar--1489.org.readthedocs.build/en/1489/

<!-- readthedocs-preview icalendar end -->