### PR TITLE
feat(alarm): add attachments getter/setter/deleter for ATTACH

### DIFF
--- a/src/icalendar/cal/alarm.py
+++ b/src/icalendar/cal/alarm.py
@@ -207,6 +207,68 @@ class Alarm(Component):
     )
 
     @property
+    def attachments(self) -> list:
+        """The ATTACH property values of this alarm.
+
+        Returns a list of :class:`~icalendar.prop.vUri` (for URI
+        attachments) or :class:`~icalendar.prop.vBinary` (for inline
+        binary data).  The list is a copy — mutating it does **not**
+        change the alarm; use the setter to replace all attachments at
+        once.
+
+        See :rfc:`5545#section-3.8.1.1`.
+
+        Example:
+
+            >>> from icalendar import Alarm
+            >>> from datetime import timedelta
+            >>> alarm = Alarm.new_audio(timedelta(minutes=-5),
+            ...     attach="ftp://example.com/bell.aud")
+            >>> alarm.attachments
+            [vUri('ftp://example.com/bell.aud')]
+        """
+        value = self.get("ATTACH")
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            return [value]
+        return list(value)
+
+    @attachments.setter
+    def attachments(self, value) -> None:
+        """Replace all ATTACH values.
+
+        Accepts a single value or a list.  ``bytes`` are wrapped in
+        :class:`~icalendar.prop.vBinary`; strings are stored as-is
+        (typically URIs).
+
+        Example:
+
+            >>> from icalendar import Alarm
+            >>> from datetime import timedelta
+            >>> alarm = Alarm.new_audio(timedelta(minutes=-5))
+            >>> alarm.attachments = ["ftp://example.com/a.aud",
+            ...                      b"\\x00\\x01raw"]
+            >>> len(alarm.attachments)
+            2
+        """
+        del self.attachments
+        if value is None:
+            return
+        if not isinstance(value, list):
+            value = [value]
+        for item in value:
+            self.add(
+                "ATTACH",
+                vBinary(item) if isinstance(item, bytes) else item,
+            )
+
+    @attachments.deleter
+    def attachments(self) -> None:
+        """Remove all ATTACH values."""
+        self.pop("ATTACH", None)
+
+    @property
     def TRIGGER_RELATED(self) -> str:
         """The RELATED parameter of the TRIGGER property.
 

--- a/src/icalendar/tests/attr/test_alarm.py
+++ b/src/icalendar/tests/attr/test_alarm.py
@@ -71,3 +71,57 @@ def test_alarm_to_string():
     a = Alarm()
     a.REPEAT = 11
     assert a.to_ical() == b"BEGIN:VALARM\r\nREPEAT:11\r\nEND:VALARM\r\n"
+
+
+def test_attachments_empty():
+    a = Alarm()
+    assert a.attachments == []
+
+
+def test_attachments_setter_uri():
+    a = Alarm()
+    a.attachments = "ftp://example.com/bell.aud"
+    assert len(a.attachments) == 1
+    assert str(a.attachments[0]) == "ftp://example.com/bell.aud"
+
+
+def test_attachments_setter_binary():
+    a = Alarm()
+    a.attachments = b"\x00\x01raw"
+    assert len(a.attachments) == 1
+
+
+def test_attachments_setter_list():
+    a = Alarm()
+    a.attachments = ["ftp://example.com/a.aud", b"\x00\x01"]
+    assert len(a.attachments) == 2
+
+
+def test_attachments_setter_replaces():
+    a = Alarm()
+    a.attachments = "ftp://example.com/old.aud"
+    a.attachments = "ftp://example.com/new.aud"
+    assert len(a.attachments) == 1
+    assert str(a.attachments[0]) == "ftp://example.com/new.aud"
+
+
+def test_attachments_setter_none_clears():
+    a = Alarm()
+    a.attachments = "ftp://example.com/bell.aud"
+    a.attachments = None
+    assert a.attachments == []
+
+
+def test_attachments_deleter():
+    a = Alarm()
+    a.attachments = "ftp://example.com/bell.aud"
+    del a.attachments
+    assert a.attachments == []
+
+
+def test_attachments_returns_copy():
+    a = Alarm()
+    a.attachments = "ftp://example.com/bell.aud"
+    lst = a.attachments
+    lst.append("extra")
+    assert len(a.attachments) == 1


### PR DESCRIPTION
Adds an `attachments` property to `Alarm` following the `attendees` pattern.

- **getter**: returns a list copy of ATTACH values (`vUri` for URIs, `vBinary` for bytes). Mutating the returned list does not affect the alarm.
- **setter**: accepts a single value or a list. `bytes` are wrapped in `vBinary`, strings stored as-is. Replaces all existing ATTACH values.
- **deleter**: removes all ATTACH values.

Rendered docs: `Alarm.attachments` — see :rfc:`5545#section-3.8.1.1`.

8 tests covering empty, URI, binary, list, replace, None-clear, delete, and copy semantics.

Closes #1613