### PR TITLE
Merge constructor docstrings into class docstrings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -173,7 +173,7 @@ apidoc_modules = [
         },
     }
 ]
-autoclass_content = "both"
+autoclass_content = "class"
 
 # -- sphinx.ext.autodoc options -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html

--- a/news/1620.documentation
+++ b/news/1620.documentation
@@ -1,0 +1,1 @@
+Merged ``__init__`` and ``__new__`` docstrings into their class docstrings, and configured Sphinx to render class docstrings only. I used OpenAI Codex (GPT-5) to inventory and migrate the docstrings, draft the regression test, and review validation output. @felix-windsor

--- a/src/icalendar/alarms.py
+++ b/src/icalendar/alarms.py
@@ -42,6 +42,14 @@ class AlarmTime:
     An AlarmTime instance combines an alarm component with its resolved
     trigger time and additional state information, such as acknowledgment
     and snoozing.
+
+    Parameters:
+        alarm: Required. The underlying alarm component.
+        trigger: Required. A date or datetime at which to trigger the alarm.
+        acknowledged_until: A datetime in UTC until which the alarm has been
+            acknowledged.
+        parent: The parent component to which the alarm refers.
+        snoozed_until: A datetime in UTC until which the alarm has been snoozed.
     """
 
     def __init__(
@@ -52,17 +60,6 @@ class AlarmTime:
         snoozed_until: datetime | None = None,
         parent: Parent | None = None,
     ):
-        """Create an instance of ``AlarmTime`` with any of its parameters.
-
-        Parameters:
-            alarm: The underlying alarm component.
-            trigger: A date or datetime at which to trigger the alarm.
-            acknowledged_until: Optional datetime in UTC until which
-                the alarm has been acknowledged.
-            snoozed_until: Optional datetime in UTC until which
-                the alarm has been snoozed.
-            parent: Optional parent component to which the alarm refers.
-        """
         self._alarm = alarm
         self._parent = parent
         self._trigger = trigger
@@ -143,48 +140,52 @@ class AlarmTime:
 class Alarms:
     """Compute the times and states of alarms.
 
-    This is an example using RFC 9074.
-    One alarm is 30 minutes before the event and acknowledged.
-    Another alarm is 15 minutes before the event and still active.
-
-    >>> from icalendar import Event, Alarms
-    >>> event = Event.from_ical(
-    ... '''BEGIN:VEVENT
-    ... CREATED:20210301T151004Z
-    ... UID:AC67C078-CED3-4BF5-9726-832C3749F627
-    ... DTSTAMP:20210301T151004Z
-    ... DTSTART;TZID=America/New_York:20210302T103000
-    ... DTEND;TZID=America/New_York:20210302T113000
-    ... SUMMARY:Meeting
-    ... BEGIN:VALARM
-    ... UID:8297C37D-BA2D-4476-91AE-C1EAA364F8E1
-    ... TRIGGER:-PT30M
-    ... ACKNOWLEDGED:20210302T150004Z
-    ... DESCRIPTION:Event reminder
-    ... ACTION:DISPLAY
-    ... END:VALARM
-    ... BEGIN:VALARM
-    ... UID:8297C37D-BA2D-4476-91AE-C1EAA364F8E1
-    ... TRIGGER:-PT15M
-    ... DESCRIPTION:Event reminder
-    ... ACTION:DISPLAY
-    ... END:VALARM
-    ... END:VEVENT
-    ... ''')
-    >>> alarms = Alarms(event)
-    >>> len(alarms.times)   # all alarms including those acknowledged
-    2
-    >>> len(alarms.active)  # the alarms that are not acknowledged, yet
-    1
-    >>> alarms.active[0].trigger  # this alarm triggers 15 minutes before 10:30
-    datetime.datetime(2021, 3, 2, 10, 15, tzinfo=ZoneInfo(key='America/New_York'))
-
     RFC 9074 specifies that alarms can also be triggered by proximity.
     This is not implemented yet.
