### PR TITLE
Ensure the news fragment has a correct filename

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,6 +19,7 @@ on:
       - '.readthedocs.yaml'
       - '.vale.ini'
       - 'uv.lock'
+      - 'news/*.*'
 
 jobs:
   docs:
@@ -46,6 +47,9 @@ jobs:
 
       - name: Create Python virtual environment, install requirements
         run: make .venv PYTHONVERSION=${{ matrix.python-version }}
+
+      - name: Check for news fragment
+        run: make changes-check PYTHONVERSION=${{ matrix.python-version }}
 
       - name: Build HTML documentation
         run: make html PYTHONVERSION=${{ matrix.python-version }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,4 +1,4 @@
-name: Check news fragements filenames, build documentation, check links, spelling, grammar, and style
+name: Check news fragments filenames, build documentation, check links, spelling, grammar, and style
 on:
   push:
     branches:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,4 +1,4 @@
-name: Build documentation, check links, spelling, grammar, and style
+name: Check news fragements filenames, build documentation, check links, spelling, grammar, and style
 on:
   push:
     branches:
@@ -48,7 +48,7 @@ jobs:
       - name: Create Python virtual environment, install requirements
         run: make .venv PYTHONVERSION=${{ matrix.python-version }}
 
-      - name: Check for news fragment
+      - name: Check news fragments filenames
         run: make changes-check PYTHONVERSION=${{ matrix.python-version }}
 
       - name: Build HTML documentation

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,10 @@ rtd-pr-preview: rtd-prepare .venv ## Build pull request preview on Read the Docs
 # /deployment
 
 # release
+.PHONY: changes-check
+changes-check: dev
+	$(TOWNCRIERPATH) check
+
 .PHONY: changes-draft
 changes-draft: dev
 	@test -n "$(VERSION)" || (echo "VERSION is not set. Run 'export VERSION=x.y.z' first." && exit 1)

--- a/news/1499.internal
+++ b/news/1499.internal
@@ -1,0 +1,1 @@
+Ensure that news fragment filenames are valid in CI. @stevepiercy

--- a/news/666.chore_error
+++ b/news/666.chore_error
@@ -1,1 +1,0 @@
-file. @stevepiercy

--- a/news/666.chore_error
+++ b/news/666.chore_error
@@ -1,0 +1,1 @@
+file. @stevepiercy


### PR DESCRIPTION
During the last release, we caught a news fragment with an incorrect filename. This check should run in CI and pass, so we don't have to think about it.