### PR TITLE
Replace parser assertions with runtime validation

### DIFF
--- a/news/1532.bugfix
+++ b/news/1532.bugfix
@@ -1,0 +1,1 @@
+Rejected invalid parser values consistently when Python optimization is enabled. I used OpenAI Codex (GPT-5) to assist with this change. @esbreeb

--- a/src/icalendar/parser/content_line.py
+++ b/src/icalendar/parser/content_line.py
@@ -123,9 +123,10 @@ class Contentline(str):
 
     def __new__(cls, value, strict=False, encoding=DEFAULT_ENCODING):
         value = to_unicode(value, encoding=encoding)
-        assert "\n" not in value, (
-            "Content line can not contain unescaped new line characters."
-        )
+        if "\n" in value:
+            raise ValueError(
+                "Content line can not contain unescaped new line characters."
+            )
         self = super().__new__(cls, value)
         self.strict = strict
         return self

--- a/src/icalendar/parser/string.py
+++ b/src/icalendar/parser/string.py
@@ -19,6 +19,9 @@ def _escape_char(text: str | bytes) -> str:
     Returns:
         The escaped text with special characters escaped.
 
+    Raises:
+        ValueError: If ``text`` is neither ``str`` nor ``bytes``.
+
     Note:
         The replacement order is critical:
 
@@ -37,7 +40,8 @@ def _escape_char(text: str | bytes) -> str:
         not part of :rfc:`5545`, which only defines ``\n`` or ``\N`` for an
         intentional line break, and doesn't give an escape form for a lone ``\r``.
     """
-    assert isinstance(text, (str, bytes))
+    if not isinstance(text, (str, bytes)):
+        raise ValueError("Text must be a string or bytes.")  # noqa: TRY004
     text = to_unicode(text)
     # NOTE: ORDER MATTERS!
     return (
@@ -61,7 +65,7 @@ escape_char = deprecate_for_version_8(_escape_char)
 """
 
 
-def _unescape_char(text: str | bytes) -> str | bytes | None:
+def _unescape_char(text: str | bytes) -> str | bytes:
     r"""Unescape iCalendar TEXT values.
 
     Reverses the escaping applied by :func:`_escape_char` according to
@@ -71,7 +75,10 @@ def _unescape_char(text: str | bytes) -> str | bytes | None:
         text: The escaped text.
 
     Returns:
-        The unescaped text, or ``None`` if ``text`` is neither ``str`` nor ``bytes``.
+        The unescaped text.
+
+    Raises:
+        ValueError: If ``text`` is neither ``str`` nor ``bytes``.
 
     Note:
         The replacement order is critical to avoid double-unescaping:
@@ -83,7 +90,8 @@ def _unescape_char(text: str | bytes) -> str | bytes | None:
         5. ``\;`` -> ``;`` (unescape semicolons)
         6. ``\\`` -> ``\`` (unescape backslashes last)
     """
-    assert isinstance(text, (str, bytes))
+    if not isinstance(text, (str, bytes)):
+        raise ValueError("Text must be a string or bytes.")  # noqa: TRY004
     # NOTE: ORDER MATTERS!
     if isinstance(text, str):
         return (
@@ -94,16 +102,14 @@ def _unescape_char(text: str | bytes) -> str | bytes | None:
             .replace("\\;", ";")
             .replace("\\\\", "\\")
         )
-    if isinstance(text, bytes):
-        return (
-            text.replace(b"\\N", b"\\n")
-            .replace(b"\r\n", b"\n")
-            .replace(b"\\n", b"\n")
-            .replace(b"\\,", b",")
-            .replace(b"\\;", b";")
-            .replace(b"\\\\", b"\\")
-        )
-    return None
+    return (
+        text.replace(b"\\N", b"\\n")
+        .replace(b"\r\n", b"\n")
+        .replace(b"\\n", b"\n")
+        .replace(b"\\,", b",")
+        .replace(b"\\;", b";")
+        .replace(b"\\\\", b"\\")
+    )
 
 
 unescape_char = deprecate_for_version_8(_unescape_char)
