### PR TITLE
Add vBinary.base64data property

### DIFF
--- a/news/1550.feature
+++ b/news/1550.feature
@@ -1,1 +1,1 @@
-Added :attr:`icalendar.prop.binary.vBinary.base64data`, a getter/setter for the Base64 string view of a BINARY property's value, so callers no longer need to call :func:`base64.b64encode`/:func:`base64.b64decode` manually. @gagana2023
+Added :attr:`vBinary.base64data <icalendar.prop.binary.vBinary.base64data>`, a getter/setter for the Base64 string view of a BINARY property's value, so callers no longer need to call :func:`base64.b64encode` or :func:`base64.b64decode` manually. @gagana2023

--- a/news/1550.feature
+++ b/news/1550.feature
@@ -1,0 +1,1 @@
+Added :attr:`icalendar.prop.binary.vBinary.base64data`, a getter/setter for the Base64 string view of a BINARY property's value, so callers no longer need to call :func:`base64.b64encode`/:func:`base64.b64decode` manually. @gagana2023

--- a/src/icalendar/prop/binary.py
+++ b/src/icalendar/prop/binary.py
@@ -36,6 +36,31 @@ class vBinary:
         except (binascii.Error, ValueError) as e:
             raise ValueError("Not valid base 64 encoding.") from e
 
+    @property
+    def base64data(self) -> str:
+        """The Base64-encoded string view of this value.
+
+        This is the same string that :meth:`to_ical` produces, exposed as
+        a plain :class:`str` instead of :class:`bytes` so you don't need to
+        call :func:`base64.b64encode` yourself. See :issue:`1550`.
+
+        Returns:
+            The Base64-encoded representation of the stored value.
+        """
+        return self.to_ical().decode("ascii")
+
+    @base64data.setter
+    def base64data(self, value: str) -> None:
+        """Set this value from a Base64-encoded string.
+
+        Parameters:
+            value: A Base64-encoded string.
+
+        Raises:
+            ValueError: If ``value`` isn't valid Base64.
+        """
+        self.obj = to_unicode(self.from_ical(value))
+
     def __eq__(self, other: object) -> bool:
         """self == other"""
         return isinstance(other, vBinary) and self.obj == other.obj

--- a/src/icalendar/tests/prop/test_vBinary.py
+++ b/src/icalendar/tests/prop/test_vBinary.py
@@ -74,3 +74,56 @@ def test_ical_value_rejects_non_base64_characters():
 def test_hash():
     obj = vBinary(b"hashed text")
     assert hash(obj) == hash(b"hashed text")
+
+
+def test_base64data_getter():
+    """base64data returns the same string as to_ical(), decoded to str."""
+    obj = vBinary(b"This is gibberish")
+    assert obj.base64data == "VGhpcyBpcyBnaWJiZXJpc2g="
+    assert obj.base64data == obj.to_ical().decode("ascii")
+
+
+def test_base64data_getter_empty():
+    """base64data of an empty value is an empty string."""
+    assert vBinary(b"").base64data == ""
+
+
+def test_base64data_setter():
+    """Setting base64data updates the underlying value."""
+    obj = vBinary(b"initial value")
+    obj.base64data = "QmluYXJ5IGRhdGEgEyBW"
+    assert obj.to_ical() == b"QmluYXJ5IGRhdGEgEyBW"
+    assert obj.from_ical(obj.to_ical()) == b"Binary data \x13 \x56"
+
+
+def test_base64data_roundtrip():
+    """Reading base64data after setting it returns the same string."""
+    obj = vBinary(b"initial value")
+    obj.base64data = "QmluYXJ5IGRhdGEgEyBW"
+    assert obj.base64data == "QmluYXJ5IGRhdGEgEyBW"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "value",
+        "áèਮ",
+        "!!!!dGV4dA==@@@@",
+        "dG V4dA==",
+        "dGV4dA==#",
+    ],
+)
+def test_base64data_setter_rejects_invalid_base64(value):
+    """The setter raises ValueError, matching from_ical's error, for bad input."""
+    obj = vBinary(b"unchanged")
+    with pytest.raises(ValueError, match=r"Not valid base 64 encoding\."):
+        obj.base64data = value
+    # a rejected assignment must not mutate the existing value
+    assert obj.to_ical() == vBinary(b"unchanged").to_ical()
+
+
+def test_base64data_setter_rejects_non_str():
+    """Non-str input raises TypeError, matching base64.b64decode's behaviour."""
+    obj = vBinary(b"unchanged")
+    with pytest.raises(TypeError):
+        obj.base64data = 12345


### PR DESCRIPTION
## Summary

- Adds `vBinary.base64data`, a getter/setter for the Base64 string view of a `vBinary` value, so callers don't have to call `base64.b64encode`/`base64.b64decode` by hand.
- The getter mirrors `to_ical()` (as `str` instead of `bytes`); the setter reuses the existing `from_ical` validation, so it raises the same `ValueError("Not valid base 64 encoding.")` on invalid input.
- Adds tests covering the getter, setter, round-trip, empty value, invalid Base64 input, and non-`str` input.
- Adds a `news/1550.feature` fragment.

Addresses #1550.

## Note on scope / #1356

Issue #1550's checklist asks to build `base64data` on top of the `bytes` attribute from #1356, and to wait for #1356 to merge first. Since #1356 is still open, this PR implements `base64data` independently against `vBinary`'s current `obj` (`str`) storage on `main`, so the feature isn't blocked.

One consequence: the checklist's last item ("replace all manual base64 encode/decode behaviour in our code base where possible", e.g. `image.py`) is **not** done here. I checked `src/icalendar/prop/image.py:59` (`params["b64data"] = value.obj`) and confirmed it currently only works because the existing test happens to pass an already-Base64-encoded string in as `obj` — `vBinary.obj` is ambiguous on `main` (sometimes raw text, sometimes pre-encoded Base64), which is exactly what #1356's `.bytes` attribute fixes. Swapping `value.obj` for `value.base64data` now would double-encode in that case and break the existing test.

**Follow-up once #1356 merges:** rebase `base64data` to read/write `self.bytes` instead of `self.obj`, then replace `value.obj` with `value.base64data` in `image.py` (the discussion this issue references: https://github.com/collective/icalendar/pull/1356#discussion_r3421606404).

## Test plan

- [x] `pytest src/icalendar/tests/prop/test_vBinary.py -v` — 22 passed
- [x] `pytest` full suite — 1556 passed, no regressions (including `test_image.py`, jCal tests)
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/icalendar/prop/binary.py` — no new errors (one pre-existing, unrelated error in `__repr__` on `main`, confirmed by running mypy against the unmodified file)
- [x] Manual REPL check of getter/setter/error paths