### PR TITLE
Bump maximum pull request description character count to 1500

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,12 +6,15 @@ Fill out the pull request template as described below.
 
 Do not edit or remove section headings as they are required, except "Additional information" which is optional.
 
-Comments, which consist of the content between each pair of `<!--` and `-->`, inclusive, may be removed.
+Comments, which consist of the content between each pair of `<!--` and `-->` delimiters, inclusively, may be removed.
 -->
 
 ## Linked issue
 
 <!--
+You must provide a link to an open issue that your pull request addresses.
+Only Admins and Maintainers are excluded from this requirement.
+
 Replace `ISSUE_NUMBER` with the issue number that your pull request addresses. This links the pull request to the related issue. Choose the appropriate form.
 
 If you completely resolve the issue, then use `"Closes"`.
@@ -27,6 +30,12 @@ This form keeps the issue open for future work.
 
 - See #ISSUE_NUMBER
 
+<!--
+You may also link to open pull requests that address the same issue, if applicable.
+
+- See #PULL_REQUEST_NUMBER
+-->
+
 ## Description
 
 <!--
@@ -40,7 +49,6 @@ Do not edit the checkbox list items.
 
 To indicate that you completed an item, place an `x` inside the checkbox, such as `[x]`.
 -->
-
 
 - [ ] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
 - [ ] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,14 @@
+<!--
+
+# INSTRUCTIONS
+
+Fill out the pull request template as described below.
+
+Do not edit or remove section headings as they are required, except "Additional information" which is optional.
+
+Comments, which consist of the content between each pair of `<!--` and `-->`, inclusive, may be removed.
+-->
+
 ## Linked issue
 
 <!--
@@ -18,9 +29,18 @@ This form keeps the issue open for future work.
 
 ## Description
 
+<!--
 Write a description of the fixes or improvements.
+-->
 
 ## Checklist
+
+<!--
+Do not edit the checkbox list items.
+
+To indicate that you completed an item, place an `x` inside the checkbox, such as `[x]`.
+-->
+
 
 - [ ] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
 - [ ] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: peakoss/anti-slop@v0
         with:
           max-failures: 1
-          max-description-length: 1000
+          max-description-length: 1500
           max-emoji-count: 1
           max-code-references: 3
           require-linked-issue: true

--- a/news/1602.internal
+++ b/news/1602.internal
@@ -1,0 +1,1 @@
+Bumped maximum pull request description character count to 1500. Added instructions as comments in the pull request template. @stevepiercy


### PR DESCRIPTION
- Added instructions as comments in the pull request template.

## Linked issue

- Closes #1602

## Description

- Bumped maximum pull request character count to 1500. The character count without the comments is 1,135. This encourages pull request descriptions to be concise, and to move discussion of the scope of work into the issue.
- Added improved instructions as comments in the pull request template.

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

Please excuse my mistake to push to `main` and subsequent revert of the commit.