+
+    Parameters:
+        component: An alarm, event, or to-do component with which to start the
+            computation.
+
+    Examples:
+        This example uses RFC 9074. One alarm is 30 minutes before the event and
+        acknowledged. Another alarm is 15 minutes before the event and still
+        active.
+
+        >>> from icalendar import Event, Alarms
+        >>> event = Event.from_ical(
+        ... '''BEGIN:VEVENT
+        ... CREATED:20210301T151004Z
+        ... UID:AC67C078-CED3-4BF5-9726-832C3749F627
+        ... DTSTAMP:20210301T151004Z
+        ... DTSTART;TZID=America/New_York:20210302T103000
+        ... DTEND;TZID=America/New_York:20210302T113000
+        ... SUMMARY:Meeting
+        ... BEGIN:VALARM
+        ... UID:8297C37D-BA2D-4476-91AE-C1EAA364F8E1
+        ... TRIGGER:-PT30M
+        ... ACKNOWLEDGED:20210302T150004Z
+        ... DESCRIPTION:Event reminder
+        ... ACTION:DISPLAY
+        ... END:VALARM
+        ... BEGIN:VALARM
+        ... UID:8297C37D-BA2D-4476-91AE-C1EAA364F8E1
+        ... TRIGGER:-PT15M
+        ... DESCRIPTION:Event reminder
+        ... ACTION:DISPLAY
+        ... END:VALARM
+        ... END:VEVENT
+        ... ''')
+        >>> alarms = Alarms(event)
+        >>> len(alarms.times)   # all alarms including those acknowledged
+        2
+        >>> len(alarms.active)  # the alarms that are not acknowledged, yet
+        1
+        >>> alarms.active[0].trigger  # this alarm triggers 15 minutes before 10:30
+        datetime.datetime(2021, 3, 2, 10, 15, tzinfo=ZoneInfo(key='America/New_York'))
     """
 
     def __init__(self, component: Alarm | Event | Todo | None = None):
-        """Start computing alarm times."""
         self._absolute_alarms: list[Alarm] = []
         self._start_alarms: list[Alarm] = []
         self._end_alarms: list[Alarm] = []

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -70,6 +70,8 @@ class Component(CaselessDict):
     Component is the base object for calendar, Event and the other
     components defined in :rfc:`5545`. Normally you will not use this class
     directly, but rather one of the subclasses.
+
+    Keys in the initial dictionary are normalized to uppercase.
     """
 
     name: ClassVar[str | None] = None
@@ -215,7 +217,6 @@ class Component(CaselessDict):
         return None
 
     def __init__(self, *args, **kwargs):
-        """Set keys to upper for initial dict."""
         super().__init__(*args, **kwargs)
         # set parameters here for properties that use non-default values
         self.subcomponents: list[Component] = []  # Components can be nested.

--- a/src/icalendar/cal/component_factory.py
+++ b/src/icalendar/cal/component_factory.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 class ComponentFactory(CaselessDict):
     """Registered components from :rfc:`7953` and :rfc:`5545`.
 
+    Keys in the initial dictionary are normalized to uppercase.
+
     To get a component, use this class as shown below.
 
     .. code-block:: pycon
@@ -41,7 +43,6 @@ class ComponentFactory(CaselessDict):
     """
 
     def __init__(self, *args, **kwargs):
-        """Set keys to upper for initial dict."""
         super().__init__(*args, **kwargs)
         from icalendar.cal.alarm import Alarm
         from icalendar.cal.availability import Availability

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -168,6 +168,7 @@ class LazyCalendar(Calendar):
 
     All properties of the calendar component are parsed immediately.
     Subcomponents and their properties are parsed lazily.
+    A new calendar starts with no subcomponents.
 
     Examples:
 
@@ -207,7 +208,6 @@ class LazyCalendar(Calendar):
     """The strategy pattern for subcomponents of the calendar."""
 
     def __init__(self, *args, **kwargs):
-        """Initialize the calendar."""
         self._subcomponents = InitialSubcomponentsStrategy()
         super().__init__(*args, **kwargs)
 

--- a/src/icalendar/caselessdict.py
+++ b/src/icalendar/caselessdict.py
@@ -78,26 +78,25 @@ class CaselessDict(OrderedDict):
     their original case. Keys can be provided as ``str`` or ``bytes``.
     They are converted to Unicode via :func:`~icalendar.parser_tools.to_unicode`,
     then uppercased before storage.
