### PR TITLE
Update Mountain Standard Time (Mexico) mapping

### DIFF
--- a/news/1546.bugfix
+++ b/news/1546.bugfix
@@ -1,0 +1,1 @@
+Updated the Windows timezone mapping for ``Mountain Standard Time (Mexico)`` to ``America/Mazatlan``, so dates after Mexico's 2022 timezone changes use the correct UTC-7 offset instead of UTC-6. I used OpenAI GPT-5.6 Sol via Rook to assist with the investigation, regression test, and drafting this change. @RobHannay

--- a/news/1546.bugfix
+++ b/news/1546.bugfix
@@ -1,1 +1,1 @@
-Updated the Windows timezone mapping for ``Mountain Standard Time (Mexico)`` to ``America/Mazatlan``, so dates after Mexico's 2022 timezone changes use the correct UTC-7 offset instead of UTC-6. I used OpenAI GPT-5.6 Sol via Rook to assist with the investigation, regression test, and drafting this change. @RobHannay
+Updated the Windows timezone mapping for ``Mountain Standard Time (Mexico)`` to ``America/Mazatlan``, so dates after Mexico's 2022 timezone changes use the correct UTC-7 offset instead of UTC-6. Prepared with AI assistance. @RobHannay

--- a/src/icalendar/tests/prop/test_windows_to_olson_mapping.py
+++ b/src/icalendar/tests/prop/test_windows_to_olson_mapping.py
@@ -16,6 +16,14 @@ def test_windows_timezone(tzp):
     assert dt == expected
 
 
+def test_mountain_standard_time_mexico(tzp):
+    """Test the current CLDR mapping for Mountain Standard Time (Mexico)."""
+    dt = vDatetime.from_ical("20260706T110000", "Mountain Standard Time (Mexico)")
+    expected = tzp.localize(datetime(2026, 7, 6, 11), "America/Mazatlan")
+    assert dt.tzinfo == expected.tzinfo
+    assert dt == expected
+
+
 @pytest.mark.parametrize("olson_id", WINDOWS_TO_OLSON.values())
 def test_olson_names(tzp, olson_id):
     """test if all mappings actually map to valid tzids"""

--- a/src/icalendar/timezone/windows_to_olson.py
+++ b/src/icalendar/timezone/windows_to_olson.py
@@ -68,7 +68,7 @@ WINDOWS_TO_OLSON = {
     "Montevideo Standard Time": "America/Montevideo",
     "Morocco Standard Time": "Africa/Casablanca",
     "Mountain Standard Time": "America/Denver",
-    "Mountain Standard Time (Mexico)": "America/Chihuahua",
+    "Mountain Standard Time (Mexico)": "America/Mazatlan",
     "Myanmar Standard Time": "Asia/Yangon",
     "N. Central Asia Standard Time": "Asia/Novosibirsk",
     "Namibia Standard Time": "Africa/Windhoek",


### PR DESCRIPTION
## Linked issue

- Closes #1546

## Description

The bundled CLDR 29 table maps `Mountain Standard Time (Mexico)` to `America/Chihuahua`, but current CLDR maps both the global and Mexico entries to `America/Mazatlan`. Those zones diverged after Mexico's 2022 timezone changes, so dates such as 6 July 2026 currently resolve at UTC-6 instead of UTC-7.

This updates the mapping to `America/Mazatlan` and adds a focused behavior regression for the July 2026 offset. It deliberately does not change `TZP.timezone()` lookup precedence: the latest revision of #1479 already checks the embedded timezone cache before provider fallbacks and would overlap with that work.

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit message and news fragment.
- [x] I checked the applicable AI terms of use, reviewed and understand the change, take responsibility for it, and confirmed the contribution is original rather than reconstructed from copyrighted material.
- [x] I added a regression test covering both configured timezone providers.
- [x] I ran and ensured all tests pass locally.
- [x] I reviewed the documentation impact; no API or narrative documentation changes are necessary for this data correction.

## Verification

- `uv run pytest -q`: 15,586 passed, 30 skipped
- `uv run pytest src/icalendar/tests/prop/test_windows_to_olson_mapping.py -q`: 216 passed
- `uv run ruff check ...`: passed
- `uv run ruff format --check ...`: passed
- `uv run towncrier build --draft`: rendered `news/1546.bugfix` successfully

---
Slack thread: https://metaviewapp.slack.com/archives/C0A3T96UMT2/p1783959558578489
Requested by: Rob

Rook session: https://rook.is/cooking/dfe003fd-a945-4099-acc2-c923b94a8b95
