### PR TITLE
Fix issue 1481 parameters

### DIFF
--- a/news/1481.internal
+++ b/news/1481.internal
@@ -1,0 +1,1 @@
+Added automated tests for docstring structure and quality.

--- a/news/1481.internal
+++ b/news/1481.internal
@@ -1,1 +1,1 @@
-Added automated tests for docstring structure and quality.
+Added automated tests for docstring structure and quality. @KartavyaDikshit

--- a/news/1481.internal.1
+++ b/news/1481.internal.1
@@ -1,0 +1,1 @@
+Added automated test for docstrings that lack a Parameters section when the signature accepts parameters other than self. @VedantPatel04

--- a/src/icalendar/tests/test_docstrings.py
+++ b/src/icalendar/tests/test_docstrings.py
@@ -1,0 +1,37 @@
+import inspect
+import re
+import pytest
+import icalendar
+
+ALLOWED_HEADINGS = {
+    "Attributes", "Parameters", "Returns", "Raises", "Example", "Examples",
+    "See also", "Attention", "Caution", "Danger", "Hint", "Important", "Note", "Tip", "Todo"
+}
+
+def get_public_objects():
+    objs = []
+    # Test on the main public module for now to establish baseline
+    for name, obj in inspect.getmembers(icalendar):
+        if name.startswith('_'): 
+            continue
+        if inspect.isclass(obj) or inspect.isfunction(obj):
+            objs.append(obj)
+    return objs
+
+@pytest.mark.parametrize("obj", get_public_objects())
+def test_docstring_headings_are_valid(obj):
+    """
+    Identify section headings that are not one of the allowed types.
+    """
+    doc = inspect.getdoc(obj)
+    if not doc:
+        return
+        
+    # Match standard docstring headings (Word followed by line of --- or ===)
+    headings = re.findall(r'^([A-Z][A-Za-z]+(?: [a-z]+)*)\n[-=]+$', doc, re.MULTILINE)
+    
+    for heading in headings:
+        assert heading in ALLOWED_HEADINGS, (
+            f"Invalid docstring heading '{heading}' found in '{obj.__name__}'. "
+            f"Allowed headings are: {', '.join(sorted(ALLOWED_HEADINGS))}"
+        )

--- a/src/icalendar/tests/test_docstrings.py
+++ b/src/icalendar/tests/test_docstrings.py
@@ -23,6 +23,47 @@ ALLOWED_HEADINGS = {
     "Todo",
 }
 
+# Objects with known-bad docstring section headings.
+# As docstrings are fixed in other PRs, remove entries from this set.
+# See https://github.com/collective/icalendar/issues/1481
+KNOWN_BAD_HEADINGS = {
+    "Availability",
+    "Available",
+    "BUSYTYPE",
+    "CLASS",
+    "CUTYPE",
+    "Calendar",
+    "Conference",
+    "Event",
+    "FBTYPE",
+    "FreeBusy",
+    "Image",
+    "Journal",
+    "PARTSTAT",
+    "Parameters",
+    "RANGE",
+    "RELATED",
+    "RELTYPE",
+    "ROLE",
+    "STATUS",
+    "TRANSP",
+    "Todo",
+    "VALUE",
+    "vCalAddress",
+    "vDate",
+    "vDatetime",
+    "vDuration",
+    "vFloat",
+    "vGeo",
+    "vInt",
+    "vMonth",
+    "vPeriod",
+    "vRecur",
+    "vTime",
+    "vUTCOffset",
+    "vUri",
+}
+
 
 def get_public_objects():
     objs = []
@@ -35,17 +76,29 @@ def get_public_objects():
     return objs
 
 
-@pytest.mark.parametrize("obj", get_public_objects())
+def _obj_id(obj):
+    """Return the name of the object for parametrize IDs."""
+    return obj.__name__
+
+
+@pytest.mark.parametrize("obj", get_public_objects(), ids=_obj_id)
 def test_docstring_headings_are_valid(obj):
     """
     Identify section headings that are not one of the allowed types.
     """
+    if obj.__name__ in KNOWN_BAD_HEADINGS:
+        pytest.xfail(
+            f"'{obj.__name__}' has known-bad docstring headings (see issue #1481)"
+        )
+
     doc = inspect.getdoc(obj)
     if not doc:
         return
 
     # Match standard docstring headings (Word(s) followed by a colon)
