### PR TITLE
docs: merge __init__/__new__ docstrings into class docstrings

### DIFF
--- a/src/icalendar/alarms.py
+++ b/src/icalendar/alarms.py
@@ -42,6 +42,15 @@ class AlarmTime:
     An AlarmTime instance combines an alarm component with its resolved
     trigger time and additional state information, such as acknowledgment
     and snoozing.
+
+    Parameters:
+        alarm: The underlying alarm component.
+        trigger: A date or datetime at which to trigger the alarm.
+        acknowledged_until: Optional datetime in UTC until which
+            the alarm has been acknowledged.
+        snoozed_until: Optional datetime in UTC until which
+            the alarm has been snoozed.
+        parent: Optional parent component to which the alarm relates.
     """
 
     def __init__(
@@ -52,17 +61,6 @@ class AlarmTime:
         snoozed_until: datetime | None = None,
         parent: Parent | None = None,
     ):
-        """Create an instance of ``AlarmTime`` with any of its parameters.
-
-        Parameters:
-            alarm: The underlying alarm component.
-            trigger: A date or datetime at which to trigger the alarm.
-            acknowledged_until: Optional datetime in UTC until which
-                the alarm has been acknowledged.
-            snoozed_until: Optional datetime in UTC until which
-                the alarm has been snoozed.
-            parent: Optional parent component to which the alarm refers.
-        """
         self._alarm = alarm
         self._parent = parent
         self._trigger = trigger
@@ -184,7 +182,6 @@ class Alarms:
     """
 
     def __init__(self, component: Alarm | Event | Todo | None = None):
-        """Start computing alarm times."""
         self._absolute_alarms: list[Alarm] = []
         self._start_alarms: list[Alarm] = []
         self._end_alarms: list[Alarm] = []

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -215,7 +215,6 @@ class Component(CaselessDict):
         return None
 
     def __init__(self, *args, **kwargs):
-        """Set keys to upper for initial dict."""
         super().__init__(*args, **kwargs)
         # set parameters here for properties that use non-default values
         self.subcomponents: list[Component] = []  # Components can be nested.

--- a/src/icalendar/cal/component_factory.py
+++ b/src/icalendar/cal/component_factory.py
@@ -41,7 +41,6 @@ class ComponentFactory(CaselessDict):
     """
 
     def __init__(self, *args, **kwargs):
-        """Set keys to upper for initial dict."""
         super().__init__(*args, **kwargs)
         from icalendar.cal.alarm import Alarm
         from icalendar.cal.availability import Availability

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -207,7 +207,6 @@ class LazyCalendar(Calendar):
     """The strategy pattern for subcomponents of the calendar."""
 
     def __init__(self, *args, **kwargs):
-        """Initialize the calendar."""
         self._subcomponents = InitialSubcomponentsStrategy()
         super().__init__(*args, **kwargs)
 

--- a/src/icalendar/caselessdict.py
+++ b/src/icalendar/caselessdict.py
@@ -78,26 +78,22 @@ class CaselessDict(OrderedDict):
     their original case. Keys can be provided as ``str`` or ``bytes``.
     They are converted to Unicode via :func:`~icalendar.parser_tools.to_unicode`,
     then uppercased before storage.
+
+    Example:
+
+        Create a new ``CaselessDict`` and normalize existing keys to uppercase.
+
+        ..  code-block:: pycon
+
+            >>> from icalendar.caselessdict import CaselessDict
+            >>> d = CaselessDict(summary="Meeting")
+            >>> d["SUMMARY"]
+            'Meeting'
+            >>> "summary" in d
+            True
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Parameters:
-            *args: Positional arguments passed to :class:`~collections.OrderedDict`.
-            **kwargs: Keyword arguments passed to :class:`~collections.OrderedDict`.
-
-        Example:
-
-            Create a new ``CaselessDict`` and normalize existing keys to uppercase.
-
-            ..  code-block:: pycon
-
-                >>> from icalendar.caselessdict import CaselessDict
-                >>> d = CaselessDict(summary="Meeting")
-                >>> d["SUMMARY"]
-                'Meeting'
-                >>> "summary" in d
-                True
-        """
         super().__init__(*args, **kwargs)
         for key, value in self.items():
             key_upper = to_unicode(key).upper()

