### PR TITLE
docs: clarify Availability.new() optional and auto-generated properties

### DIFF
--- a/news/1473.documentation.1
+++ b/news/1473.documentation.1
@@ -1,0 +1,1 @@
+Clarified optional parameters and auto-generated ``UID`` and ``DTSTAMP`` values in the :meth:`~icalendar.cal.availability.Availability.new` docstring, and fixed a copy-paste summary that referred to an event. AI disclosure: Grok assisted with reviewing the implementation and drafting the docstring update. @checkzhao8888

--- a/src/icalendar/cal/availability.py
+++ b/src/icalendar/cal/availability.py
@@ -263,36 +263,38 @@ class Availability(Component):
         uid: str | uuid.UUID | None = None,
         url: str | None = None,
     ):
-        """Create a new event with all required properties.
+        """Create a new availability.
 
         This creates a new Availability in accordance with :rfc:`7953`.
 
         Parameters:
-            busy_type: The :attr:`busy_type` of the availability.
-            categories: The :attr:`categories` of the availability.
-            classification: The :attr:`classification` of the availability.
-            comments: The :attr:`~icalendar.cal.component.Component.comments` of the availability.
-            concepts: The :attr:`~icalendar.cal.component.Component.concepts` of the availability.
-            contacts: The :attr:`contacts` of the availability.
-            created: The :attr:`~icalendar.cal.component.Component.created` of the availability.
-            description: The :attr:`description` of the availability.
-            end: The :attr:`end` of the availability.
-            last_modified: The :attr:`~icalendar.cal.component.Component.last_modified` of the
+            busy_type: Optional. The :attr:`busy_type` of the availability.
+            categories: Optional. The :attr:`categories` of the availability.
+            classification: Optional. The :attr:`classification` of the availability.
+            comments: Optional. The :attr:`~icalendar.cal.component.Component.comments` of the availability.
+            components: Optional. :class:`~icalendar.cal.available.Available` subcomponents to add.
+            concepts: Optional. The :attr:`~icalendar.cal.component.Component.concepts` of the availability.
+            contacts: Optional. The :attr:`contacts` of the availability.
+            created: Optional. The :attr:`~icalendar.cal.component.Component.created` of the availability.
+            description: Optional. The :attr:`description` of the availability.
+            end: Optional. The :attr:`end` of the availability.
+            last_modified: Optional. The :attr:`~icalendar.cal.component.Component.last_modified` of the
                 availability.
-            links: The :attr:`~icalendar.cal.component.Component.links` of the availability.
-            location: The :attr:`location` of the availability.
-            organizer: The :attr:`organizer` of the availability.
-            refids: :attr:`~icalendar.cal.component.Component.refids` of the availability.
-            related_to: :attr:`~icalendar.cal.component.Component.related_to` of the availability.
-            sequence: The :attr:`sequence` of the availability.
+            links: Optional. The :attr:`~icalendar.cal.component.Component.links` of the availability.
+            location: Optional. The :attr:`location` of the availability.
+            organizer: Optional. The :attr:`organizer` of the availability.
+            priority: Optional. The :attr:`priority` of the availability.
+            refids: Optional. :attr:`~icalendar.cal.component.Component.refids` of the availability.
+            related_to: Optional. :attr:`~icalendar.cal.component.Component.related_to` of the availability.
+            sequence: Optional. The :attr:`sequence` of the availability.
             stamp: The :attr:`~icalendar.cal.component.Component.stamp` of the availability.
-                If None, this is set to the current time.
-            start: The :attr:`start` of the availability.
-            subcomponents: The :attr:`~icalendar.cal.component.Component.subcomponents` of the availability.
-            summary: The :attr:`summary` of the availability.
+                If ``None``, this is set to the current UTC time.
+            start: Optional. The :attr:`start` of the availability.
+            subcomponents: Optional. The :attr:`~icalendar.cal.component.Component.subcomponents` of the availability.
+            summary: Optional. The :attr:`summary` of the availability.
             uid: The :attr:`~icalendar.cal.component.Component.uid` of the availability.
                 If ``None``, this is set to a new :func:`uuid.uuid4`.
-            url: The :attr:`url` of the availability.
+            url: Optional. The :attr:`url` of the availability.
 
         Returns:
             :class:`Availability`


### PR DESCRIPTION
## Linked issue

- [x] See #1473

## Description

Clarifies the `Availability.new()` docstring to align with RFC terminology and match the style used in other `new()` docstring updates (for example, #1459 and #1504).

Changes:
- Fix the copy-paste summary that incorrectly said "Create a new event".
- Mark optional parameters explicitly.
- Document auto-generated `UID` and `DTSTAMP` values when arguments are `None`.
- Document the previously undocumented `components` and `priority` parameters.

AI disclosure: Grok assisted with reviewing the implementation, comparing existing `new()` docstring patterns, and drafting the update.

## Checklist

- [x] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.