### PR TITLE
Don't close pull requests automatically when the anti-slop GitHub Act…

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -32,3 +32,4 @@ jobs:
           success-add-pr-labels: 'PR quality: good'
           failure-add-pr-labels: 'ai-suspicion'
           failure-pr-message: 'This pull request did not pass quality checks and AI use is suspected. Please review [Contribute](https://icalendar.readthedocs.io/en/latest/contribute/index.html) and make any necessary amendments.'
+          close-pr: false

--- a/news/+anti-slop-dont-close-on-fail.internal
+++ b/news/+anti-slop-dont-close-on-fail.internal
@@ -1,0 +1,1 @@
+Don't close pull requests automatically when the anti-slop GitHub Action fails. @stevepiercy


### PR DESCRIPTION
…ion fails

## Linked issue

- See #1533

## Description

Don't close pull requests automatically when the anti-slop GitHub Action fails.

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).