### PR TITLE
Make "Instructions" not a section heading

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!--
 
-# INSTRUCTIONS
+INSTRUCTIONS
 
 Fill out the pull request template as described below.
 

--- a/news/+pr-template-instructions-not-heading.internal
+++ b/news/+pr-template-instructions-not-heading.internal
@@ -1,0 +1,1 @@
+Made "Instructions" not a section heading in the pull request template. "Instructions" was interpreted as a section heading, even though it is in a comment. @stevepiercy


### PR DESCRIPTION
<!--

# INSTRUCTIONS

-->

## Linked issue

- See https://github.com/collective/icalendar/actions/runs/30324660519?pr=1606

## Description

"Instructions" was interpreted as a section heading, even though it is in a comment.

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).
