### PR TITLE
docs: correct Journal.new parameter list

### DIFF
--- a/news/1473.documentation.1
+++ b/news/1473.documentation.1
@@ -1,0 +1,1 @@
+Corrected the :meth:`icalendar.cal.journal.Journal.new` documentation so its parameter list matches the public method signature. I used AI to assist with this change. @w3lld1

--- a/src/icalendar/cal/journal.py
+++ b/src/icalendar/cal/journal.py
@@ -217,7 +217,6 @@ class Journal(Component):
             contacts: The :attr:`contacts` of the journal.
             created: The :attr:`~icalendar.Component.created` of the journal.
             description: The :attr:`description` of the journal.
-            end: The :attr:`end` of the journal.
             last_modified: The :attr:`~icalendar.Component.last_modified` of
                 the journal.
             links: The :attr:`~icalendar.Component.links` of the journal.


### PR DESCRIPTION
Remove the nonexistent end entry so the documented parameters match the public method signature.

See #1473

AI: OpenAI GPT-5.6-sol assisted with repository and issue inspection, drafting the focused documentation correction, and selecting validation checks. I reviewed the change and verified the rendered documentation and doctests.

## Linked issue

<!--
Replace `ISSUE_NUMBER` with the issue number that your pull request addresses. This links the pull request to the related issue. Choose the appropriate form.

If you completely resolve the issue, then use `"Closes"`.
GitHub will automatically close the related issue when the PR gets merged.
-->

- Closes #ISSUE_NUMBER

<!--
If you resolve only a part of the issue, then use `"See"`.
This form keeps the issue open for future work.
-->

- See #ISSUE_NUMBER

## Description

Write a description of the fixes or improvements.

## Checklist

- [ ] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [ ] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

Upload screenshots, videos, links to documentation, or any other relevant information.
