### PR TITLE
docs: clarify Journal.new() and Available.new() docstrings

### DIFF
--- a/news/1473.documentation.3
+++ b/news/1473.documentation.3
@@ -1,0 +1,1 @@
+Clarified optional parameters and auto-generated ``UID`` and ``DTSTAMP`` values in the :meth:`~icalendar.cal.journal.Journal.new` and :meth:`~icalendar.cal.available.Available.new` docstrings, and removed a nonexistent ``end`` parameter from the Journal docstring. AI disclosure: Grok assisted with reviewing the implementations and drafting the docstring updates. @checkzhao8888

--- a/src/icalendar/cal/available.py
+++ b/src/icalendar/cal/available.py
@@ -118,36 +118,36 @@ class Available(Component):
         summary: str | None = None,
         uid: str | uuid.UUID | None = None,
     ):
-        """Create a new Available component with all required properties.
+        """Create a new available component.
 
         This creates a new Available component in accordance with :rfc:`7953`.
 
         Parameters:
-            categories: The :attr:`categories` of the Available component.
-            comments: The :attr:`~icalendar.Component.comments` of the Available
+            categories: Optional. The :attr:`categories` of the Available component.
+            comments: Optional. The :attr:`~icalendar.Component.comments` of the Available
                 component.
-            concepts: The :attr:`~icalendar.Component.concepts` of the Available
+            concepts: Optional. The :attr:`~icalendar.Component.concepts` of the Available
                 component.
-            contacts: The :attr:`contacts` of the Available component.
-            created: The :attr:`~icalendar.Component.created` of the Available
+            contacts: Optional. The :attr:`contacts` of the Available component.
+            created: Optional. The :attr:`~icalendar.Component.created` of the Available
                 component.
-            description: The :attr:`description` of the Available component.
-            end: The :attr:`end` of the Available component.
-            last_modified: The :attr:`~icalendar.Component.last_modified` of the
+            description: Optional. The :attr:`description` of the Available component.
+            end: Optional. The :attr:`end` of the Available component.
+            last_modified: Optional. The :attr:`~icalendar.Component.last_modified` of the
                 Available component.
-            links: The :attr:`~icalendar.Component.links` of the Available component.
-            location: The :attr:`location` of the Available component.
-            recurrence_id: The :attr:`RECURRENCE_ID` of the Available component.
-            refids: :attr:`~icalendar.Component.refids` of the Available component.
-            related_to: :attr:`~icalendar.Component.related_to` of the Available
+            links: Optional. The :attr:`~icalendar.Component.links` of the Available component.
+            location: Optional. The :attr:`location` of the Available component.
+            recurrence_id: Optional. The :attr:`RECURRENCE_ID` of the Available component.
+            refids: Optional. :attr:`~icalendar.Component.refids` of the Available component.
+            related_to: Optional. :attr:`~icalendar.Component.related_to` of the Available
                 component.
-            sequence: The :attr:`sequence` of the Available component.
+            sequence: Optional. The :attr:`sequence` of the Available component.
             stamp: The :attr:`~icalendar.Component.stamp` of the Available component.
-                If None, this is set to the current time.
-            start: The :attr:`start` of the Available component.
-            summary: The :attr:`summary` of the Available component.
+                If ``None``, this is set to the current UTC time.
+            start: Optional. The :attr:`start` of the Available component.
+            summary: Optional. The :attr:`summary` of the Available component.
             uid: The :attr:`uid` of the Available component.
-                If None, this is set to a new :func:`uuid.uuid4`.
+                If ``None``, this is set to a new :func:`uuid.uuid4`.
 
         Returns:
             :class:`Available`

--- a/src/icalendar/cal/journal.py
+++ b/src/icalendar/cal/journal.py
@@ -203,37 +203,36 @@ class Journal(Component):
         uid: str | uuid.UUID | None = None,
         url: str | None = None,
     ):
-        """Create a new journal entry with all required properties.
+        """Create a new journal entry.
 
         This creates a new Journal in accordance with :rfc:`5545`.
 
         Parameters:
