### PR TITLE
docs: include availability categories references

### DIFF
--- a/news/1624.documentation
+++ b/news/1624.documentation
@@ -1,0 +1,2 @@
+Updated the ``categories`` property documentation to include the ``Available``
+and ``Availability`` components and its RFC 7953 conformance reference.

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -669,13 +669,16 @@ You can get, set, and delete categories for a component.
 
 This property can be used in icalendar through its Python attributes of:
 
+-   :attr:`Available.categories <icalendar.cal.available.Available.categories>`
+-   :attr:`Availability.categories <icalendar.cal.availability.Availability.categories>`
 -   :attr:`Calendar.categories <icalendar.cal.calendar.Calendar.categories>`
 -   :attr:`Event.categories <icalendar.cal.event.Event.categories>`
 -   :attr:`Journal.categories <icalendar.cal.journal.Journal.categories>`
 -   :attr:`Todo.categories <icalendar.cal.todo.Todo.categories>`
 
-The categories property for ``Event``, ``Journal``, and ``Todo`` complies
-with :rfc:`5545#section-3.8.1.2`, and for ``Calendar`` with :rfc:`7986#section-5.6`.
+The categories property for ``Available`` and ``Availability`` complies with
+:rfc:`7953#section-3.1`, for ``Event``, ``Journal``, and ``Todo`` with
+:rfc:`5545#section-3.8.1.2`, and for ``Calendar`` with :rfc:`7986#section-5.6`.
 
 Note:
     At present, icalendar doesn't take the LANGUAGE parameter as defined


### PR DESCRIPTION
Closes #1624.\n\nThe shared categories_property docstring now lists Available.categories and Availability.categories, and cites RFC 7953 section 3.1 alongside the existing RFC references. This keeps the change limited to the requested documentation slice.\n\nValidation:\n- python -m compileall -q src\n- git diff --check\n\nThe repository's optional documentation and test tools are not installed in this environment.