### PR TITLE
Add test confirming CR is normalized after round trip

### DIFF
--- a/src/icalendar/tests/test_parsing.py
+++ b/src/icalendar/tests/test_parsing.py
@@ -333,6 +333,16 @@ def test_lone_carriage_return_cannot_inject_content_line():
     )
 
 
+def test_carriage_return_normalized_after_round_trip():
+    r"""Issue #1477: after a serialise/parse round trip, ``\r`` is never
+    preserved, so a value written with ``\r`` and one written with ``\n``
+    come out identical."""
+    event = Event()
+    event.add("SUMMARY", "safe\rvalue")
+    round_tripped = Event.from_ical(event.to_ical())
+    assert round_tripped["SUMMARY"] == "safe\nvalue"
+
+
 def test_split_on_unescaped_comma():
     """Test splitting on unescaped commas."""
     from icalendar.parser import split_on_unescaped_comma


### PR DESCRIPTION
Adds a test for the round-trip normalization behavior discussed in #1477 
   (bullet 4): after serializing and re-parsing an event, a value written 
   with `\r` and one written with `\n` compare equal, since `_escape_char` 
   already normalizes all newline variants to `\n` on serialize.

   This covers the last unaddressed bullet in #1477; the escape-side 
   behavior (bullet 1) and RFC 6868 parameter round-trip (bullets 2-3) 
   were already covered by existing tests.