-    headings = re.findall(r"^[ \t]*([A-Z][A-Za-z]+(?: [A-Za-z]+)*):[ \t]*$", doc, re.MULTILINE)
+    headings = re.findall(
+        r"^[ \t]*([A-Z][A-Za-z]+(?: [A-Za-z]+)*):(?=\s|$)", doc, re.MULTILINE
+    )
 
     for heading in headings:
         assert heading in ALLOWED_HEADINGS, (

--- a/src/icalendar/tests/test_docstrings.py
+++ b/src/icalendar/tests/test_docstrings.py
@@ -44,8 +44,8 @@ def test_docstring_headings_are_valid(obj):
     if not doc:
         return
 
-    # Match standard docstring headings (Word followed by line of --- or ===)
-    headings = re.findall(r"^([A-Z][A-Za-z]+(?: [a-z]+)*)\n[-=]+$", doc, re.MULTILINE)
+    # Match standard docstring headings (Word(s) followed by a colon)
+    headings = re.findall(r"^[ \t]*([A-Z][A-Za-z]+(?: [A-Za-z]+)*):[ \t]*$", doc, re.MULTILINE)
 
     for heading in headings:
         assert heading in ALLOWED_HEADINGS, (

--- a/src/icalendar/tests/test_docstrings.py
+++ b/src/icalendar/tests/test_docstrings.py
@@ -93,7 +93,9 @@ def test_docstring_headings_are_valid(obj):
     """
     if obj.__name__ in KNOWN_BAD_HEADINGS:
         pytest.xfail(
-            f"'{obj.__module__}.{obj.__qualname__}' has a known bad docstring heading (see issue #1481)"
+            f"'{obj.__module__}.{obj.__qualname__}'\n"
+            "  Invalid docstring section heading. See:\n"
+            "  https://icalendar.readthedocs.io/en/stable/contribute/documentation/style-guide.html#docstring-structure"
         )
 
     doc = inspect.getdoc(obj)

--- a/src/icalendar/tests/test_docstrings.py
+++ b/src/icalendar/tests/test_docstrings.py
@@ -1,22 +1,39 @@
 import inspect
 import re
+
 import pytest
+
 import icalendar
 
 ALLOWED_HEADINGS = {
-    "Attributes", "Parameters", "Returns", "Raises", "Example", "Examples",
-    "See also", "Attention", "Caution", "Danger", "Hint", "Important", "Note", "Tip", "Todo"
+    "Attributes",
+    "Parameters",
+    "Returns",
+    "Raises",
+    "Example",
+    "Examples",
+    "See also",
+    "Attention",
+    "Caution",
+    "Danger",
+    "Hint",
+    "Important",
+    "Note",
+    "Tip",
+    "Todo",
 }
+
 
 def get_public_objects():
     objs = []
     # Test on the main public module for now to establish baseline
     for name, obj in inspect.getmembers(icalendar):
-        if name.startswith('_'): 
+        if name.startswith("_"):
             continue
         if inspect.isclass(obj) or inspect.isfunction(obj):
             objs.append(obj)
     return objs
+
 
 @pytest.mark.parametrize("obj", get_public_objects())
 def test_docstring_headings_are_valid(obj):
@@ -26,10 +43,10 @@ def test_docstring_headings_are_valid(obj):
     doc = inspect.getdoc(obj)
     if not doc:
         return
-        
+
     # Match standard docstring headings (Word followed by line of --- or ===)
-    headings = re.findall(r'^([A-Z][A-Za-z]+(?: [a-z]+)*)\n[-=]+$', doc, re.MULTILINE)
-    
+    headings = re.findall(r"^([A-Z][A-Za-z]+(?: [a-z]+)*)\n[-=]+$", doc, re.MULTILINE)
+
     for heading in headings:
         assert heading in ALLOWED_HEADINGS, (
             f"Invalid docstring heading '{heading}' found in '{obj.__name__}'. "

--- a/src/icalendar/tests/test_docstrings.py
+++ b/src/icalendar/tests/test_docstrings.py
@@ -3,6 +3,9 @@
 It may be amended as needed.
 ``KNOWN_BAD_HEADINGS`` is a set of known bad headings.
 As docstrings are fixed, their headings may be removed from this set.
+``KNOWN_MISSING_PARAMETERS`` is a set of functions and methods whose
+docstrings lack a ``Parameters`` section.
+As docstrings are fixed, their names may be removed from this set.
 See https://github.com/collective/icalendar/issues/1481
 """
 
@@ -69,6 +72,25 @@ KNOWN_BAD_HEADINGS = {
     "vUri",
 }
 
+KNOWN_MISSING_PARAMETERS = {
+    "Alarms.__init__",
+    "Conference.__init__",
+    "ICalParsingError.__init__",
+    "Image.__init__",
+    "is_utc",
+    "vBinary.__init__",
+    "vCategory.__init__",
+    "vDDDLists.__init__",
+    "vDDDTypes.__init__",
+    "vDate.__init__",
+    "vDatetime.__init__",
+    "vDuration.__init__",
+    "vGeo.__init__",
+    "vPeriod.__init__",
+    "vTime.__init__",
+    "vUTCOffset.__init__",
+}
+
 
 def get_public_objects():
     objs = []
@@ -81,9 +103,47 @@ def get_public_objects():
     return objs
 
 
+def get_public_objects_with_parameters():
+    """Return public functions and ``__init__`` methods with parameters.
+
+    For each public object, select the function itself or, for a class, the
+    ``__init__`` method defined by that class. Keep only those whose
+    signatures accept parameters other than ``self`` and ``cls``, excluding
+    ``*args`` and ``**kwargs``.
+    """
+    functions = []
+    for obj in get_public_objects():
+        # A class's docstring must not contain a Parameters section.
+        # Sphinx appends the __init__ docstring to the class docstring.
+        if inspect.isclass(obj):
+            function = obj.__dict__.get("__init__")
+            if not inspect.isfunction(function):
+                continue
+        else:
+            function = obj
+        try:
+            signature = inspect.signature(function)
+        except (ValueError, TypeError):
+            continue
+        parameters = [
+            parameter
+            for name, parameter in signature.parameters.items()
+            if name not in ("self", "cls")
+            and parameter.kind not in (parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD)
+        ]
+        if parameters:
+            functions.append(function)
+    return functions
+
+
 def _obj_id(obj):
     """Return the name of the object for parametrize IDs."""
     return obj.__name__
+
+
+def _function_id(function):
+    """Return the qualified name of the function for parametrize IDs."""
+    return function.__qualname__
 
 
 @pytest.mark.parametrize("obj", get_public_objects(), ids=_obj_id)
@@ -112,3 +172,27 @@ def test_docstring_headings_are_valid(obj):
             f"Invalid docstring heading '{heading}' found in '{obj.__name__}'. "
             f"Allowed headings are: {', '.join(sorted(ALLOWED_HEADINGS))}"
         )
+
+
+@pytest.mark.parametrize(
+    "function", get_public_objects_with_parameters(), ids=_function_id
+)
+def test_docstring_has_parameters_section(function):
+    """
+    Identify docstrings that lack a Parameters section when the signature
+    accepts parameters other than self.
+    """
+    if function.__qualname__ in KNOWN_MISSING_PARAMETERS:
+        pytest.xfail(
+            f"'{function.__module__}.{function.__qualname__}'\n"
+            "  Missing 'Parameters' docstring section. See:\n"
+            "  https://icalendar.readthedocs.io/en/stable/contribute/documentation/style-guide.html#docstring-structure"
+        )
+
+    doc = inspect.getdoc(function) or ""
+    assert re.search(r"^\s*Parameters:\s*$", doc, re.MULTILINE), (
+        "Missing 'Parameters' docstring section in "
+        f"'{function.__module__}.{function.__qualname__}', whose signature "
+        "accepts parameters other than 'self'. See: "
+        "https://icalendar.readthedocs.io/en/stable/contribute/documentation/style-guide.html#docstring-structure"
+    )

--- a/src/icalendar/tests/test_docstrings.py
+++ b/src/icalendar/tests/test_docstrings.py
@@ -1,3 +1,11 @@
+"""Inspect all docstring section headings.
+``ALLOWED_HEADINGS`` is a set of allowed headings.
+It may be amended as needed.
+``KNOWN_BAD_HEADINGS`` is a set of known bad headings.
+As docstrings are fixed, their headings may be removed from this set.
+See https://github.com/collective/icalendar/issues/1481
+"""
+
 import inspect
 import re
 
@@ -23,9 +31,6 @@ ALLOWED_HEADINGS = {
     "Todo",
 }
 
-# Objects with known-bad docstring section headings.
-# As docstrings are fixed in other PRs, remove entries from this set.
-# See https://github.com/collective/icalendar/issues/1481
 KNOWN_BAD_HEADINGS = {
     "Availability",
     "Available",
@@ -84,11 +89,11 @@ def _obj_id(obj):
 @pytest.mark.parametrize("obj", get_public_objects(), ids=_obj_id)
 def test_docstring_headings_are_valid(obj):
     """
-    Identify section headings that are not one of the allowed types.
+    Identify docstring section headings that are not one of the allowed types.
     """
     if obj.__name__ in KNOWN_BAD_HEADINGS:
         pytest.xfail(
-            f"'{obj.__name__}' has known-bad docstring headings (see issue #1481)"
+            f"'{obj.__module__}.{obj.__qualname__}' has a known bad docstring heading (see issue #1481)"
         )
 
     doc = inspect.getdoc(obj)
@@ -97,7 +102,7 @@ def test_docstring_headings_are_valid(obj):
 
     # Match standard docstring headings (Word(s) followed by a colon)
     headings = re.findall(
-        r"^[ \t]*([A-Z][A-Za-z]+(?: [A-Za-z]+)*):(?=\s|$)", doc, re.MULTILINE
+        r"^ *([A-Z][A-Za-z]+(?: [A-Za-z]+)*):(?:\n|$)", doc, re.MULTILINE
     )
 
     for heading in headings:


### PR DESCRIPTION
## Linked issue

<!--
Replace `ISSUE_NUMBER` with the issue number that your pull request addresses. This links the pull request to the related issue. Choose the appropriate form.

If you completely resolve the issue, then use `"Closes"`.
GitHub will automatically close the related issue when the PR gets merged.
-->

- Closes #ISSUE_NUMBER

<!--
If you resolve only a part of the issue, then use `"See"`.
This form keeps the issue open for future work.
-->

- See #1481 

## Description

Addresses missing Parameters sections of docstrings for functions with parameters OTHER THAN self. 

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

Upload screenshots, videos, links to documentation, or any other relevant information.