+
+    Parameters:
+        *args: Positional arguments passed to :class:`~collections.OrderedDict`.
+        **kwargs: Keyword arguments passed to :class:`~collections.OrderedDict`.
+
+    Examples:
+        Create a new ``CaselessDict`` and normalize existing keys to uppercase.
+
+        ..  code-block:: pycon
+
+            >>> from icalendar.caselessdict import CaselessDict
+            >>> d = CaselessDict(summary="Meeting")
+            >>> d["SUMMARY"]
+            'Meeting'
+            >>> "summary" in d
+            True
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Parameters:
-            *args: Positional arguments passed to :class:`~collections.OrderedDict`.
-            **kwargs: Keyword arguments passed to :class:`~collections.OrderedDict`.
-
-        Example:
-
-            Create a new ``CaselessDict`` and normalize existing keys to uppercase.
-
-            ..  code-block:: pycon
-
-                >>> from icalendar.caselessdict import CaselessDict
-                >>> d = CaselessDict(summary="Meeting")
-                >>> d["SUMMARY"]
-                'Meeting'
-                >>> "summary" in d
-                True
-        """
         super().__init__(*args, **kwargs)
         for key, value in self.items():
             key_upper = to_unicode(key).upper()

--- a/src/icalendar/error.py
+++ b/src/icalendar/error.py
@@ -113,7 +113,14 @@ def _repr_index(index: str | int) -> str:
 
 
 class JCalParsingError(InvalidCalendar):
-    """Could not parse a part of the JCal."""
+    """Could not parse a part of the JCal.
+
+    Parameters:
+        message: Required. A description of the error that occurred while parsing.
+        path: The location in the jCal structure where the error occurred.
+        parser: The parser class or its name where the error occurred.
+        value: The value which caused the error, if available.
+    """
 
     _default_value = object()
 
@@ -124,14 +131,6 @@ class JCalParsingError(InvalidCalendar):
         path: list[str | int] | None | str | int = None,
         value: object = _default_value,
     ) -> None:
-        """Create a new JCalParsingError.
-
-        Parameters:
-            message: A description of the error that occurred while parsing.
-            parser: The parser class or its name where the error occurred.
-            path: The location in the jCal structure where the error occurred.
-            value: The value which caused the error, if available.
-        """
         self.path = self._get_path(path)
         if not isinstance(parser, str):
             parser = parser.__name__

--- a/src/icalendar/parser/ical/component.py
+++ b/src/icalendar/parser/ical/component.py
@@ -20,6 +20,12 @@ class ComponentIcalParser:
 
     This uses the template method pattern, where the main parsing
     logic can be refined in subclasses.
+
+    Parameters:
+        component_factory: Required. The factory to use for creating components.
+        data: Required. The raw iCalendar data to parse, either as bytes or a
+            list of content lines.
+        types_factory: Required. The factory to use for creating property values.
     """
 
     datetime_names: ClassVar[tuple[str, ...]] = (
@@ -42,14 +48,6 @@ class ComponentIcalParser:
         component_factory: ComponentFactory,
         types_factory: TypesFactory,
     ):
-        """Initialize the parser with the raw data.
-
-        Parameters:
-            data: The raw iCalendar data to parse, either as bytes
-                or a list of content lines.
-            component_factory: The factory to use for creating components.
-            types_factory: The factory to use for creating property values.
-        """
         self._data = data
         self._component_factory = component_factory
         self._types_factory = types_factory

--- a/src/icalendar/parser/ical/lazy.py
+++ b/src/icalendar/parser/ical/lazy.py
@@ -92,10 +92,13 @@ class LazySubcomponent:
     """A subcomponent that is evaluated lazily.
 
     This class holds the raw data of the subcomponent ready for parsing.
+
+    Parameters:
+        name: Required. The name of the subcomponent.
+        parser: Required. The parser that holds the raw subcomponent data.
     """
 
     def __init__(self, name: str, parser: ComponentIcalParser):
-        """Initialize the lazy subcomponent with the raw data."""
         self._name = name
         self._parser = parser
         self._component: Component | None = None

--- a/src/icalendar/parser/parameter.py
+++ b/src/icalendar/parser/parameter.py
@@ -237,6 +237,7 @@ class Parameters(CaselessDict):
 
     It knows nothing of datatypes.
     Its main concern is textual structure.
+    Create new parameters from positional mappings and keyword values.
 
     Examples:
 
