### PR TITLE
Add bool return type type-hint to Parameters.is_utc

### DIFF
--- a/news/938.documentation.1
+++ b/news/938.documentation.1
@@ -1,0 +1,1 @@
+Added a ``bool`` return type annotation to :meth:`~icalendar.parser.parameter.Parameters.is_utc`. I used OpenAI Codex (GPT-5) to identify the method. @Ace-0

--- a/src/icalendar/parser/parameter.py
+++ b/src/icalendar/parser/parameter.py
@@ -455,7 +455,7 @@ class Parameters(CaselessDict):
     def tzid(self) -> str | None:
         """The TZID parameter from :rfc:`5545`."""
 
-    def is_utc(self):
+    def is_utc(self) -> bool:
         """Whether the TZID parameter is UTC."""
         return self.tzid == "UTC"
 


### PR DESCRIPTION


## Linked issue

<!--
You must provide a link to an open issue that your pull request addresses.
Only Admins and Maintainers are excluded from this requirement.

Replace `ISSUE_NUMBER` with the issue number that your pull request addresses. This links the pull request to the related issue. Choose the appropriate form.

If you completely resolve the issue, then use `"Closes"`.
GitHub will automatically close the related issue when the PR gets merged.
-->

<!--
If you resolve only a part of the issue, then use `"See"`.
This form keeps the issue open for future work.
-->

- See #938

<!--
You may also link to open pull requests that address the same issue, if applicable.

- See #PULL_REQUEST_NUMBER
-->

## Description

<!--
Write a description of the fixes or improvements.
-->

Added a `bool` return type annotation to Parameters.is_utc. 

AI model: OpenAI Codex (GPT-5).
AI use: I used Codex to identify Parameters.is_utc as a scoped function for issue #938. I made and verified the change manually.

## Checklist

<!--
Do not edit the checkbox list items.

To indicate that you completed an item, place an `x` inside the checkbox, such as `[x]`.
-->

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

One test failed as
```
docs: FAIL code 2 (130.54=setup[0.24]+cmd[130.30] seconds) 
```
Because there seems to be one broken link returning HTTP 404 in `docs/contribute/documentation/style-guide.rst:71`: 
https://documatt.com/sphinx-reredirects/usage/
Should i open a new issue for it?
