### PR TITLE
TDD: Accept email strings as attendees

### DIFF
--- a/docs/how-to/attendees.rst
+++ b/docs/how-to/attendees.rst
@@ -2,24 +2,34 @@
 Event attendees
 ===============
 
-This chapter explains how to use the event attendee information in iCalendar files with the icalendar library.
-Attendees are present inside of events, alarms, and other calendar components, and occur as a :class:`~icalendar.prop.cal_address.vCalAddress`.
+This chapter explains how to work with attendee information in iCalendar files using the icalendar library.
+Each attendee is a :class:`~icalendar.prop.cal_address.vCalAddress`.
+The components that support attendees are :class:`~icalendar.cal.event.Event`, :class:`~icalendar.cal.todo.Todo`, :class:`~icalendar.cal.journal.Journal`, and :class:`~icalendar.cal.alarm.Alarm`.
+The examples below use :class:`~icalendar.cal.event.Event`, but the same attendee API applies to each of these components.
 
 .. seealso::
 
     :attr:`Event.attendees <icalendar.cal.event.Event.attendees>`
 
-Add attendees to an event
--------------------------
+Assign attendees to an event
+----------------------------
 
-Assign an email string or a list of email strings directly to an event.
-Both plain email addresses and addresses that already start with ``mailto:`` are accepted.
-They are automatically converted to :class:`~icalendar.prop.cal_address.vCalAddress` objects.
+Assign a single email string to :attr:`~icalendar.cal.event.Event.attendees` to set one attendee.
+The string is converted to a :class:`~icalendar.prop.cal_address.vCalAddress` object.
 
 .. code-block:: pycon
 
     >>> from icalendar import Event
     >>> event = Event.new()