@@ -125,9 +131,14 @@ def _foldline(line: str, limit: int = 75, fold_sep: str = "\r\n ") -> str:
     line can be split between any two characters by inserting a CRLF
     immediately followed by a single linear white-space character (i.e.,
     SPACE or HTAB).
+
+    Raises:
+        ValueError: If ``line`` is not a string or contains a newline.
     """
-    assert isinstance(line, str)
-    assert "\n" not in line
+    if not isinstance(line, str):
+        raise ValueError("Line must be a string.")  # noqa: TRY004
+    if "\n" in line:
+        raise ValueError("Line can not contain new line characters.")
 
     # Use a fast and simple variant for the common case that line is all ASCII.
     try:

--- a/src/icalendar/tests/test_icalendar.py
+++ b/src/icalendar/tests/test_icalendar.py
@@ -6,7 +6,9 @@ from icalendar.parser import (
     Contentline,
     Contentlines,
     Parameters,
+    _escape_char,
     _foldline,
+    _unescape_char,
     dquote,
     q_join,
     q_split,
@@ -70,7 +72,7 @@ class IcalendarTestCase(unittest.TestCase):
         # N or a LATIN CAPITAL LETTER N, that is "\n" or "\N".
 
         # Newlines are not allowed in content lines
-        self.assertRaises(AssertionError, Contentline, b"1234\r\n\r\n1234")
+        self.assertRaises(ValueError, Contentline, b"1234\r\n\r\n1234")
 
         assert Contentline("1234\\n\\n1234").to_ical() == b"1234\\n\\n1234"
 
@@ -256,8 +258,11 @@ class IcalendarTestCase(unittest.TestCase):
         # I don't really get this test
         # at least just but bytes in there
         # porting it to "run" under python 2 & 3 makes it not much better
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError, match="Line must be a string"):
             _foldline("привет".encode(), limit=3)
+
+        with pytest.raises(ValueError, match="new line characters"):
+            _foldline("SUMMARY:Test\nINJECTED:Bad")
 
         assert _foldline("foobar", limit=4) == "foo\r\n bar"
         assert (
@@ -272,6 +277,14 @@ class IcalendarTestCase(unittest.TestCase):
             _foldline("DESCRIPTION:АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЬЫЪЭЮЯ")
             == "DESCRIPTION:АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЬЫЪЭ\r\n ЮЯ"
         )
+
+    def test_escape_functions_reject_invalid_types(self):
+        for function in (_escape_char, _unescape_char):
+            with (
+                self.subTest(function=function),
+                pytest.raises(ValueError, match="Text must be a string or bytes"),
+            ):
+                function(1)
 
     def test_value_double_quoting(self):
         assert dquote("Max") == "Max"


### PR DESCRIPTION
## Linked issue

- Closes #1532

## Description

Replace four runtime parser assertions with explicit `ValueError` checks. Python removes assertions when running with `-O`, which previously allowed embedded newlines through `Contentline` and `_foldline`, and caused inconsistent failures for invalid input types.

The change also updates `_unescape_char`'s return annotation and docstrings to document the new validation behavior. Existing tests now assert the stable exception type and cover every replacement branch.

## Validation

- `python -m pytest src/icalendar/tests/test_icalendar.py -q`
- Full test suite under branch coverage: 15,612 tests collected, successful
- Overall coverage: 97%
- `content_line.py` coverage: 97%
- `string.py` coverage: 97%
- `python -m ruff format --check ...`
- `python -m ruff check ...`
- `python -O` manual regression covering all five invalid input cases

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in the commit message and change log entry.
- [x] I added or updated tests.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I updated the affected parser docstrings and return annotation.

## AI disclosure

OpenAI Codex (GPT-5, 2026-07-12) assisted with issue analysis, drafting the implementation and tests, and running validation. The use is disclosed in commit `9ada5da1` and `news/1532.bugfix` as required by the project policy.
