### PR TITLE
Validate Alarm REPEAT when setting: reject negative values

### DIFF
--- a/news/1594.feature
+++ b/news/1594.feature
@@ -1,0 +1,1 @@
+Validate the ``REPEAT`` property of :class:`~icalendar.cal.alarm.Alarm` when setting it: negative values now raise a :class:`ValueError`. :func:`icalendar.attr.single_int_property` accepts a new ``min_value`` argument for this. AI disclosure: I used Devin (Cognition) to draft this change and its tests; I reviewed and validated the result. @pratyushsinghal7

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -403,13 +403,20 @@ def multi_language_text_property(
     return property(fget, fset, fdel, doc)
 
 
-def single_int_property(prop: str, default: int, doc: str) -> property:
+def single_int_property(
+    prop: str, default: int, doc: str, min_value: int | None = None
+) -> property:
     """Create a property for an int value that exists only once.
 
     Parameters:
         prop: The name of the property
         default: The default value
         doc: The documentation string
+        min_value: The smallest value the property accepts when set.
+            ``None`` disables the check.
+
+    Raises:
+        ValueError: When setting a value smaller than ``min_value``.
     """
 
     def fget(self: Component) -> int:
@@ -421,6 +428,8 @@ def single_int_property(prop: str, default: int, doc: str) -> property:
 
     def fset(self: Component, value: int | None):
         """Set the property."""
+        if value is not None and min_value is not None and int(value) < min_value:
+            raise ValueError(f"{prop} must be an int >= {min_value}, not {value}")
         fdel(self)
         if value is not None:
             self.add(prop, value)
@@ -1294,7 +1303,9 @@ initial trigger.
 Defaults to ``0``, meaning the alarm fires once. Must be paired with
 :attr:`~icalendar.cal.alarm.Alarm.DURATION`. Conforms with :rfc:`5545#section-3.8.6.2`.
 The value is capped at :data:`icalendar.config.MAX_ALARM_REPEAT` on read.
+Setting a negative value raises a :class:`ValueError`.
 """,
+        min_value=0,
     )
 
     def fget(self):

--- a/src/icalendar/cal/alarm.py
+++ b/src/icalendar/cal/alarm.py
@@ -119,7 +119,11 @@ class Alarm(Component):
                 >>> alarm.REPEAT = 2
                 >>> alarm.REPEAT
                 2
+
+        Raises:
+            ValueError: When set to a value smaller than ``0``.
         """,
+        min_value=0,
     )
 
     DURATION = property(
@@ -369,7 +373,7 @@ class Alarm(Component):
                     "DURATION and REPEAT must be set together or not at all"
                 )
             self.DURATION = duration