@@ -271,7 +272,6 @@ class Parameters(CaselessDict):
     """
 
     def __init__(self, *args, **kwargs):
-        """Create new parameters."""
         if args and args[0] is None:
             # allow passing None
             args = args[1:]

--- a/src/icalendar/prop/adr.py
+++ b/src/icalendar/prop/adr.py
@@ -51,6 +51,15 @@ class vAdr:
     Semicolons are field separators and are NOT escaped.
     Commas and backslashes within field values ARE escaped per :rfc:`6350`.
 
+    Initialize an address with seven fields or parse it from a vCard-formatted
+    string.
+
+    Parameters:
+        fields: Required. An :class:`AdrFields`, tuple, or list of seven strings,
+            one per field, or a vCard-formatted string with semicolon-separated
+            fields.
+        params: Property parameters.
+
     Examples:
         .. code-block:: pycon
 
@@ -72,13 +81,6 @@ class vAdr:
         /,
         params: dict[str, Any] | None = None,
     ):
-        """Initialize ADR with seven fields or parse from vCard format string.
-
-        Parameters:
-            fields: Either an AdrFields, tuple, or list of seven strings, one per field,
-                    or a vCard format string with semicolon-separated fields
-            params: Optional property parameters
-        """
         if isinstance(fields, str):
             fields = self.from_ical(fields)
         if isinstance(fields, AdrFields):

--- a/src/icalendar/prop/factory.py
+++ b/src/icalendar/prop/factory.py
@@ -40,6 +40,8 @@ class TypesFactory(CaselessDict):
 
     The value and parameter names don't overlap. So one factory is enough for
     both kinds.
+
+    Keys in the initial dictionary are normalized to uppercase.
     """
 
     _instance: ClassVar[TypesFactory | None] = None
@@ -51,7 +53,6 @@ class TypesFactory(CaselessDict):
         return TypesFactory._instance
 
     def __init__(self, *args, **kwargs):
-        """Set keys to upper for initial dict"""
         super().__init__(*args, **kwargs)
         self.all_types = (
             vBinary,

--- a/src/icalendar/prop/geo.py
+++ b/src/icalendar/prop/geo.py
@@ -9,7 +9,16 @@ from icalendar.parser import Parameters
 
 
 class vGeo:
-    """Geographic Position
+    """Geographic position.
+
+    Create a geographic position from a tuple of latitude and longitude.
+
+    Parameters:
+        geo: Required. A tuple of latitude and longitude.
+        params: Property parameters.
+
+    Raises:
+        ValueError: If ``geo`` is not a tuple of latitude and longitude.
 
     Property Name:
         GEO
@@ -76,11 +85,6 @@ class vGeo:
         /,
         params: dict[str, Any] | None = None,
     ):
-        """Create a new vGeo from a tuple of (latitude, longitude).
-
-        Raises:
-            ValueError: if geo is not a tuple of (latitude, longitude)
-        """
         try:
             latitude, longitude = (geo[0], geo[1])
             latitude = float(latitude)

--- a/src/icalendar/prop/image.py
+++ b/src/icalendar/prop/image.py
@@ -35,11 +35,11 @@ class Image:
         on the image in the calendar user agent.
 
     Parameters:
-        uri: The URI of the image.
+        altrep: The link target of the image.
         b64data: The data of the image, base64 encoded.
+        display: The display mode, for example, ``"BADGE"``.
         fmttype: The format type, e.g. ``"image/png"``.
-        altrep: Link target of the image.
-        display: The display mode, e.g. ``"BADGE"``.
+        uri: The URI of the image.
 
     """
 
@@ -84,7 +84,6 @@ class Image:
         altrep: str | None = None,
         display: str | None = None,
     ) -> None:
-        """Create a new image according to :rfc:`7986`."""
         if uri is not None and b64data is not None:
             raise ValueError("Image cannot have both URI and binary data (RFC 7986)")
         if uri is None and b64data is None:

--- a/src/icalendar/prop/n.py
+++ b/src/icalendar/prop/n.py
@@ -44,6 +44,14 @@ class vN:
     Semicolons are field separators and are NOT escaped.
     Commas and backslashes within field values ARE escaped per :rfc:`6350`.
 
+    Initialize a name with five fields or parse it from a vCard-formatted string.
+
+    Parameters:
+        fields: Required. An :class:`NFields`, tuple, or list of five strings,
+            one per field, or a vCard-formatted string with semicolon-separated
+            fields.
+        params: Property parameters.
+
     Examples:
 
         .. code-block:: pycon
@@ -66,13 +74,6 @@ class vN:
         /,
         params: dict[str, Any] | None = None,
     ):
-        """Initialize N with five fields or parse from vCard format string.
-
-        Parameters:
-            fields: Either an NFields, tuple, or list of five strings, one per field,
-                    or a vCard format string with semicolon-separated fields
-            params: Optional property parameters
-        """
         if isinstance(fields, str):
             fields = self.from_ical(fields)
         if isinstance(fields, NFields):

--- a/src/icalendar/prop/org.py
+++ b/src/icalendar/prop/org.py
@@ -25,6 +25,14 @@ class vOrg:
     Semicolons are field separators and are NOT escaped.
     Commas and backslashes within field values ARE escaped per :rfc:`6350`.
 
+    Initialize an organization with one or more fields or parse it from a
+    vCard-formatted string.
+
+    Parameters:
+        fields: Required. A tuple or list of one or more strings, or a
+            vCard-formatted string with semicolon-separated fields.
+        params: Property parameters.
+
     Examples:
         A property value consisting of an organizational name,
         organizational unit #1 name, and organizational unit #2 name.
@@ -55,13 +63,6 @@ class vOrg:
         /,
         params: dict[str, Any] | None = None,
     ):
-        """Initialize ORG with variable fields or parse from vCard format string.
-
-        Parameters:
-            fields: Either a tuple or list of one or more strings, or a
-                    vCard format string with semicolon-separated fields
-            params: Optional property parameters
-        """
         if isinstance(fields, str):
             fields = self.from_ical(fields)
         if len(fields) < 1:

--- a/src/icalendar/tests/test_docstrings.py
+++ b/src/icalendar/tests/test_docstrings.py
@@ -6,8 +6,10 @@ As docstrings are fixed, their headings may be removed from this set.
 See https://github.com/collective/icalendar/issues/1481
 """
 
