### PR TITLE
Fix AttributeError when VALUE parameter is a comma-separated list

### DIFF
--- a/src/icalendar/parser/parameter.py
+++ b/src/icalendar/parser/parameter.py
@@ -208,6 +208,8 @@ def single_string_parameter(func: Callable | None = None, upper=False):
         def fget(self: Parameters):
             """Get the value."""
             value = self.get(name)
+            if isinstance(value, list):
+                value = value[0] if value else None
             if value is not None and upper:
                 value = value.upper()
             return value

--- a/src/icalendar/tests/test_parameter_value_list.py
+++ b/src/icalendar/tests/test_parameter_value_list.py
@@ -1,0 +1,26 @@
+"""Comma-separated VALUE parameters must not crash Parameters.value."""
+
+from icalendar import Calendar
+from icalendar.parser.parameter import Parameters
+
+
+def test_parameters_value_uses_first_of_comma_list():
+    params = Parameters.from_ical("VALUE=DATE,DATE")
+    assert params.value == "DATE"
+
+
+def test_from_ical_value_date_comma_list():
+    ics = (
+        "BEGIN:VCALENDAR\r\n"
+        "VERSION:2.0\r\n"
+        "PRODID:-//test//EN\r\n"
+        "BEGIN:VEVENT\r\n"
+        "UID:1\r\n"
+        "DTSTART:20200101T000000Z\r\n"
+        "DTEND;VALUE=DATE,DATE:20200102\r\n"
+        "END:VEVENT\r\n"
+        "END:VCALENDAR\r\n"
+    )
+    cal = Calendar.from_ical(ics)
+    event = cal.walk("VEVENT")[0]
+    assert event["DTEND"].dt.year == 2020


### PR DESCRIPTION
Parameters.value hits AttributeError when VALUE=DATE,DATE comma list. This PR fixes the regression with a focused test covering the case.