### PR TITLE
Fix test component has examples for alarm

### DIFF
--- a/news/743.chore
+++ b/news/743.chore
@@ -1,0 +1,1 @@
+Fix incomplete example tests for ``Alarm``. ``test_component_has_examples`` was adapted for ``Alarm.example()`` but never used to test an example for ``Alarm``. @angatha

--- a/src/icalendar/tests/test_examples.py
+++ b/src/icalendar/tests/test_examples.py
@@ -49,6 +49,9 @@ def test_creating_calendar_with_unicode_fields(calendars, utc):
         (Event, "event_with_rsvp"),
         (Timezone, "pacific_fiji"),
         (Todo, "example"),
+        (Alarm, "example"),
+        (Alarm, "rfc_5545_end"),
+        (Alarm, "start_date"),
     ],
 )
 def test_component_has_examples(


### PR DESCRIPTION
## Linked issue

- See #743
- Related to #1027

## Description

#1027 introduced examples for `Alarm` and updated the tests. `test_component_has_examples` however was not fully updated. A module was added but no actual new test. This adds such tests.

## Checklist

<!--
Do not edit the checkbox list items.

To indicate that you completed an item, place an `x` inside the checkbox, such as `[x]`.
-->

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