-            self.REPEAT = repeat
+            self.repeat = repeat
 
     @classmethod
     def new_display(
@@ -414,6 +418,7 @@ class Alarm(Component):
         Raises:
             ~icalendar.error.InvalidCalendar: If required fields are missing
                 or ``duration`` and ``repeat`` are not both provided together.
+            ValueError: If ``repeat`` is negative.
 
         Example:
             Create a display alarm that fires 15 minutes before the event:
@@ -514,6 +519,7 @@ class Alarm(Component):
         Raises:
             ~icalendar.error.InvalidCalendar: If required fields are missing
                 or ``duration`` and ``repeat`` are not both provided together.
+            ValueError: If ``repeat`` is negative.
 
         Example:
             Create an audio alarm using a custom sound file:
@@ -606,6 +612,7 @@ class Alarm(Component):
             ~icalendar.error.InvalidCalendar: If required fields are missing,
                 ``attendees`` is empty, or ``duration`` and ``repeat`` are not
                 both provided together.
+            ValueError: If ``repeat`` is negative.
 
         Example:
             Create an email alarm sent to two recipients:

--- a/src/icalendar/tests/attr/test_alarm.py
+++ b/src/icalendar/tests/attr/test_alarm.py
@@ -52,3 +52,35 @@ def test_alarm_to_string():
     a = Alarm()
     a.REPEAT = 11
     assert a.to_ical() == b"BEGIN:VALARM\r\nREPEAT:11\r\nEND:VALARM\r\n"
+
+
+def test_set_REPEAT_to_zero():
+    """Zero is the boundary and a valid value."""
+    a = Alarm()
+    a.REPEAT = 0
+    assert a.REPEAT == 0
+
+
+@pytest.mark.parametrize("value", [-1, -10])
+def test_set_negative_REPEAT(value):
+    """Setting a negative REPEAT raises a ValueError."""
+    a = Alarm()
+    with pytest.raises(ValueError, match="REPEAT must be an int >= 0"):
+        a.REPEAT = value
+
+
+@pytest.mark.parametrize("value", [-1, -10])
+def test_set_negative_repeat_lowercase(value):
+    """The lowercase repeat property validates the same way."""
+    a = Alarm()
+    with pytest.raises(ValueError, match="REPEAT must be an int >= 0"):
+        a.repeat = value
+
+
+def test_negative_repeat_keeps_existing_value():
+    """A failed set does not modify the existing value."""
+    a = Alarm()
+    a.REPEAT = 3
+    with pytest.raises(ValueError):
+        a.REPEAT = -1
+    assert a.REPEAT == 3

--- a/src/icalendar/tests/attr/test_alarm_factory_methods.py
+++ b/src/icalendar/tests/attr/test_alarm_factory_methods.py
@@ -92,6 +92,55 @@ def test_repeat_without_duration_raises(alarm_fn):
         alarm_fn()
 
 
+@pytest.mark.parametrize(
+    "alarm_fn",
+    [
+        lambda: Alarm.new_display(
+            "desc", timedelta(minutes=-5), duration=timedelta(minutes=1), repeat=-1
+        ),
+        lambda: Alarm.new_audio(
+            timedelta(minutes=-5), duration=timedelta(minutes=1), repeat=-1
+        ),
+        lambda: Alarm.new_email(
+            "S",
+            "D",
+            timedelta(minutes=-30),
+            vCalAddress("mailto:a@example.com"),
+            duration=timedelta(minutes=5),
+            repeat=-1,
+        ),
+    ],
+    ids=["display", "audio", "email"],
+)
+def test_negative_repeat_raises(alarm_fn):
+    with pytest.raises(ValueError, match="REPEAT must be an int >= 0"):
+        alarm_fn()
+
+
+@pytest.mark.parametrize(
+    "alarm_fn",
+    [
+        lambda: Alarm.new_display(
+            "desc", timedelta(minutes=-5), duration=timedelta(minutes=1), repeat=0
+        ),
+        lambda: Alarm.new_audio(
+            timedelta(minutes=-5), duration=timedelta(minutes=1), repeat=0
+        ),
+        lambda: Alarm.new_email(
+            "S",
+            "D",
+            timedelta(minutes=-30),
+            vCalAddress("mailto:a@example.com"),
+            duration=timedelta(minutes=5),
+            repeat=0,
+        ),
+    ],
+    ids=["display", "audio", "email"],
+)
+def test_zero_repeat_is_valid(alarm_fn):
+    assert alarm_fn().REPEAT == 0
+
+
 def test_new_audio_sets_action():
     alarm = Alarm.new_audio(timedelta(minutes=-5))
     assert alarm["ACTION"] == "AUDIO"


### PR DESCRIPTION
## Linked issue

- See #1594

## Description

Setting a negative value on the alarm REPEAT property used to be stored silently, even though RFC 5545 defines REPEAT as a non-negative count. This adds a `min_value` argument to the int property helper and uses it for REPEAT, so a negative value now raises a ValueError. A failed set leaves any existing value untouched. The alarm factory methods assign through the validated setter, so they get the same check.

This covers the setter-validation part of the issue; auditing other lowercase int attributes for boundaries is left for follow-up, hence "See" rather than "Closes".

## Checklist

- [x] I added a change log entry.
- [x] I followed icalendar's AI policy and disclosed my AI use in the commit message and change log entry.
- [x] I added tests for positive, zero, and negative values.
- [x] I ran all tests locally.
- [x] I updated the docstrings.
