### PR TITLE
Revise security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,10 @@
 # Security policy
 
-As a project under the `collective` GitHub organization as well as a dependency of Plone, icalendar follows the security policy of Plone.
+This security policy describes how to privately report _potential_ security issues with icalendar, and how the icalendar security team processes reports, all in a responsible manner.
+If you're unsure whether your issue qualifies as a security vulnerability, it's better to err on the side of caution and report it as one, allowing the icalendar security team to evaluate its merits and determine whether it's one.
 
--   [Report a security issue](https://plone.org/security/report).
--   [Security announcements](https://plone.org/security/announcements)
--   Read more about [security in Plone](https://plone.org/security).
+-   [Report a _potential_ security issue](https://github.com/collective/icalendar/security/advisories/new).
+-   [Security advisories](https://github.com/collective/icalendar/security/advisories)
 
 
 ## Supported versions
@@ -14,29 +14,32 @@ It is highly recommended to upgrade to the latest release.
 
 ## Procedure
 
-The maintainers of icalendar will coordinate with the [Plone security team](https://plone.org/security/report).
+The icalendar security team will coordinate with the [Plone security team](https://plone.org/security/report).
 
-If we determine that your report may be a security issue with the project, we may contact you for further information.
-We volunteers ask that you delay public disclosure of your report for at least ninety (90) days from the date you report it to us.
-This will allow sufficient time for us to process your report and coordinate disclosure with you.
+If it's determined that your report may be a security vulnerability with the project, the team may contact you for further information.
+As volunteers, the team asks that you delay public disclosure of your report for at least ninety (90) days from the date you report it to the team.
+This will allow sufficient time for the team to process your report and coordinate disclosure with you.
 
 Once verified and fixed, the following steps will be taken:
 
--   We will use GitHub's Security Advisory tool to report the issue.
--   GitHub will review our Security Advisory report for compliance with Common Vulnerabilities and Exposures (CVE) rules.
+-   The team will use GitHub's Security Advisory tool to report the vulnerability.
+-   GitHub will review the Security Advisory report for compliance with Common Vulnerabilities and Exposures (CVE) rules.
     If it is compliant, they will submit it to the MITRE Corporation to generate a [CVE](https://www.cve.org/).
     This in turn submits the CVE to the [National Vulnerability Database (NVD)](https://nvd.nist.gov/vuln/search).
-    GitHub notifies us of their decision.
--   Assuming it is compliant, we then publish [our Security Advisory](https://github.com/collective/icalendar/security/advisories) on GitHub, which triggers the next steps.
+    GitHub notifies the team of their decision.
+-   Assuming it is compliant, the team then publishes the [Security Advisory](https://github.com/collective/icalendar/security/advisories) on GitHub, which triggers the next steps.
 -   GitHub will publish the CVE to the CVE List.
--   GitHub will broadcast our Security Advisory via the [GitHub Advisory Database](https://github.com/advisories).
--   GitHub will send [security alerts](https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/about-alerts-for-vulnerable-dependencies) to all repositories that use our package (and have opted into security alerts).
+-   GitHub will broadcast the Security Advisory via the [GitHub Advisory Database](https://github.com/advisories).
+-   GitHub will send [security alerts](https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/about-alerts-for-vulnerable-dependencies) to all repositories that use icalendar and have opted into security alerts.
     This includes Dependabot alerts.
--   We will make a bug-fix release.
--   We will send an announcement through our usual channels:
+-   The team will make a bug-fix release.
+-   The team will send an announcement through the usual channels:
 
     - the [change log](https://github.com/collective/icalendar/CHANGES.rst)
-    - the GitHub releases of icalendar
+    - the [GitHub releases of icalendar](https://github.com/collective/icalendar/releases)
+    - [icalendar Discussions Announcements](https://github.com/collective/icalendar/discussions/categories/announcements)
+    - [icalendar Open Collective conversations](https://opencollective.com/python-icalendar/conversations)
     - [Plone's Security Announcements](https://plone.org/security/announcements)
+    - [Plone Community Forum Announcements](https://community.plone.org/c/announcements/27)
 
--   We will provide credit to the reporter or researcher in the vulnerability notice.
+-   The icalendar security team will provide credit to the reporter or researcher in the vulnerability notice.

--- a/news/1612.documentation
+++ b/news/1612.documentation
@@ -1,0 +1,1 @@
+Revised the security policy to use GitHub Security Advisory procedure instead of emailing the Plone security team, and clarified language. @stevepiercy


### PR DESCRIPTION
## Linked issue

- Closes #1612

## Description

- Revise security policy
- Use GHSA instead email
- Remove Plone from the reporting workflow
- Replace we and us with the icalendar security team or the team

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).
