### PR TITLE
fix: replace parser assert guards with explicit raises (#1532)

### DIFF
--- a/news/1532.bugfix
+++ b/news/1532.bugfix
@@ -1,0 +1,1 @@
+Replace parser ``assert`` guards with explicit raises so newline (``ValueError``) and type (``TypeError``) checks still run under ``python -O``. @gitcommit90

--- a/src/icalendar/parser/content_line.py
+++ b/src/icalendar/parser/content_line.py
@@ -123,9 +123,10 @@ class Contentline(str):
 
     def __new__(cls, value, strict=False, encoding=DEFAULT_ENCODING):
         value = to_unicode(value, encoding=encoding)
-        assert "\n" not in value, (
-            "Content line can not contain unescaped new line characters."
-        )
+        if "\n" in value:
+            raise ValueError(
+                "Content line can not contain unescaped new line characters."
+            )
         self = super().__new__(cls, value)
         self.strict = strict
         return self

--- a/src/icalendar/parser/string.py
+++ b/src/icalendar/parser/string.py
@@ -37,7 +37,8 @@ def _escape_char(text: str | bytes) -> str:
         not part of :rfc:`5545`, which only defines ``\n`` or ``\N`` for an
         intentional line break, and doesn't give an escape form for a lone ``\r``.
     """
-    assert isinstance(text, (str, bytes))
+    if not isinstance(text, (str, bytes)):
+        raise TypeError("text must be str or bytes")
     text = to_unicode(text)
     # NOTE: ORDER MATTERS!
     return (
@@ -83,7 +84,8 @@ def _unescape_char(text: str | bytes) -> str | bytes | None:
         5. ``\;`` -> ``;`` (unescape semicolons)
         6. ``\\`` -> ``\`` (unescape backslashes last)
     """
-    assert isinstance(text, (str, bytes))
+    if not isinstance(text, (str, bytes)):
+        raise TypeError("text must be str or bytes")
     # NOTE: ORDER MATTERS!
     if isinstance(text, str):
         return (
@@ -126,8 +128,10 @@ def _foldline(line: str, limit: int = 75, fold_sep: str = "\r\n ") -> str:
     immediately followed by a single linear white-space character (i.e.,
     SPACE or HTAB).
     """
-    assert isinstance(line, str)
-    assert "\n" not in line
+    if not isinstance(line, str):
+        raise TypeError("line must be str")
+    if "\n" in line:
+        raise ValueError("line can not contain unescaped new line characters.")
 
     # Use a fast and simple variant for the common case that line is all ASCII.
     try:

--- a/src/icalendar/tests/test_icalendar.py
+++ b/src/icalendar/tests/test_icalendar.py
@@ -70,7 +70,7 @@ class IcalendarTestCase(unittest.TestCase):
         # N or a LATIN CAPITAL LETTER N, that is "\n" or "\N".
 
         # Newlines are not allowed in content lines
-        self.assertRaises(AssertionError, Contentline, b"1234\r\n\r\n1234")
+        self.assertRaises(ValueError, Contentline, b"1234\r\n\r\n1234")
 
         assert Contentline("1234\\n\\n1234").to_ical() == b"1234\\n\\n1234"
 
@@ -256,7 +256,7 @@ class IcalendarTestCase(unittest.TestCase):
         # I don't really get this test
         # at least just but bytes in there
         # porting it to "run" under python 2 & 3 makes it not much better
-        with pytest.raises(AssertionError):
+        with pytest.raises(TypeError):
             _foldline("привет".encode(), limit=3)
 
         assert _foldline("foobar", limit=4) == "foo\r\n bar"

--- a/src/icalendar/tests/test_issue_1532_assert_to_valueerror.py
+++ b/src/icalendar/tests/test_issue_1532_assert_to_valueerror.py
@@ -1,0 +1,37 @@
+"""Issue #1532: parser guards must raise even under python -O.
+
+``assert`` is stripped by ``-O``, so newline and type guards in the parsing
+pipeline must use explicit ``if`` / ``raise`` checks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from icalendar.parser.content_line import Contentline
+from icalendar.parser.string import _escape_char, _foldline, _unescape_char
+
+
+def test_contentline_rejects_embedded_newline():
+    with pytest.raises(ValueError, match="new line"):
+        Contentline("SUMMARY:Test\nINJECTED:Bad")
+
+
+def test_foldline_rejects_embedded_newline():
+    with pytest.raises(ValueError, match="new line"):
+        _foldline("SUMMARY:Test\nINJECTED:Bad")
+
+
+def test_foldline_rejects_non_str():
+    with pytest.raises(TypeError, match="str"):
+        _foldline(b"not-a-str")  # type: ignore[arg-type]
+
+
+def test_escape_char_rejects_bad_type():
+    with pytest.raises(TypeError, match="str or bytes"):
+        _escape_char(123)  # type: ignore[arg-type]
+
+
+def test_unescape_char_rejects_bad_type():
+    with pytest.raises(TypeError, match="str or bytes"):
+        _unescape_char(123)  # type: ignore[arg-type]


### PR DESCRIPTION
Fixes #1532

Replace `assert` statements in the parsing pipeline with explicit `raise` statements so validation guards still run under `python -O`.

## Changes
- `Contentline.__new__`: newline guard now raises `ValueError`
- `_escape_char`, `_unescape_char`: type guards now raise `TypeError`
- `_foldline`: type and newline guards now raise `TypeError`/`ValueError`
- Updated existing tests that expected `AssertionError`
- Added regression tests in `test_issue_1532_assert_to_valueerror.py`
- Added towncrier news fragment

## Testing
- Focused tests: 12 passed
- Full suite: 15586 passed, 30 skipped
- Verified `-O` now raises `ValueError` for newline injection
- ruff clean on all touched files