-            attendees: The :attr:`attendees` of the journal.
-            categories: The :attr:`categories` of the journal.
-            classification: The :attr:`classification` of the journal.
-            color: The :attr:`color` of the journal.
-            comments: The :attr:`~icalendar.Component.comments` of the journal.
-            concepts: The :attr:`~icalendar.Component.concepts` of the journal.
-            contacts: The :attr:`contacts` of the journal.
-            created: The :attr:`~icalendar.Component.created` of the journal.
-            description: The :attr:`description` of the journal.
-            end: The :attr:`end` of the journal.
-            last_modified: The :attr:`~icalendar.Component.last_modified` of
+            attendees: Optional. The :attr:`attendees` of the journal.
+            categories: Optional. The :attr:`categories` of the journal.
+            classification: Optional. The :attr:`classification` of the journal.
+            color: Optional. The :attr:`color` of the journal.
+            comments: Optional. The :attr:`~icalendar.Component.comments` of the journal.
+            concepts: Optional. The :attr:`~icalendar.Component.concepts` of the journal.
+            contacts: Optional. The :attr:`contacts` of the journal.
+            created: Optional. The :attr:`~icalendar.Component.created` of the journal.
+            description: Optional. The :attr:`description` of the journal.
+            last_modified: Optional. The :attr:`~icalendar.Component.last_modified` of
                 the journal.
-            links: The :attr:`~icalendar.Component.links` of the journal.
-            organizer: The :attr:`organizer` of the journal.
-            recurrence_id: The :attr:`RECURRENCE_ID` of the journal.
-            refids: :attr:`~icalendar.Component.refids` of the journal.
-            related_to: :attr:`~icalendar.Component.related_to` of the journal.
-            sequence: The :attr:`sequence` of the journal.
+            links: Optional. The :attr:`~icalendar.Component.links` of the journal.
+            organizer: Optional. The :attr:`organizer` of the journal.
+            recurrence_id: Optional. The :attr:`RECURRENCE_ID` of the journal.
+            refids: Optional. :attr:`~icalendar.Component.refids` of the journal.
+            related_to: Optional. :attr:`~icalendar.Component.related_to` of the journal.
+            sequence: Optional. The :attr:`sequence` of the journal.
             stamp: The :attr:`~icalendar.Component.stamp` of the journal.
-                If None, this is set to the current time.
-            start: The :attr:`start` of the journal.
-            status: The :attr:`status` of the journal.
-            summary: The :attr:`summary` of the journal.
+                If ``None``, this is set to the current UTC time.
+            start: Optional. The :attr:`start` of the journal.
+            status: Optional. The :attr:`status` of the journal.
+            summary: Optional. The :attr:`summary` of the journal.
             uid: The :attr:`uid` of the journal.
-                If None, this is set to a new :func:`uuid.uuid4`.
-            url: The :attr:`url` of the journal.
+                If ``None``, this is set to a new :func:`uuid.uuid4`.
+            url: Optional. The :attr:`url` of the journal.
 
         Returns:
             :class:`Journal`


### PR DESCRIPTION
## Linked issue

- [x] See #1473

## Description

Clarifies the `Journal.new()` and `Available.new()` docstrings to align with RFC terminology and match the style used in other `new()` docstring updates (for example, #1504–#1506).

Changes:
- Replace misleading "with all required properties" summaries.
- Mark optional parameters explicitly.
- Document auto-generated `UID` and `DTSTAMP` values when arguments are `None`.
- Remove a nonexistent `end` parameter from the `Journal.new()` docstring.

AI disclosure: Grok assisted with reviewing the implementations, comparing existing `new()` docstring patterns, and drafting the updates.

## Checklist

- [x] I've added a change log entry to `/news`, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I've added or updated tests if applicable.
- [x] I've run and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I've added or edited documentation, both as docstrings to be rendered in the API documentation and narrative documentation, as necessary.