+import ast
 import inspect
 import re
+from pathlib import Path
 
 import pytest
 
@@ -84,6 +86,28 @@ def get_public_objects():
 def _obj_id(obj):
     """Return the name of the object for parametrize IDs."""
     return obj.__name__
+
+
+def test_constructor_methods_have_no_docstrings():
+    """Ensure class documentation is not split across constructor docstrings."""
+    package_path = Path(icalendar.__file__).parent
+    constructors_with_docstrings = []
+
+    for path in sorted(package_path.rglob("*.py")):
+        module = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(module):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name in {"__init__", "__new__"}
+                and ast.get_docstring(node, clean=False) is not None
+            ):
+                relative_path = path.relative_to(package_path)
+                constructors_with_docstrings.append(f"{relative_path}:{node.lineno}")
+
+    assert not constructors_with_docstrings, (
+        "Move constructor docstrings into their class docstrings: "
+        f"{', '.join(constructors_with_docstrings)}"
+    )
 
 
 @pytest.mark.parametrize("obj", get_public_objects(), ids=_obj_id)

--- a/src/icalendar/tests/test_issue_798_property_parameters.py
+++ b/src/icalendar/tests/test_issue_798_property_parameters.py
@@ -23,10 +23,11 @@ from icalendar.timezone.tzp import TZP
 
 
 class Prop:
+    """A property used to test property parameters."""
+
     params: Parameters
 
     def __init__(self, **parameters):
-        """Create a new property."""
         self.params = Parameters(parameters)
 
     def to_ical(self) -> str:

--- a/src/icalendar/timezone/tzp.py
+++ b/src/icalendar/timezone/tzp.py
@@ -24,10 +24,12 @@ class TZP:
     If you would like to have another timezone implementation,
     you can create a new one and pass it to this proxy.
     All of icalendar will then use this timezone implementation.
+
+    Parameters:
+        provider: The timezone provider or the name of a registered provider.
     """
 
     def __init__(self, provider: str | TZProvider = DEFAULT_TIMEZONE_PROVIDER):
-        """Create a new timezone implementation proxy."""
         self.use(provider)
 
     def use_pytz(self) -> None:


### PR DESCRIPTION
## Linked issue

- Closes #1620

## Description

Moves every `__init__` and `__new__` docstring in the package into its containing class docstring so API documentation has a single source of class-level content.

This also:

- configures Sphinx with `autoclass_content = "class"`;
- preserves and organizes existing parameter, example, and exception documentation;
- adds an AST regression test that reports any constructor docstrings added later;
- adds the required documentation news fragment.

Responsible AI disclosure: I used OpenAI Codex (GPT-5) to inventory and migrate the docstrings, draft the AST regression test, update the Sphinx configuration and news entry, and review validation output. I reviewed the complete diff and validated the changes locally.

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar project guidelines for [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

Local validation:

- `uv run pytest -q`: 17,888 passed, 28 skipped, 529 xfailed.
- `make test`: CPython 3.10, 3.11, 3.12, 3.13, and 3.14 passed; the `nopytz` environment passed.
- `CARGO_NET_GIT_FETCH_WITH_CLI=true uv run tox -e pypy3`: passed with 97% coverage.
- Strict `make html` Sphinx build: passed with warnings treated as errors.
- `uv run ruff format --check`, `uv run ruff check`, and `git diff --check`: passed.

The combined docs tox run completed HTML, doctest, and Vale successfully; its link-check phase only reported two pre-existing external-site responses unrelated to this change: a 404 from the sphinx-reredirects documentation URL and a 403 from a Stack Overflow timezone link.