### PR TITLE
Fix AttributeError when VTIMEZONE has duplicate TZID properties

### DIFF
--- a/src/icalendar/cal/timezone.py
+++ b/src/icalendar/cal/timezone.py
@@ -141,10 +141,13 @@ class Timezone(Component):
         Please note that the names of the timezone are different from this name
         and may change with winter/summer time.
         """
+        tzid = self["TZID"]
+        if isinstance(tzid, list):
+            tzid = tzid[0]
         try:
-            return str(self["TZID"])
+            return str(tzid)
         except UnicodeEncodeError:
-            return self["TZID"].encode("ascii", "replace")
+            return tzid.encode("ascii", "replace")
 
     def get_transitions(
         self,

--- a/src/icalendar/tests/test_duplicate_vtimezone_tzid.py
+++ b/src/icalendar/tests/test_duplicate_vtimezone_tzid.py
@@ -1,0 +1,25 @@
+"""Duplicate TZID properties on VTIMEZONE must not crash parsing."""
+
+from icalendar import Calendar
+
+
+def test_from_ical_duplicate_vtimezone_tzid_uses_first():
+    """Two TZID lines become a list; from_ical used to AttributeError on strip."""
+    ics = (
+        "BEGIN:VCALENDAR\r\n"
+        "VERSION:2.0\r\n"
+        "PRODID:-//test//EN\r\n"
+        "BEGIN:VTIMEZONE\r\n"
+        "TZID:UTC\r\n"
+        "TZID:EST\r\n"
+        "BEGIN:STANDARD\r\n"
+        "DTSTART:19700101T000000\r\n"
+        "TZOFFSETFROM:+0000\r\n"
+        "TZOFFSETTO:+0000\r\n"
+        "END:STANDARD\r\n"
+        "END:VTIMEZONE\r\n"
+        "END:VCALENDAR\r\n"
+    )
+    cal = Calendar.from_ical(ics)
+    vtimezone = cal.walk("VTIMEZONE")[0]
+    assert vtimezone.tz_name == "UTC"

--- a/src/icalendar/tests/test_duplicate_vtimezone_tzid.py
+++ b/src/icalendar/tests/test_duplicate_vtimezone_tzid.py
@@ -4,14 +4,14 @@ from icalendar import Calendar
 
 
 def test_from_ical_duplicate_vtimezone_tzid_uses_first():
-    """Two TZID lines become a list; from_ical used to AttributeError on strip."""
+    """Two TZID lines become a list; unknown first id must still parse."""
     ics = (
         "BEGIN:VCALENDAR\r\n"
         "VERSION:2.0\r\n"
         "PRODID:-//test//EN\r\n"
         "BEGIN:VTIMEZONE\r\n"
-        "TZID:UTC\r\n"
-        "TZID:EST\r\n"
+        "TZID:Custom/WeirdZone\r\n"
+        "TZID:AlsoWeird\r\n"
         "BEGIN:STANDARD\r\n"
         "DTSTART:19700101T000000\r\n"
         "TZOFFSETFROM:+0000\r\n"
@@ -22,4 +22,4 @@ def test_from_ical_duplicate_vtimezone_tzid_uses_first():
     )
     cal = Calendar.from_ical(ics)
     vtimezone = cal.walk("VTIMEZONE")[0]
-    assert vtimezone.tz_name == "UTC"
+    assert vtimezone.tz_name == "Custom/WeirdZone"

--- a/src/icalendar/timezone/tzp.py
+++ b/src/icalendar/timezone/tzp.py
@@ -128,13 +128,16 @@ class TZP:
         """
         return self.__provider.create_timezone(timezone_component)
 
-    def clean_timezone_id(self, tzid: str) -> str:
+    def clean_timezone_id(self, tzid: str | list) -> str:
         """Return a clean version of the timezone id.
 
         Timezone ids can be a bit unclean, starting with a / for example.
         Internally, we should use this to identify timezones.
         """
-        return tzid.strip("/")
+        # Duplicate TZID properties are stored as a list; RFC allows one.
+        if isinstance(tzid, list):
+            tzid = tzid[0]
+        return str(tzid).strip("/")
 
     def timezone(self, tz_id: str) -> datetime.tzinfo | None:
         """Return a timezone with an id or None if we cannot find it."""

--- a/src/icalendar/timezone/tzp.py
+++ b/src/icalendar/timezone/tzp.py
@@ -108,7 +108,7 @@ class TZP:
         This can influence the result from timezone(): Once cached, the
         custom timezone is returned from timezone().
         """
-        _unclean_id = timezone_component["TZID"]
+        _unclean_id = timezone_component.tz_name
         _id = self.clean_timezone_id(_unclean_id)
         if (
             not self.__provider.knows_timezone_id(_id)
@@ -128,16 +128,13 @@ class TZP:
         """
         return self.__provider.create_timezone(timezone_component)
 
-    def clean_timezone_id(self, tzid: str | list) -> str:
+    def clean_timezone_id(self, tzid: str) -> str:
         """Return a clean version of the timezone id.
 
         Timezone ids can be a bit unclean, starting with a / for example.
         Internally, we should use this to identify timezones.
         """
-        # Duplicate TZID properties are stored as a list; RFC allows one.
-        if isinstance(tzid, list):
-            tzid = tzid[0]
-        return str(tzid).strip("/")
+        return tzid.strip("/")
 
     def timezone(self, tz_id: str) -> datetime.tzinfo | None:
         """Return a timezone with an id or None if we cannot find it."""


### PR DESCRIPTION
Calendar.from_ical hits AttributeError when duplicate TZID in VTIMEZONE. This PR fixes the regression with a focused test covering the case. claimed