+    >>> event.attendees = "emily.smith@example.com"
+    >>> event.attendees
+    [vCalAddress('mailto:emily.smith@example.com')]
+
+Assign a list of email strings to set several attendees at once.
+A plain email address receives a ``mailto:`` prefix, while an address that already starts with ``mailto:`` is kept as is.
+
+.. code-block:: pycon
+
     >>> event.attendees = [
     ...     "emily.smith@example.com",
     ...     "mailto:alex@example.com",
@@ -27,25 +37,28 @@ They are automatically converted to :class:`~icalendar.prop.cal_address.vCalAddr
     >>> event.attendees
     [vCalAddress('mailto:emily.smith@example.com'), vCalAddress('mailto:alex@example.com')]
 
-You can also pass attendee strings while creating the event.
+You can also pass attendee strings when creating the event with :meth:`Event.new <icalendar.cal.event.Event.new>`.
+This is equivalent to assigning them afterward.
 
 .. code-block:: pycon
 
     >>> event = Event.new(attendees="emily.smith@example.com")
+    >>> event.attendees
+    [vCalAddress('mailto:emily.smith@example.com')]
 
-When an attendee needs parameters such as ``CN``, ``ROLE``, or ``RSVP``, create
-it with :meth:`vCalAddress.new <icalendar.prop.cal_address.vCalAddress.new>`.
+An attendee may carry parameters defined by :rfc:`5545`, such as ``CN``, ``ROLE``, and ``RSVP``.
+Create such an attendee with :meth:`vCalAddress.new <icalendar.prop.cal_address.vCalAddress.new>`, whose Python keyword arguments ``cn``, ``role``, and ``rsvp`` set those RFC parameters.
 
 .. code-block:: pycon
 
     >>> from icalendar import vCalAddress, CUTYPE, ROLE, PARTSTAT
     >>> attendee = vCalAddress.new(
     ...     "emily.smith@example.com",  # email address
-    ...     cn="Emily Smith",           # common name
-    ...     cutype=CUTYPE.INDIVIDUAL,   # calendar user type
-    ...     role=ROLE.CHAIR,            # role
-    ...     partstat=PARTSTAT.ACCEPTED, # participation status
-    ...     rsvp=True,                  # RSVP requirement
+    ...     cn="Emily Smith",           # CN parameter (common name)
+    ...     cutype=CUTYPE.INDIVIDUAL,   # CUTYPE parameter (calendar user type)
+    ...     role=ROLE.CHAIR,            # ROLE parameter
+    ...     partstat=PARTSTAT.ACCEPTED, # PARTSTAT parameter (participation status)
+    ...     rsvp=True,                  # RSVP parameter
     ... )
 
 .. note::
@@ -53,7 +66,8 @@ it with :meth:`vCalAddress.new <icalendar.prop.cal_address.vCalAddress.new>`.
     Apart from the email, all parameters are optional.
     Use the enumerations defined in :mod:`icalendar.enums` to ensure valid values.
 
-Then add the attendee to the event.
+Assign the attendee to the event.
+Assigning a new value replaces any attendees that were set before.
 
 .. code-block:: pycon
 

--- a/docs/how-to/attendees.rst
+++ b/docs/how-to/attendees.rst
@@ -46,7 +46,7 @@ This is equivalent to assigning them afterward.
     >>> event.attendees
     [vCalAddress('mailto:emily.smith@example.com')]
 
-An attendee may carry parameters defined by :rfc:`5545`, such as ``CN``, ``ROLE``, and ``RSVP``.
+An attendee may carry parameters defined by :rfc:`5545#section-3.8.4.1`, such as ``CN``, ``ROLE``, and ``RSVP``.
 Create such an attendee with :meth:`vCalAddress.new <icalendar.prop.cal_address.vCalAddress.new>`, whose Python keyword arguments ``cn``, ``role``, and ``rsvp`` set those RFC parameters.
 
 .. code-block:: pycon
@@ -72,11 +72,6 @@ Assigning a new value replaces any attendees that were set before.
 .. code-block:: pycon
 
     >>> event.attendees = [attendee]    # set the attribute
-
-The resulting event looks like this:
-
-.. code-block:: pycon
-
     >>> print(event.to_ical())
     BEGIN:VEVENT
     DTSTAMP:20250517T080612Z

--- a/docs/how-to/attendees.rst
+++ b/docs/how-to/attendees.rst
@@ -12,16 +12,33 @@ Attendees are present inside of events, alarms, and other calendar components, a
 Add attendees to an event
 -------------------------
 
-To add attendees to an event in icalendar, import the required classes.
+Assign an email string or a list of email strings directly to an event.
+Both plain email addresses and addresses that already start with ``mailto:`` are accepted.
+They are automatically converted to :class:`~icalendar.prop.cal_address.vCalAddress` objects.
 
 .. code-block:: pycon
 
-    >>> from icalendar import Event, vCalAddress, CUTYPE, ROLE, PARTSTAT
+    >>> from icalendar import Event
+    >>> event = Event.new()
+    >>> event.attendees = [
+    ...     "emily.smith@example.com",
+    ...     "mailto:alex@example.com",
+    ... ]
+    >>> event.attendees
+    [vCalAddress('mailto:emily.smith@example.com'), vCalAddress('mailto:alex@example.com')]
 
-Then create the attendee object and set its parameters.
+You can also pass attendee strings while creating the event.
 
 .. code-block:: pycon
 
+    >>> event = Event.new(attendees="emily.smith@example.com")
+
+When an attendee needs parameters such as ``CN``, ``ROLE``, or ``RSVP``, create
+it with :meth:`vCalAddress.new <icalendar.prop.cal_address.vCalAddress.new>`.
+
+.. code-block:: pycon
+
+    >>> from icalendar import vCalAddress, CUTYPE, ROLE, PARTSTAT
     >>> attendee = vCalAddress.new(
     ...     "emily.smith@example.com",  # email address
     ...     cn="Emily Smith",           # common name
@@ -36,11 +53,10 @@ Then create the attendee object and set its parameters.
     Apart from the email, all parameters are optional.
     Use the enumerations defined in :mod:`icalendar.enums` to ensure valid values.
 
-Finally, add the attendee to the event.
+Then add the attendee to the event.
 
 .. code-block:: pycon
 
-    >>> event = Event.new()
     >>> event.attendees = [attendee]    # set the attribute
 
 The resulting event looks like this:

--- a/docs/how-to/attendees.rst
+++ b/docs/how-to/attendees.rst
@@ -71,6 +71,7 @@ Assigning a new value replaces any attendees that were set before.
 
 .. code-block:: pycon
 
+    >>> event = Event.new()
     >>> event.attendees = [attendee]    # set the attribute
     >>> print(event.to_ical())
     BEGIN:VEVENT

--- a/news/1593.feature
+++ b/news/1593.feature
@@ -1,0 +1,1 @@
+Allowed attendee properties to accept plain and ``mailto:``-prefixed email strings, which are converted to :class:`~icalendar.prop.cal_address.vCalAddress` objects automatically. I used OpenAI Codex with GPT-5 to help implement, document, and verify this change. @SyedIshmumAhnaf

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -753,16 +753,13 @@ def _set_attendees(self: Component, value: ATTENDEE_TYPE_SETTER):
     _del_attendees(self)
     if value is None:
         return
-    if isinstance(value, vCalAddress):
+    if isinstance(value, (vCalAddress, str)):
         value = [value]
-    elif isinstance(value, str):
-        value = [vCalAddress.new(value)]
     elif not isinstance(value, list):
         value = list(value) if isinstance(value, Sequence) else [value]
     for index, attendee in enumerate(value):
-        if isinstance(attendee, vCalAddress):
-            continue
-        if isinstance(attendee, str):
+        # vCalAddress subclasses str, so exclude it before normalizing strings
+        if not isinstance(attendee, vCalAddress) and isinstance(attendee, str):
             value[index] = vCalAddress.new(attendee)
     self["ATTENDEE"] = value
 

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import itertools
+from collections.abc import Sequence
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Literal, TypeAlias
 
@@ -27,7 +28,7 @@ from icalendar.timezone import tzp
 from icalendar.tools import is_date
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable
 
     from icalendar.cal import Component
 
@@ -744,13 +745,25 @@ def _get_attendees(self: Component) -> list[vCalAddress]:
     return value
 
 
-def _set_attendees(self: Component, value: list[vCalAddress] | vCalAddress | None):
+ATTENDEE_TYPE_SETTER: TypeAlias = Sequence[vCalAddress | str] | vCalAddress | str | None
+
+
+def _set_attendees(self: Component, value: ATTENDEE_TYPE_SETTER):
     """Set attendees."""
     _del_attendees(self)
     if value is None:
         return
-    if not isinstance(value, list):
+    if isinstance(value, vCalAddress):
         value = [value]
+    elif isinstance(value, str):
+        value = [vCalAddress.new(value)]
+    elif not isinstance(value, list):
+        value = list(value) if isinstance(value, Sequence) else [value]
+    for index, attendee in enumerate(value):
+        if isinstance(attendee, vCalAddress):
+            continue
+        if isinstance(attendee, str):
+            value[index] = vCalAddress.new(attendee)
     self["ATTENDEE"] = value
 
 
@@ -785,31 +798,43 @@ Description:
     type of iCalendar alarm.
 
 Examples:
-    Add a new attendee to an existing event.
+    Assign one or more attendee email addresses directly. Strings are
+    converted to :class:`~icalendar.prop.cal_address.vCalAddress` objects
+    and receive a ``mailto:`` prefix when needed.
 
     .. code-block:: pycon
 
-        >>> from icalendar import Event, vCalAddress
+        >>> from icalendar import Event
         >>> event = Event()
-        >>> event.attendees.append(vCalAddress("mailto:me@my-domain.com"))
+        >>> event.attendees = [
+        ...     "me@my-domain.com",
+        ...     "mailto:you@my-domain.com",
+        ... ]
+        >>> event.attendees[0]
+        vCalAddress('mailto:me@my-domain.com')
+        >>> event.attendees[1]
+        vCalAddress('mailto:you@my-domain.com')
         >>> print(event.to_ical())
         BEGIN:VEVENT
         ATTENDEE:mailto:me@my-domain.com
+        ATTENDEE:mailto:you@my-domain.com
         END:VEVENT
 
-    Create an email alarm with several attendees:
+    Use :meth:`vCalAddress.new
+    <icalendar.prop.cal_address.vCalAddress.new>` when an attendee needs
+    parameters such as ``CN``, ``ROLE``, or ``RSVP``.
 
-        >>> from icalendar import Alarm, vCalAddress
-        >>> alarm = Alarm.new(attendees = [
-        ...     vCalAddress("mailto:me@my-domain.com"),
-        ...     vCalAddress("mailto:you@my-domain.com"),
-        ... ], summary = "Email alarm")
-        >>> print(alarm.to_ical())
-        BEGIN:VALARM
-        ATTENDEE:mailto:me@my-domain.com
-        ATTENDEE:mailto:you@my-domain.com
-        SUMMARY:Email alarm
-        END:VALARM
+    .. code-block:: pycon
+
+        >>> from icalendar import vCalAddress
+        >>> event.attendees = [
+        ...     vCalAddress.new(
+        ...         "chair@example.com",
+        ...         cn="Meeting Chair",
+        ...         role="CHAIR",
+        ...         rsvp=True,
+        ...     )
+        ... ]
 """,
 )
 
@@ -2640,6 +2665,7 @@ Example:
 
 
 __all__ = [
+    "ATTENDEE_TYPE_SETTER",
     "CONCEPTS_TYPE_SETTER",
     "LINKS_TYPE_SETTER",
     "RECURRENCE_ID",

--- a/src/icalendar/cal/alarm.py
+++ b/src/icalendar/cal/alarm.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from icalendar.compatibility import Self
-    from icalendar.prop import vCalAddress
 
 
 class Alarm(Component):
@@ -606,7 +605,7 @@ class Alarm(Component):
         summary: str,
         description: str,
         trigger: timedelta | datetime,
-        attendees: Sequence[vCalAddress | str] | vCalAddress | str,
+        attendees: ATTENDEE_TYPE_SETTER,
         attachments: Sequence[str] | str | None = None,
         duration: timedelta | None = None,
         repeat: int | None = None,
@@ -657,22 +656,25 @@ class Alarm(Component):
                 both provided together.
 
         Example:
-            Create an email alarm sent to two recipients:
+            Create an email alarm sent to two recipients. Plain email strings
+            and ``mailto:``-prefixed strings are both accepted and normalized
+            to :class:`~icalendar.prop.cal_address.vCalAddress`:
 
             .. code-block:: pycon
 
                 >>> from datetime import timedelta
-                >>> from icalendar import Alarm, vCalAddress
+                >>> from icalendar import Alarm
                 >>> alarm = Alarm.new_email(
                 ...     summary="Meeting reminder",
                 ...     description="Your meeting starts in 30 minutes.",
                 ...     trigger=timedelta(minutes=-30),
-                ...     attendees=[vCalAddress("mailto:user@example.com")],
+                ...     attendees=["user@example.com", "mailto:boss@example.com"],
                 ... )
                 >>> print(alarm.to_ical().decode())
                 BEGIN:VALARM
                 ACTION:EMAIL
                 ATTENDEE:mailto:user@example.com
+                ATTENDEE:mailto:boss@example.com
                 DESCRIPTION:Your meeting starts in 30 minutes.
                 SUMMARY:Meeting reminder
                 TRIGGER:-PT30M

--- a/src/icalendar/cal/alarm.py
+++ b/src/icalendar/cal/alarm.py
@@ -6,6 +6,7 @@ from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, NamedTuple
 
 from icalendar.attr import (
+    ATTENDEE_TYPE_SETTER,
     CONCEPTS_TYPE_SETTER,
     LINKS_TYPE_SETTER,
     RELATED_TO_TYPE_SETTER,
@@ -362,7 +363,7 @@ class Alarm(Component):
     def new(
         cls,
         /,
-        attendees: list[vCalAddress] | None = None,
+        attendees: ATTENDEE_TYPE_SETTER = None,
         concepts: CONCEPTS_TYPE_SETTER = None,
         description: str | None = None,
         links: LINKS_TYPE_SETTER = None,
@@ -605,7 +606,7 @@ class Alarm(Component):
         summary: str,
         description: str,
         trigger: timedelta | datetime,
-        attendees: Sequence[vCalAddress] | vCalAddress,
+        attendees: Sequence[vCalAddress | str] | vCalAddress | str,
         attachments: Sequence[str] | str | None = None,
         duration: timedelta | None = None,
         repeat: int | None = None,
@@ -623,7 +624,7 @@ class Alarm(Component):
         Conforms to :rfc:`5545#section-3.6.6`.
 
         Parameters:
-            attendees: Required. One or more recipient addresses as
+            attendees: Required. One or more recipient addresses as email strings or
                 :class:`~icalendar.prop.cal_address.vCalAddress` instances. A
                 single address or a sequence of addresses. At least one is
                 required.

--- a/src/icalendar/cal/event.py
+++ b/src/icalendar/cal/event.py
@@ -7,6 +7,7 @@ from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Literal
 
 from icalendar.attr import (
+    ATTENDEE_TYPE_SETTER,
     CONCEPTS_TYPE_SETTER,
     LINKS_TYPE_SETTER,
     RELATED_TO_TYPE_SETTER,
@@ -433,7 +434,7 @@ class Event(Component):
     def new(
         cls,
         /,
-        attendees: list[vCalAddress] | None = None,
+        attendees: ATTENDEE_TYPE_SETTER = None,
         categories: Sequence[str] = (),
         classification: CLASS | None = None,
         color: str | None = None,

--- a/src/icalendar/cal/journal.py
+++ b/src/icalendar/cal/journal.py
@@ -7,6 +7,7 @@ from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from icalendar.attr import (
+    ATTENDEE_TYPE_SETTER,
     CONCEPTS_TYPE_SETTER,
     LINKS_TYPE_SETTER,
     RELATED_TO_TYPE_SETTER,
@@ -199,7 +200,7 @@ class Journal(Component):
     def new(
         cls,
         /,
-        attendees: list[vCalAddress] | None = None,
+        attendees: ATTENDEE_TYPE_SETTER = None,
         categories: Sequence[str] = (),
         classification: CLASS | None = None,
         color: str | None = None,

--- a/src/icalendar/cal/todo.py
+++ b/src/icalendar/cal/todo.py
@@ -7,6 +7,7 @@ from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Literal
 
 from icalendar.attr import (
+    ATTENDEE_TYPE_SETTER,
     CONCEPTS_TYPE_SETTER,
     LINKS_TYPE_SETTER,
     RELATED_TO_TYPE_SETTER,
@@ -322,7 +323,7 @@ class Todo(Component):
     def new(
         cls,
         /,
-        attendees: list[vCalAddress] | None = None,
+        attendees: ATTENDEE_TYPE_SETTER = None,
         categories: Sequence[str] = (),
         classification: CLASS | None = None,
         color: str | None = None,

--- a/src/icalendar/tests/attr/test_alarm_factory_methods.py
+++ b/src/icalendar/tests/attr/test_alarm_factory_methods.py
@@ -414,25 +414,22 @@ def test_alarm_new_concepts_none_is_empty():
     assert "CONCEPT" not in alarm
 
 
-def test_new_email_singleton_string_attendee_normalizes():
-    """A singleton plain string attendee should normalize to a vCalAddress."""
+@pytest.mark.parametrize(
+    ("attendees", "expected"),
+    [
+        ("first@example.com", "mailto:first@example.com"),
+        (["first@example.com"], "mailto:first@example.com"),
+        ("mailto:second@example.net", "mailto:second@example.net"),
+        (["mailto:second@example.net"], "mailto:second@example.net"),
+    ],
+)
+def test_new_email_string_attendee_normalizes(attendees, expected):
+    """Plain and mailto: string attendees, singleton or in a list, normalize to vCalAddress."""
     alarm = Alarm.new_email(
         summary="S",
         description="D",
         trigger=timedelta(minutes=-30),
-        attendees="first@example.com",
+        attendees=attendees,
     )
     assert isinstance(alarm.attendees[0], vCalAddress)
-    assert str(alarm.attendees[0]) == "mailto:first@example.com"
-
-
-def test_new_email_list_with_prefixed_string_attendee_normalizes():
-    """A list containing an already-prefixed string attendee normalizes to a vCalAddress."""
-    alarm = Alarm.new_email(
-        summary="S",
-        description="D",
-        trigger=timedelta(minutes=-30),
-        attendees=["mailto:second@example.net"],
-    )
-    assert isinstance(alarm.attendees[0], vCalAddress)
-    assert str(alarm.attendees[0]) == "mailto:second@example.net"
+    assert str(alarm.attendees[0]) == expected

--- a/src/icalendar/tests/attr/test_alarm_factory_methods.py
+++ b/src/icalendar/tests/attr/test_alarm_factory_methods.py
@@ -412,3 +412,27 @@ def test_alarm_new_concepts_none_is_empty():
     alarm = Alarm.new(concepts=None)
     assert alarm.concepts == []
     assert "CONCEPT" not in alarm
+
+
+def test_new_email_singleton_string_attendee_normalizes():
+    """A singleton plain string attendee should normalize to a vCalAddress."""
+    alarm = Alarm.new_email(
+        summary="S",
+        description="D",
+        trigger=timedelta(minutes=-30),
+        attendees="first@example.com",
+    )
+    assert isinstance(alarm.attendees[0], vCalAddress)
+    assert str(alarm.attendees[0]) == "mailto:first@example.com"
+
+
+def test_new_email_list_with_prefixed_string_attendee_normalizes():
+    """A list containing an already-prefixed string attendee normalizes to a vCalAddress."""
+    alarm = Alarm.new_email(
+        summary="S",
+        description="D",
+        trigger=timedelta(minutes=-30),
+        attendees=["mailto:second@example.net"],
+    )
+    assert isinstance(alarm.attendees[0], vCalAddress)
+    assert str(alarm.attendees[0]) == "mailto:second@example.net"

--- a/src/icalendar/tests/test_issue_1593.py
+++ b/src/icalendar/tests/test_issue_1593.py
@@ -1,0 +1,18 @@
+"""Tests for https://github.com/collective/icalendar/issues/1593."""
+
+from icalendar import Event, vCalAddress
+
+
+def test_mixed_attendees_normalizes_only_the_string_slot():
+    """Normalize a string without replacing the list or existing address."""
+    existing = vCalAddress("mailto:existing@example.com")
+    existing.params["CN"] = "Existing User"
+    attendees = ["first@example.com", existing]
+    e = Event()
+    e.attendees = attendees
+
+    assert e.attendees is attendees
+    assert e.attendees[1] is existing
+    assert e.attendees[1].params["CN"] == "Existing User"
+    assert isinstance(e.attendees[0], vCalAddress)
+    assert str(e.attendees[0]) == "mailto:first@example.com"

--- a/src/icalendar/tests/test_issue_843_new_method_for_components.py
+++ b/src/icalendar/tests/test_issue_843_new_method_for_components.py
@@ -1201,23 +1201,3 @@ def test_modify_empty_attendees_2():
     e.attendees = attendees
     attendees.append(attendee1)
     assert e.attendees == [attendee1] == attendees
-
-
-def test_mixed_attendees_normalizes_only_the_string_slot():
-    """A list mixing a plain string and an existing vCalAddress normalizes only the string.
-
-    This preserves list identity, the identity and parameters of an existing
-    vCalAddress, and the normalization of the string slot to a vCalAddress
-    (which the generic ``==`` parametrization in ``new_test_cases`` cannot check).
-    """
-    existing = vCalAddress("mailto:existing@example.com")
-    existing.params["CN"] = "Existing User"
-    attendees = ["first@example.com", existing]
-    e = Event()
-    e.attendees = attendees
-
-    assert e.attendees is attendees
-    assert e.attendees[1] is existing
-    assert e.attendees[1].params["CN"] == "Existing User"
-    assert isinstance(e.attendees[0], vCalAddress)
-    assert str(e.attendees[0]) == "mailto:first@example.com"

--- a/src/icalendar/tests/test_issue_843_new_method_for_components.py
+++ b/src/icalendar/tests/test_issue_843_new_method_for_components.py
@@ -764,6 +764,36 @@ new_test_cases = [
         True,
         "two attendees",
     ),
+    (
+        COMPONENTS_ATTENDEES,
+        "attendees",
+        "ATTENDEE",
+        "plain@example.com",
+        [vCalAddress("mailto:plain@example.com")],
+        True,
+        "a plain email string is normalized to a vCalAddress",
+    ),
+    (
+        COMPONENTS_ATTENDEES,
+        "attendees",
+        "ATTENDEE",
+        "mailto:prefixed@example.net",
+        [vCalAddress("mailto:prefixed@example.net")],
+        True,
+        "a mailto: string is not prefixed twice",
+    ),
+    (
+        COMPONENTS_ATTENDEES,
+        "attendees",
+        "ATTENDEE",
+        ["plain@example.com", "mailto:prefixed@example.net"],
+        [
+            vCalAddress("mailto:plain@example.com"),
+            vCalAddress("mailto:prefixed@example.net"),
+        ],
+        True,
+        "a list of plain and mailto: strings is normalized",
+    ),
 ]
 
 rfc_7986_test_cases = [
@@ -1173,65 +1203,21 @@ def test_modify_empty_attendees_2():
     assert e.attendees == [attendee1] == attendees
 
 
-attendee_string_plain = "first@example.com"
-attendee_string_prefixed = "mailto:second@example.net"
-
-
-def assert_attendee_is_normalized_vcaladdress(attendee, expected: str):
-    """Check that the attendee is a vCalAddress with the exact expected value.
-
-    We cannot rely on == alone because vCalAddress subclasses str.
-    """
-    assert isinstance(attendee, vCalAddress)
-    assert str(attendee) == expected
-
-
-@pytest.mark.parametrize("component", COMPONENTS_ATTENDEES)
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        (attendee_string_plain, "mailto:first@example.com"),
-        (attendee_string_prefixed, "mailto:second@example.net"),
-    ],
-)
-def test_set_attendees_normalizes_string(component, value, expected):
-    """Setting attendees with a plain string normalizes it to a vCalAddress."""
-    c = component()
-    c.attendees = value
-    assert len(c.attendees) == 1
-    assert_attendee_is_normalized_vcaladdress(c.attendees[0], expected)
-    assert f"ATTENDEE:{expected}".encode() in c.to_ical().splitlines()
-
-
-@pytest.mark.parametrize("component", COMPONENTS_ATTENDEES)
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        (attendee_string_plain, "mailto:first@example.com"),
-        (attendee_string_prefixed, "mailto:second@example.net"),
-    ],
-)
-def test_new_with_attendees_normalizes_string(
-    component, value, expected, dont_validate_new
-):
-    """Creating with new() and a plain string attendee normalizes it to a vCalAddress."""
-    c = component.new(attendees=value)
-    assert len(c.attendees) == 1
-    assert_attendee_is_normalized_vcaladdress(c.attendees[0], expected)
-    assert f"ATTENDEE:{expected}".encode() in c.to_ical().splitlines()
-
-
 def test_mixed_attendees_normalizes_only_the_string_slot():
