### PR TITLE
Fix line folding across escape sequences

### DIFF
--- a/news/1501.bugfix
+++ b/news/1501.bugfix
@@ -1,0 +1,1 @@
+Avoid folding content lines between escape prefixes and their escaped characters. AI disclosure: I used GPT-5 Codex to help draft and refine this change and its tests; I reviewed and validated the output locally. @kingrubic

--- a/src/icalendar/parser/string.py
+++ b/src/icalendar/parser/string.py
@@ -129,27 +129,31 @@ def _foldline(line: str, limit: int = 75, fold_sep: str = "\r\n ") -> str:
     assert isinstance(line, str)
     assert "\n" not in line
 
-    # Use a fast and simple variant for the common case that line is all ASCII.
-    try:
-        line.encode("ascii")
-    except (UnicodeEncodeError, UnicodeDecodeError):
-        pass
-    else:
-        return fold_sep.join(
-            line[i : i + limit - 1] for i in range(0, len(line), limit - 1)
-        )
-
-    ret_chars: list[str] = []
+    folded_lines: list[str] = []
+    current_chars: list[str] = []
     byte_count = 0
     for char in line:
         char_byte_len = len(char.encode(DEFAULT_ENCODING))
+        if current_chars and byte_count + char_byte_len >= limit:
+            # For compatibility with existing clients, avoid splitting escaped
+            # values such as TEXT backslash escapes or RFC 6868 parameter
+            # escapes across a folded line boundary. See issue #1501.
+            if len(current_chars) > 1 and current_chars[-1] in r"\^":
+                escaped_prefix = current_chars.pop()
+                folded_lines.append("".join(current_chars))
+                current_chars = [escaped_prefix]
+                byte_count = len(escaped_prefix.encode(DEFAULT_ENCODING))
+            else:
+                folded_lines.append("".join(current_chars))
+                current_chars = []
+                byte_count = 0
+        current_chars.append(char)
         byte_count += char_byte_len
-        if byte_count >= limit:
-            ret_chars.append(fold_sep)
-            byte_count = char_byte_len
-        ret_chars.append(char)
 
-    return "".join(ret_chars)
+    if current_chars:
+        folded_lines.append("".join(current_chars))
+
+    return fold_sep.join(folded_lines)
 
 
 foldline = deprecate_for_version_8(_foldline)

--- a/src/icalendar/tests/test_parsing.py
+++ b/src/icalendar/tests/test_parsing.py
@@ -9,7 +9,13 @@ from icalendar import vBinary, vRecur
 from icalendar.cal.calendar import Calendar
 from icalendar.cal.component_factory import ComponentFactory
 from icalendar.cal.event import Event
-from icalendar.parser import Contentline, Parameters, _escape_char, _unescape_char
+from icalendar.parser import (
+    Contentline,
+    Parameters,
+    _escape_char,
+    _foldline,
+    _unescape_char,
+)
 
 
 @pytest.mark.parametrize(
@@ -142,6 +148,49 @@ def test_description_parsed_properly_issue_53(events):
         b"July 12 at 6:30 PM"
         in events.issue_53_description_parsed_properly["DESCRIPTION"].to_ical()
     )
+
+
+@pytest.mark.parametrize(
+    "escape_sequence",
+    [
+        r"\n",
+        r"\N",
+        r"\,",
+        r"\;",
+        r"\\",
+        "^n",
+        "^^",
+        "^'",
+    ],
+)
+@pytest.mark.parametrize("line_limit", range(60, 91))
+def test_foldline_does_not_split_escape_sequences_issue_1501(
+    escape_sequence, line_limit
+):
+    """Issue #1501 - line folding must not split escape sequences."""
+    prefix = "DESCRIPTION:" + ("a" * (line_limit - len("DESCRIPTION:") - 2))
+    line = prefix + escape_sequence + "after fold"
+
+    folded = _foldline(line, limit=line_limit)
+
+    assert "\r\n " in folded
+    assert (escape_sequence[0] + "\r\n " + escape_sequence[1]) not in folded
+
+
+@pytest.mark.parametrize("escape_sequence", [r"\n", "^n"])
+def test_foldline_does_not_split_escape_sequences_across_multiple_lines_issue_1501(
+    escape_sequence,
+):
+    """Issue #1501 - escape-aware folding applies after the first fold too."""
+    line_limit = 60
+    prefix = "DESCRIPTION:" + ("a" * (line_limit - len("DESCRIPTION:") - 2))
+    repeated_segment = escape_sequence + ("b" * (line_limit - len(escape_sequence) - 1))
+    line = prefix + repeated_segment + escape_sequence + "after fold"
+
+    folded = _foldline(line, limit=line_limit)
+
+    assert folded.count("\r\n ") >= 2
+    assert (escape_sequence[0] + "\r\n " + escape_sequence[1]) not in folded
 
 
 def test_raises_value_error_for_properties_without_parent_pull_179():


### PR DESCRIPTION
## Summary
- fixes #1501 by avoiding folded line breaks between escape prefixes and their escaped characters
- applies to TEXT backslash escapes (`\n`, `\,`, etc.) and RFC 6868 parameter escapes (`^n`, `^^`, `^\'`)
- adds a regression test covering both escape families
- adds a towncrier bugfix fragment

## Verification
- `uv run pytest src/icalendar/tests/test_parsing.py -k '1501'`
- `uv run pytest src/icalendar/tests/test_parsing.py`
- `uv run pytest` (16090 passed, 28 skipped)
- `uv run ruff check src/icalendar/parser/string.py src/icalendar/tests/test_parsing.py`
- `uv run ruff format --check src/icalendar/parser/string.py src/icalendar/tests/test_parsing.py`