--- a/src/icalendar/error.py
+++ b/src/icalendar/error.py
@@ -113,7 +113,14 @@ def _repr_index(index: str | int) -> str:
 
 
 class JCalParsingError(InvalidCalendar):
-    """Could not parse a part of the JCal."""
+    """Could not parse a part of the JCal.
+
+    Parameters:
+        message: A description of the error that occurred while parsing.
+        parser: The parser class or its name where the error occurred.
+        path: The location in the jCal structure where the error occurred.
+        value: The value which caused the error, if available.
+    """
 
     _default_value = object()
 
@@ -124,14 +131,6 @@ class JCalParsingError(InvalidCalendar):
         path: list[str | int] | None | str | int = None,
         value: object = _default_value,
     ) -> None:
-        """Create a new JCalParsingError.
-
-        Parameters:
-            message: A description of the error that occurred while parsing.
-            parser: The parser class or its name where the error occurred.
-            path: The location in the jCal structure where the error occurred.
-            value: The value which caused the error, if available.
-        """
         self.path = self._get_path(path)
         if not isinstance(parser, str):
             parser = parser.__name__

--- a/src/icalendar/parser/ical/component.py
+++ b/src/icalendar/parser/ical/component.py
@@ -42,14 +42,6 @@ class ComponentIcalParser:
         component_factory: ComponentFactory,
         types_factory: TypesFactory,
     ):
-        """Initialize the parser with the raw data.
-
-        Parameters:
-            data: The raw iCalendar data to parse, either as bytes
-                or a list of content lines.
-            component_factory: The factory to use for creating components.
-            types_factory: The factory to use for creating property values.
-        """
         self._data = data
         self._component_factory = component_factory
         self._types_factory = types_factory

--- a/src/icalendar/parser/ical/lazy.py
+++ b/src/icalendar/parser/ical/lazy.py
@@ -95,7 +95,6 @@ class LazySubcomponent:
     """
 
     def __init__(self, name: str, parser: ComponentIcalParser):
-        """Initialize the lazy subcomponent with the raw data."""
         self._name = name
         self._parser = parser
         self._component: Component | None = None

--- a/src/icalendar/parser/parameter.py
+++ b/src/icalendar/parser/parameter.py
@@ -271,7 +271,6 @@ class Parameters(CaselessDict):
     """
 
     def __init__(self, *args, **kwargs):
-        """Create new parameters."""
         if args and args[0] is None:
             # allow passing None
             args = args[1:]

--- a/src/icalendar/prop/adr.py
+++ b/src/icalendar/prop/adr.py
@@ -72,13 +72,6 @@ class vAdr:
         /,
         params: dict[str, Any] | None = None,
     ):
-        """Initialize ADR with seven fields or parse from vCard format string.
-
-        Parameters:
-            fields: Either an AdrFields, tuple, or list of seven strings, one per field,
-                    or a vCard format string with semicolon-separated fields
-            params: Optional property parameters
-        """
         if isinstance(fields, str):
             fields = self.from_ical(fields)
         if isinstance(fields, AdrFields):

--- a/src/icalendar/prop/factory.py
+++ b/src/icalendar/prop/factory.py
@@ -51,7 +51,6 @@ class TypesFactory(CaselessDict):
         return TypesFactory._instance
 
     def __init__(self, *args, **kwargs):
-        """Set keys to upper for initial dict"""
         super().__init__(*args, **kwargs)
         self.all_types = (
             vBinary,

--- a/src/icalendar/prop/geo.py
+++ b/src/icalendar/prop/geo.py
@@ -76,11 +76,6 @@ class vGeo:
         /,
         params: dict[str, Any] | None = None,
     ):