-    """A list mixing a plain string and an existing vCalAddress normalizes only the string."""
+    """A list mixing a plain string and an existing vCalAddress normalizes only the string.
+
+    This preserves list identity, the identity and parameters of an existing
+    vCalAddress, and the normalization of the string slot to a vCalAddress
+    (which the generic ``==`` parametrization in ``new_test_cases`` cannot check).
+    """
     existing = vCalAddress("mailto:existing@example.com")
     existing.params["CN"] = "Existing User"
-    attendees = [attendee_string_plain, existing]
+    attendees = ["first@example.com", existing]
     e = Event()
     e.attendees = attendees
 
     assert e.attendees is attendees
     assert e.attendees[1] is existing
     assert e.attendees[1].params["CN"] == "Existing User"
-    assert_attendee_is_normalized_vcaladdress(
-        e.attendees[0], "mailto:first@example.com"
-    )
+    assert isinstance(e.attendees[0], vCalAddress)
+    assert str(e.attendees[0]) == "mailto:first@example.com"

--- a/src/icalendar/tests/test_issue_843_new_method_for_components.py
+++ b/src/icalendar/tests/test_issue_843_new_method_for_components.py
@@ -1171,3 +1171,67 @@ def test_modify_empty_attendees_2():
     e.attendees = attendees
     attendees.append(attendee1)
     assert e.attendees == [attendee1] == attendees
