### PR TITLE
fix(sdist): include funding.json in hatch build for 7.x (#1493)

### DIFF
--- a/news/1648.bugfix.rst
+++ b/news/1648.bugfix.rst
@@ -1,1 +1,1 @@
-Include ``funding.json`` in the sdist tarball.
+Include :file:`funding.json` in the sdist tarball. @ChickenisLegit

--- a/news/1648.bugfix.rst
+++ b/news/1648.bugfix.rst
@@ -1,0 +1,1 @@
+Include ``funding.json`` in the sdist tarball.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,9 @@ exclude = [
   "/htmlcov",
 ]
 
+[tool.hatch.build.targets.sdist.force-include]
+"funding.json" = "funding.json"
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/icalendar"]
 


### PR DESCRIPTION
This PR backports the fix from #1494 to the 7.x branch to ensure \unding.json\ is included in the source distribution. Fixes #1493.