### PR TITLE
docs: clarify new() docstrings for FreeBusy, Availability, and Journal

### DIFF
--- a/news/1473.documentation
+++ b/news/1473.documentation
@@ -1,0 +1,5 @@
+Clarified the :meth:`icalendar.cal.free_busy.FreeBusy.new`,
+:meth:`icalendar.cal.availability.Availability.new`, and
+:meth:`icalendar.cal.journal.Journal.new` docstrings so their summaries and
+documented parameters match the Python implementations. This change was drafted
+with OpenAI Codex and reviewed by @axelray-dev.

--- a/src/icalendar/cal/availability.py
+++ b/src/icalendar/cal/availability.py
@@ -263,7 +263,7 @@ class Availability(Component):
         uid: str | uuid.UUID | None = None,
         url: str | None = None,
     ):
-        """Create a new event with all required properties.
+        """Create a new availability with all required properties.
 
         This creates a new Availability in accordance with :rfc:`7953`.
 

--- a/src/icalendar/cal/free_busy.py
+++ b/src/icalendar/cal/free_busy.py
@@ -106,25 +106,25 @@ class FreeBusy(Component):
         uid: str | uuid.UUID | None = None,
         url: str | None = None,
     ):
-        """Create a new alarm with all required properties.
+        """Create a new FreeBusy with all required properties.
 
-        This creates a new Alarm in accordance with :rfc:`5545`.
+        This creates a new FreeBusy in accordance with :rfc:`5545`.
 
         Parameters:
-            comments: The :attr:`~icalendar.cal.component.Component.comments` of the component.
-            concepts: The :attr:`~icalendar.cal.component.Component.concepts` of the component.
-            contacts: The :attr:`contacts` of the component.
-            end: The :attr:`end` of the component.
-            links: The :attr:`~icalendar.cal.component.Component.links` of the component.
-            organizer: The :attr:`organizer` of the component.
-            refids: :attr:`~icalendar.cal.component.Component.refids` of the component.
-            related_to: :attr:`~icalendar.cal.component.Component.related_to` of the component.
-            stamp: The :attr:`~icalendar.cal.component.Component.DTSTAMP` of the component.
+            comments: The :attr:`~icalendar.cal.component.Component.comments` of the free_busy.
+            concepts: The :attr:`~icalendar.cal.component.Component.concepts` of the free_busy.
+            contacts: The :attr:`contacts` of the free_busy.
+            end: The :attr:`end` of the free_busy.
+            links: The :attr:`~icalendar.cal.component.Component.links` of the free_busy.
+            organizer: The :attr:`organizer` of the free_busy.
+            refids: :attr:`~icalendar.cal.component.Component.refids` of the free_busy.
+            related_to: :attr:`~icalendar.cal.component.Component.related_to` of the free_busy.
+            stamp: The :attr:`~icalendar.cal.component.Component.DTSTAMP` of the free_busy.
                 If None, this is set to the current time.
-            start: The :attr:`start` of the component.
-            uid: The :attr:`uid` of the component.
+            start: The :attr:`start` of the free_busy.
+            uid: The :attr:`uid` of the free_busy.
                 If None, this is set to a new :func:`uuid.uuid4`.
-            url: The :attr:`url` of the component.
+            url: The :attr:`url` of the free_busy.
 
         Returns:
             :class:`FreeBusy`

--- a/src/icalendar/cal/free_busy.py
+++ b/src/icalendar/cal/free_busy.py
@@ -111,20 +111,20 @@ class FreeBusy(Component):
         This creates a new FreeBusy in accordance with :rfc:`5545`.
 
         Parameters:
-            comments: The :attr:`~icalendar.cal.component.Component.comments` of the free_busy.
-            concepts: The :attr:`~icalendar.cal.component.Component.concepts` of the free_busy.
-            contacts: The :attr:`contacts` of the free_busy.
-            end: The :attr:`end` of the free_busy.
-            links: The :attr:`~icalendar.cal.component.Component.links` of the free_busy.
-            organizer: The :attr:`organizer` of the free_busy.
-            refids: :attr:`~icalendar.cal.component.Component.refids` of the free_busy.
-            related_to: :attr:`~icalendar.cal.component.Component.related_to` of the free_busy.
-            stamp: The :attr:`~icalendar.cal.component.Component.DTSTAMP` of the free_busy.
+            comments: The :attr:`~icalendar.cal.component.Component.comments` of the FreeBusy.
+            concepts: The :attr:`~icalendar.cal.component.Component.concepts` of the FreeBusy.
+            contacts: The :attr:`contacts` of the FreeBusy.
+            end: The :attr:`end` of the FreeBusy.
+            links: The :attr:`~icalendar.cal.component.Component.links` of the FreeBusy.
+            organizer: The :attr:`organizer` of the FreeBusy.
+            refids: :attr:`~icalendar.cal.component.Component.refids` of the FreeBusy.
+            related_to: :attr:`~icalendar.cal.component.Component.related_to` of the FreeBusy.
+            stamp: The :attr:`~icalendar.cal.component.Component.DTSTAMP` of the FreeBusy.
                 If None, this is set to the current time.
-            start: The :attr:`start` of the free_busy.
-            uid: The :attr:`uid` of the free_busy.
+            start: The :attr:`start` of the FreeBusy.
+            uid: The :attr:`uid` of the FreeBusy.
                 If None, this is set to a new :func:`uuid.uuid4`.
-            url: The :attr:`url` of the free_busy.
+            url: The :attr:`url` of the FreeBusy.
 
         Returns:
             :class:`FreeBusy`

--- a/src/icalendar/cal/journal.py
+++ b/src/icalendar/cal/journal.py
@@ -217,7 +217,6 @@ class Journal(Component):
             contacts: The :attr:`contacts` of the journal.
             created: The :attr:`~icalendar.Component.created` of the journal.
             description: The :attr:`description` of the journal.
-            end: The :attr:`end` of the journal.
             last_modified: The :attr:`~icalendar.Component.last_modified` of
                 the journal.
             links: The :attr:`~icalendar.Component.links` of the journal.


### PR DESCRIPTION
See #1473. Audit new() method docstrings against RFC 5545/7953 and the Python implementation.

Fixes three copy-paste/stale-parameter bugs found during review:

- free_busy.py: docstring said "Create a new alarm" and used generic "component" references instead of "free_busy". Corrected to match the FreeBusy class.
- availability.py: first line said "Create a new event" instead of "Create a new availability". Corrected to match the Availability class.
- journal.py: docstring documented an "end" parameter that does not exist in Journal.new(). The class has "end = start" at line 130 (alias), but the new() signature has no end parameter. Removed the stale entry.

The remaining four files (alarm, available, event, todo) were checked and their docstrings match their signatures.

Changelog entry added in news/1473.documentation per towncrier convention.

## Responsible AI use

- Model/tool: OpenAI Codex
- Usage: audited docstrings against Python signatures and RFC references, drafted the small documentation changes
- Human validation: Axel reviewed the diff, checked the signatures against the source, and verified CI/docs

<!-- readthedocs-preview icalendar start -->
----
Documentation preview: https://icalendar--1490.org.readthedocs.build/en/1490/
<!-- readthedocs-preview icalendar end -->