+
+
+attendee_string_plain = "first@example.com"
+attendee_string_prefixed = "mailto:second@example.net"
+
+
+def assert_attendee_is_normalized_vcaladdress(attendee, expected: str):
+    """Check that the attendee is a vCalAddress with the exact expected value.
+
+    We cannot rely on == alone because vCalAddress subclasses str.
+    """
+    assert isinstance(attendee, vCalAddress)
+    assert str(attendee) == expected
+
+
+@pytest.mark.parametrize("component", COMPONENTS_ATTENDEES)
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (attendee_string_plain, "mailto:first@example.com"),
+        (attendee_string_prefixed, "mailto:second@example.net"),
+    ],
+)
+def test_set_attendees_normalizes_string(component, value, expected):
+    """Setting attendees with a plain string normalizes it to a vCalAddress."""
+    c = component()
+    c.attendees = value
+    assert len(c.attendees) == 1
+    assert_attendee_is_normalized_vcaladdress(c.attendees[0], expected)
+    assert f"ATTENDEE:{expected}".encode() in c.to_ical().splitlines()
+
+
+@pytest.mark.parametrize("component", COMPONENTS_ATTENDEES)
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (attendee_string_plain, "mailto:first@example.com"),
+        (attendee_string_prefixed, "mailto:second@example.net"),
+    ],
+)
+def test_new_with_attendees_normalizes_string(
+    component, value, expected, dont_validate_new
+):
+    """Creating with new() and a plain string attendee normalizes it to a vCalAddress."""
+    c = component.new(attendees=value)
+    assert len(c.attendees) == 1
+    assert_attendee_is_normalized_vcaladdress(c.attendees[0], expected)
+    assert f"ATTENDEE:{expected}".encode() in c.to_ical().splitlines()
+
+
+def test_mixed_attendees_normalizes_only_the_string_slot():
+    """A list mixing a plain string and an existing vCalAddress normalizes only the string."""
+    existing = vCalAddress("mailto:existing@example.com")
+    existing.params["CN"] = "Existing User"
+    attendees = [attendee_string_plain, existing]
+    e = Event()
+    e.attendees = attendees
+
+    assert e.attendees is attendees
+    assert e.attendees[1] is existing
+    assert e.attendees[1].params["CN"] == "Existing User"
+    assert_attendee_is_normalized_vcaladdress(
+        e.attendees[0], "mailto:first@example.com"
+    )


