### PR TITLE
docs: clarify optional properties in Alarm.new() docstring

### DIFF
--- a/src/icalendar/cal/alarm.py
+++ b/src/icalendar/cal/alarm.py
@@ -322,14 +322,14 @@ class Alarm(Component):
         This creates a new Alarm in accordance with :rfc:`5545`.
 
         Parameters:
-            attendees: The :attr:`attendees` of the alarm.
-            concepts: The :attr:`~icalendar.cal.component.Component.concepts` of the alarm.
-            description: The :attr:`description` of the alarm.
-            links: The :attr:`~icalendar.cal.component.Component.links` of the alarm.
-            refids: :attr:`~icalendar.cal.component.Component.refids` of the alarm.
-            related_to: :attr:`~icalendar.cal.component.Component.related_to` of the alarm.
-            summary: The :attr:`summary` of the alarm.
-            uid: The :attr:`uid` of the alarm.
+            attendees: Optional. The :attr:`attendees` of the alarm.
+            concepts: Optional. The :attr:`~icalendar.cal.component.Component.concepts` of the alarm.
+            description: Optional. The :attr:`description` of the alarm.
+            links: Optional. The :attr:`~icalendar.cal.component.Component.links` of the alarm.
+            refids: Optional. :attr:`~icalendar.cal.component.Component.refids` of the alarm.
+            related_to: Optional. :attr:`~icalendar.cal.component.Component.related_to` of the alarm.
+            summary: Optional. The :attr:`summary` of the alarm.
+            uid: Optional. The :attr:`uid` of the alarm.
 
         Returns:
             :class:`Alarm`


### PR DESCRIPTION
## Linked issue

Closes #1473

## Description

This PR adds "Optional." to each parameter description in the
`Alarm.new()` docstring to clarify that these parameters are optional.

## Checklist

- [ ] I've added a change log entry to `/news`, following the instructions in Change log entry format.
- [x] I've added or updated tests if applicable. *(N/A — docs-only change)*
- [x] I've run and ensured all tests pass locally by following Run tests.
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.

## Additional information

Docs-only change — no functional code modified.