### PR TITLE
Add review pull requests to Contribute, add link to pulls

### DIFF
--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -16,8 +16,8 @@ Examples of how to contribute
 -   Report security issues per the `Security Policy <https://github.com/collective/icalendar/blob/main/SECURITY.md>`_.
 -   Report all other issues in the `issue tracker <https://github.com/collective/icalendar/issues>`_.
 -   Comment on and resolve issues.
--   Triage issues and pull requests.
--   Review, comment on, and make suggestions to change the pull request.
+-   Triage open issues and `pull requests <https://github.com/collective/icalendar/pulls>`_.
+-   Review, comment on, and make suggestions to change a pull request.
     See the GitHub documentation `Reviewing proposed changes in a pull request <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request>`_.
 -   Submit pull requests from your fork of the icalendar repository.
 -   Extend the :doc:`documentation/index`.

--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -17,6 +17,8 @@ Examples of how to contribute
 -   Report all other issues in the `issue tracker <https://github.com/collective/icalendar/issues>`_.
 -   Comment on and resolve issues.
 -   Triage issues and pull requests.
+-   Review, comment on, and make suggestions to change the pull request.
+    See the GitHub documentation `Reviewing proposed changes in a pull request <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request>`_.
 -   Submit pull requests from your fork of the icalendar repository.
 -   Extend the :doc:`documentation/index`.
 -   Create or comment on a topic in `Discussions <https://github.com/collective/icalendar/discussions>`_.

--- a/news/+contribute-review-prs.documentation
+++ b/news/+contribute-review-prs.documentation
@@ -1,0 +1,1 @@
+Added a bullet point for reviewing pull requests to "Examples of how to contribute." @stevepiercy


### PR DESCRIPTION
## Linked issue

https://github.com/collective/icalendar/discussions/1508

## Description

- Added a bullet point for reviewing pull requests to Examples of how to contribute.
- Added a link to pull requests.

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

