### PR TITLE
docs: convert vUri docstring to Pythonic style (#1244)

### DIFF
--- a/news/1244.documentation
+++ b/news/1244.documentation
@@ -1,0 +1,1 @@
+Rewrote the RFC-copy-paste docstring of :class:`~icalendar.prop.uri.vUri` as a Pythonic docstring with a summary, description, and doctest-verified example, matching the style already used by :class:`~icalendar.prop.boolean.vBoolean` and other converted value types. I used AI (Claude) to assist me with this change; I reviewed and tested it myself. @YOUR-GITHUB-USERNAME

--- a/src/icalendar/prop/uri.py
+++ b/src/icalendar/prop/uri.py
@@ -9,35 +9,15 @@ from icalendar.parser_tools import DEFAULT_ENCODING, to_unicode
 
 
 class vUri(str):
-    """URI
+    """A value that identifies a resource with a URI, per :rfc:`5545#section-3.3.13`.
 
-    Value Name:
-        URI
+    This value type is used to reference values that are large, binary, or
+    otherwise undesirable to include directly in the iCalendar object, such
+    as a network file. Property values with this value type must follow the
+    generic URI syntax defined in :rfc:`3986`. When a property *parameter*
+    value is a URI, it must be specified as a quoted-string value.
 
-    Purpose:
-        This value type is used to identify values that contain a
-        uniform resource identifier (URI) type of reference to the
-        property value.
-
-    Format Definition:
-        This value type is defined by the following notation:
-
-        .. code-block:: text
-
-            uri = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
-
-    Description:
-        This value type might be used to reference binary
-        information, for values that are large, or otherwise undesirable
-        to include directly in the iCalendar object.
-
-        Property values with this value type MUST follow the generic URI
-        syntax defined in [RFC3986].
-
-        When a property parameter value is a URI value type, the URI MUST
-        be specified as a quoted-string value.
-
-    Examples:
+    Example:
         The following is a URI for a network file:
 
         .. code-block:: ics


### PR DESCRIPTION
Drafted with assistance from Claude (Anthropic). I reviewed the change, ran the full test suite (10358 passed) and doctest, and confirmed ruff formatting/linting pass before submitting