### PR TITLE
Fix empty changelog entry for #698

### DIFF
--- a/news/698.chore.2
+++ b/news/698.chore.2
@@ -1,0 +1,1 @@
+Added assertions to `test_parser_tools_from_unicode` covering the case where `from_unicode()` receives a value that is neither `str` nor `bytes`, mirroring the existing coverage for `to_unicode()`'s equivalent fallback. Prepared with the assistance of Claude (via the Claude Code VS Code extension). @adityaanikam


### PR DESCRIPTION
## Linked issue

- See #698

## Description

`news/698.chore.2` was committed empty in #1582 — the content existed in
my editor but wasn't saved to disk before the commit, and CI's changelog
verifier only checks that the file exists, not that it has content. This
restores the intended entry.

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

This is a text-only fix to a changelog fragment — no code or tests are
affected, so the test/documentation checklist items don't apply here.
