### PR TITLE
Fix broken link to Component.to_ical in parse-errors docs

### DIFF
--- a/docs/how-to/parse-errors.rst
+++ b/docs/how-to/parse-errors.rst
@@ -94,7 +94,7 @@ One broken property does not prevent access to other valid properties in the sam
 Round-trip serialization
 ------------------------
 
-Broken properties preserve their raw values, so they serialize correctly with :meth:`~icalendar.cal.component.Component.to_ical`.
+Broken properties preserve their raw values, so they serialize correctly with :meth:`Component.to_ical <icalendar.cal.component.Component.to_ical>`.
 
 .. code-block:: pycon
 

--- a/docs/how-to/parse-errors.rst
+++ b/docs/how-to/parse-errors.rst
@@ -94,7 +94,7 @@ One broken property does not prevent access to other valid properties in the sam
 Round-trip serialization
 ------------------------
 
-Broken properties preserve their raw values, so they serialize correctly with :meth:`~icalendar.Component.to_ical`.
+Broken properties preserve their raw values, so they serialize correctly with :meth:`~icalendar.cal.component.Component.to_ical`.
 
 .. code-block:: pycon
 

--- a/news/1158.documentation
+++ b/news/1158.documentation
@@ -1,3 +1,1 @@
-Fixed the broken link to `Component.to_ical` in the documentation of how to handle parsing errors.
-
-AI disclosure: used Claude Sonnet 5 with the prompt "Fix broken links to Python objects in parse-errors.rst" to assist with this change. @SemTiOne
+Fixed the broken link to `Component.to_ical` in the documentation of how to handle parsing errors. AI disclosure: used Claude Sonnet 5 with the prompt "Fix broken links to Python objects in parse-errors.rst" to assist with this change. @SemTiOne

--- a/news/1158.documentation
+++ b/news/1158.documentation
@@ -1,0 +1,3 @@
+Fixed the broken link to `Component.to_ical` in the documentation of how to handle parsing errors.
+
+AI disclosure: used Claude Sonnet 5 with the prompt "Fix broken links to Python objects in parse-errors.rst" to assist with this change. @SemTiOne

--- a/news/1158.documentation
+++ b/news/1158.documentation
@@ -1,1 +1,1 @@
-Fixed the broken link to `Component.to_ical` in the documentation of how to handle parsing errors. AI disclosure: used Claude Sonnet 5 with the prompt "Fix broken links to Python objects in parse-errors.rst" to assist with this change. @SemTiOne
+Fixed the broken link to :meth:`Component.to_ical <icalendar.cal.component.Component.to_ical>` in the documentation of how to handle parsing errors. AI disclosure: used Claude Sonnet 5 with the prompt "Fix broken links to Python objects in parse-errors.rst" to assist with this change. @SemTiOne


### PR DESCRIPTION
## Linked issue

- See #1158

## Description

Fixed a broken link in `docs/how-to/parse-errors.rst` that pointed to `icalendar.Component.to_ical`. The link now points to the full definition path `icalendar.cal.component.Component.to_ical`.

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).