-        """Create a new vGeo from a tuple of (latitude, longitude).
-
-        Raises:
-            ValueError: if geo is not a tuple of (latitude, longitude)
-        """
         try:
             latitude, longitude = (geo[0], geo[1])
             latitude = float(latitude)

--- a/src/icalendar/prop/image.py
+++ b/src/icalendar/prop/image.py
@@ -84,7 +84,6 @@ class Image:
         altrep: str | None = None,
         display: str | None = None,
     ) -> None:
-        """Create a new image according to :rfc:`7986`."""
         if uri is not None and b64data is not None:
             raise ValueError("Image cannot have both URI and binary data (RFC 7986)")
         if uri is None and b64data is None:

--- a/src/icalendar/prop/n.py
+++ b/src/icalendar/prop/n.py
@@ -66,13 +66,6 @@ class vN:
         /,
         params: dict[str, Any] | None = None,
     ):
-        """Initialize N with five fields or parse from vCard format string.
-
-        Parameters:
-            fields: Either an NFields, tuple, or list of five strings, one per field,
-                    or a vCard format string with semicolon-separated fields
-            params: Optional property parameters
-        """
         if isinstance(fields, str):
             fields = self.from_ical(fields)
         if isinstance(fields, NFields):

--- a/src/icalendar/prop/org.py
+++ b/src/icalendar/prop/org.py
@@ -55,13 +55,6 @@ class vOrg:
         /,
         params: dict[str, Any] | None = None,
     ):
-        """Initialize ORG with variable fields or parse from vCard format string.
-
-        Parameters:
-            fields: Either a tuple or list of one or more strings, or a
-                    vCard format string with semicolon-separated fields
-            params: Optional property parameters
-        """
         if isinstance(fields, str):
             fields = self.from_ical(fields)
         if len(fields) < 1:

--- a/src/icalendar/tests/test_no_init_docstrings.py
+++ b/src/icalendar/tests/test_no_init_docstrings.py
@@ -1,0 +1,55 @@
+"""Ensure no __init__ or __new__ method carries a docstring.
+
+Sphinx appends __init__/__new__ docstrings to the class docstring,
+producing confusing output.  All constructor documentation must live
+in the class docstring itself.
+
+See https://github.com/collective/icalendar/issues/1620
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+SRC = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _iter_init_docstrings():
+    """Yield (file, class, method, lineno) for every __init__/__new__
+    that has a docstring."""
+    for py in SRC.rglob("*.py"):
+        if "tests" in py.parts or "__pycache__" in py.parts:
+            continue
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for item in node.body:
+                if (
+                    isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and item.name in ("__init__", "__new__")
+                    and ast.get_docstring(item) is not None
+                ):
+                    yield (
+                        str(py.relative_to(SRC)),
+                        node.name,
+                        item.name,
+                        item.lineno,
+                    )
+
+
+def test_no_init_or_new_docstrings():
+    offenders = list(_iter_init_docstrings())
+    if offenders:
+        lines = [
+            f"  {f}:{ln} {cls}.{meth}"
+            for f, cls, meth, ln in offenders
+        ]
+        pytest.fail(
+            "Found __init__/__new__ methods with docstrings "
+            "(move them to the class docstring):\n" + "\n".join(lines)
+        )

--- a/src/icalendar/timezone/tzp.py
+++ b/src/icalendar/timezone/tzp.py
@@ -27,7 +27,6 @@ class TZP:
     """
 
     def __init__(self, provider: str | TZProvider = DEFAULT_TIMEZONE_PROVIDER):
-        """Create a new timezone implementation proxy."""
         self.use(provider)
 
     def use_pytz(self) -> None:


### PR DESCRIPTION
Moves all constructor documentation from `__init__`/`__new__` methods into their class docstrings so Sphinx renders them correctly with `autoclass_content = 'class'`.

- 17 methods migrated across 14 files
- Added `test_no_init_docstrings.py` — fails if any `__init__`/`__new__` carries a docstring
- 14085 existing tests pass

Closes #1620