### PR TITLE
Improve docstring for Alarm.ACKNOWLEDGED

### DIFF
--- a/src/icalendar/cal/alarm.py
+++ b/src/icalendar/cal/alarm.py
@@ -157,33 +157,31 @@ class Alarm(Component):
 
     ACKNOWLEDGED = single_utc_property(
         "ACKNOWLEDGED",
-        """This is defined in RFC 9074:
+        """The UTC date and time at which the alarm was last sent or acknowledged.
 
-    Purpose: This property specifies the UTC date and time at which the
-    corresponding alarm was last sent or acknowledged.
+        Returns a :class:`datetime.datetime` in UTC or ``None`` if not set. Setting
+        this attribute accepts a :class:`~datetime.datetime` in UTC.
 
-    This property is used to specify when an alarm was last sent or acknowledged.
-    This allows clients to determine when a pending alarm has been acknowledged
-    by a calendar user so that any alerts can be dismissed across multiple devices.
-    It also allows clients to track repeating alarms or alarms on recurring events or
-    to-dos to ensure that the right number of missed alarms can be tracked.
+        This property allows clients to track when a pending alarm was acknowledged
+        by a user, so that alerts can be dismissed across multiple devices. Clients
+        should set this to the current UTC date-time when a user acknowledges the alarm,
+        or when the alarm is triggered for email-based alerts.
 
-    Clients SHOULD set this property to the current date-time value in UTC
-    when a calendar user acknowledges a pending alarm. Certain kinds of alarms,
-    such as email-based alerts, might not provide feedback as to when the calendar user
-    sees them. For those kinds of alarms, the client SHOULD set this property
-    when the alarm is triggered and the action is successfully carried out.
+        Conforming with :rfc:`9074`, the :attr:`ACKNOWLEDGED` property can appear
+        once in an :class:`~icalendar.cal.alarm.Alarm` component.
 
-    When an alarm is triggered on a client, clients can check to see if an "ACKNOWLEDGED"
-    property is present. If it is, and the value of that property is greater than or
-    equal to the computed trigger time for the alarm, then the client SHOULD NOT trigger
-    the alarm. Similarly, if an alarm has been triggered and
-    an "alert" has been presented to a calendar user, clients can monitor
-    the iCalendar data to determine whether an "ACKNOWLEDGED" property is added or
-    changed in the alarm component. If the value of any "ACKNOWLEDGED" property
-    in the alarm changes and is greater than or equal to the trigger time of the alarm,
-    then clients SHOULD dismiss or cancel any "alert" presented to the calendar user.
-    """,
+        Example:
+            Set the acknowledged time for an alarm.
+
+            .. code-block:: pycon
+
+                >>> from datetime import datetime, timezone
+                >>> from icalendar import Alarm
+                >>> alarm = Alarm()
+                >>> alarm.ACKNOWLEDGED = datetime(2021, 3, 2, 15, 20, 24, tzinfo=timezone.utc)
+                >>> alarm.ACKNOWLEDGED
+                datetime.datetime(2021, 3, 2, 15, 20, 24, tzinfo=datetime.timezone.utc)
+        """,
     )
 
     TRIGGER = create_single_property(

--- a/src/icalendar/cal/alarm.py
+++ b/src/icalendar/cal/alarm.py
@@ -159,16 +159,12 @@ class Alarm(Component):
         "ACKNOWLEDGED",
         """The UTC date and time at which the alarm was last sent or acknowledged.
 
-        Returns a :class:`datetime.datetime` in UTC or ``None`` if not set. Setting
-        this attribute accepts a :class:`~datetime.datetime` in UTC.
+        This allows clients to determine when a pending alarm has been acknowledged
+        by a calendar user so that any alerts can be dismissed across multiple devices.
+        It also allows clients to track missed alarms for repeating or recurring events.
 
-        This property allows clients to track when a pending alarm was acknowledged
-        by a user, so that alerts can be dismissed across multiple devices. Clients
-        should set this to the current UTC date-time when a user acknowledges the alarm,
-        or when the alarm is triggered for email-based alerts.
-
-        Conforming with :rfc:`9074`, the :attr:`ACKNOWLEDGED` property can appear
-        once in an :class:`~icalendar.cal.alarm.Alarm` component.
+        Conforming with :rfc:`9074#section-5.1`, clients should set this to the
+        current date-time in UTC when a user acknowledges a pending alarm.
 
         Example:
             Set the acknowledged time for an alarm.
@@ -179,8 +175,8 @@ class Alarm(Component):
                 >>> from icalendar import Alarm
                 >>> alarm = Alarm()
                 >>> alarm.ACKNOWLEDGED = datetime(2021, 3, 2, 15, 20, 24, tzinfo=timezone.utc)
-                >>> alarm.ACKNOWLEDGED
-                datetime.datetime(2021, 3, 2, 15, 20, 24, tzinfo=datetime.timezone.utc)
+                >>> alarm.ACKNOWLEDGED.strftime("%Y-%m-%d %H:%M:%S%z")
+                '2021-03-02 15:20:24+0000'
         """,
     )
 


### PR DESCRIPTION
Addresses part of #1244. Rewrote raw RFC quote to follow pythonic docstring style with a worked example.