### PR DESCRIPTION
## Linked issue

- Closes #1593 

## Description

Allow attendee properties and component factory methods to accept email addresses as strings.

Plain email strings are normalized through vCalAddress.new(), automatically adding the mailto: prefix. Already-prefixed mailto: strings are preserved without adding another prefix.

The implementation applies consistently to:

* direct attendee-property assignment;
* Event.new();
* Todo.new();
* Journal.new();
* Alarm.new();
* Alarm.new_email().

Existing vCalAddress objects are preserved without replacing them or losing parameters such as CN, ROLE, or RSVP. Mutable attendee lists are normalized in place so their object identity is retained, while other supported sequences are converted to lists.

Public attendee type hints and documentation have been updated, and news/1593.feature records the new behavior.

The commits preserve the issue’s requested TDD structure:
- an intentionally failing tests-only commit;
- the implementation, typing, documentation, and news-fragment commit.

AI-assisted: Claude Sonnet 5 performed repository reconnaissance, OpenAI GPT-5.6 Thinking was used as a co-worker to bounce ideas off of and drafted test snippets from the recon as well, and OpenAI GPT-5 (Codex) performed minor implementation and read-only diff review. The contributor implemented, reviewed, and validated the changes.

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

### Red TDD phase

* test_issue_843_new_method_for_components.py: 17 failed, 297 passed 
* test_alarm_factory_methods.py: 2 failed, 31 passed 
* test_issue_870_vcaladdress_new.py: 36 passed

The 19 failures demonstrated that attendee email strings remained plain str objects instead of being normalized to vCalAddress.

### Focused green phase

* test_issue_843_new_method_for_components.py: 314 passed 
* test_alarm_factory_methods.py: 33 passed 
* test_issue_870_vcaladdress_new.py: 36 passed

### Complete test suite

- 16,104 passed 
- 28 skipped 
- 0 failed 
- 97% coverage

The complete test matrix passed locally for Python 3.10, 3.11, 3.12, 3.13, and PyPy 3.10.

### Documentation and change fragment

- Vale: 0 errors
- Documentation doctests: 367 passed
- Sphinx HTML build: passed
- make changes-check: passed

The final local external-link check reported two unrelated existing external-link failures:

* a 404 from a URL referenced by docs/contribute/documentation/style-guide.rst;
* an HTTP 403 response from a Stack Overflow URL in generated API documentation.

Neither affected location is changed by this pull request.