### PR TITLE
Contributes to #1072: apply Google style to docstrings in Component

### DIFF
--- a/news/1072.documentation
+++ b/news/1072.documentation
@@ -1,1 +1,1 @@
-Improved the docstrings of :meth:\`~icalendar.cal.component.Component._encode\`, :meth:\`~icalendar.cal.component.Component.walk\`, and :meth:\`~icalendar.cal.component.Component.to_ical\` to follow the Google-style format. I used AI to assist me with this change. @anuragdewangan48-gif
+Added a docstring to the :func:\`~icalendar.cli.main\` function to follow the project's Google Style guide. @Areej-cs

--- a/news/1072.documentation
+++ b/news/1072.documentation
@@ -1,1 +1,1 @@
-Added a docstring to the :func:`~icalendar.cli.main` function to follow the project's Google Style guide. @Areej-cs
+Improved the docstrings of :meth:\`~icalendar.cal.component.Component._encode\`, :meth:\`~icalendar.cal.component.Component.walk\`, and :meth:\`~icalendar.cal.component.Component.to_ical\` to follow the Google-style format. I used AI to assist me with this change. @anuragdewangan48-gif

--- a/news/1072.documentation.1
+++ b/news/1072.documentation.1
@@ -1,1 +1,1 @@
-Improved docstrings in :mod:`icalendar.error` to follow the project's Google-style docstring format, adding ``Parameters`` and ``Returns`` sections where appropriate. I used AI to assist me with this change. @Vrinda0211
+Improved the docstrings of :meth:\`~icalendar.cal.component.Component._encode\`, :meth:\`~icalendar.cal.component.Component.walk\`, and :meth:\`~icalendar.cal.component.Component.to_ical\` to follow the Google-style format. I used AI to assist me with this change. @anuragdewangan48-gif

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -250,23 +250,18 @@ class Component(CaselessDict):
     def _encode(cls, name, value, parameters=None, encode=1):
         """Encode values to icalendar property values.
 
-        :param name: Name of the property.
-        :type name: string
+        Args:
+            name (str): Name of the property.
+            value: Value of the property. Either a basic Python type or
+                any of icalendar's own property types.
+            parameters (dict, optional): Property parameter dictionary for
+                the value. Only available if encode is set to True.
+            encode (bool): True, if the value should be encoded to one of
+                icalendar's own property types (fallback is "vText"), or
+                False, if not.
 
-        :param value: Value of the property. Either of a basic Python type of
-                      any of the icalendar's own property types.
-        :type value: Python native type or icalendar property type.
-
-        :param parameters: Property parameter dictionary for the value. Only
-                           available, if encode is set to True.
-        :type parameters: Dictionary
-
-        :param encode: True, if the value should be encoded to one of
-                       icalendar's own property types (Fallback is "vText")
-                       or False, if not.
-        :type encode: Boolean
-
-        :returns: icalendar property value
+        Returns:
+            icalendar property value.
         """
         if not encode:
             return value
@@ -457,12 +452,15 @@ class Component(CaselessDict):
         """Recursively traverses component and subcomponents. Returns sequence
         of same. If name is passed, only components with name will be returned.
 
-        :param name: The name of the component or None such as ``VEVENT``.
-        :param select: A function that takes the component as first argument
-          and returns True/False.
-        :returns: A list of components that match.
-        :rtype: list[Component]
+        Args:
+            name (str, optional): The name of the component or None such as ``VEVENT``.
+            select (callable, optional): A function that takes the component
+                as first argument and returns True/False.
+
+        Returns:
+            list[Component]: A list of components that match.
         """
+       
         if name is not None:
             name = name.upper()
         return self._walk(name, select)
@@ -618,9 +616,11 @@ class Component(CaselessDict):
         return contentlines
 
     def to_ical(self, sorted: bool = True):
-        """
-        :param sorted: Whether parameters and properties should be
-                       lexicographically sorted.
+        """Return this component as an iCalendar formatted string.
+
+        Args:
+            sorted (bool): Whether parameters and properties should be
+                lexicographically sorted.
         """
 
         content_lines = self.content_lines(sorted=sorted)

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -252,15 +252,11 @@ class Component(CaselessDict):
     ):
         """Encode values to icalendar property values.
 
-             Parameters:
+        Parameters:
             name: Required. Name of the property.
-            value: Required. Value of the property. Either a basic Python type
-                or any of icalendar's own property types.
-            encode: True if the value should be encoded to one of
-                icalendar's own property types (fallback is "vText"),
-                or False if not.
-            parameters: Property parameter dictionary for the value. Only
-                available if encode is set to True.
+            value: Required. Value of the property. Either a basic Python type or any of icalendar's own property types.
+            encode: True if the value should be encoded to one of icalendar's own property types (fallback is "vText"), or False if not.
+            parameters: Property parameter dictionary for the value. Only available if encode is set to True.
 
         Returns:
             icalendar property value.
@@ -451,13 +447,11 @@ class Component(CaselessDict):
         name: str | None = None,
         select: callable[[Component], bool] = lambda _: True,
     ) -> list[Component]:
-        """Recursively traverses component and subcomponents. Returns sequence
-        of same. If name is passed, only components with name will be returned.
+        """Recursively traverses component and subcomponents. Returns sequence of same. If name is passed, only components with name will be returned.
 
-         Parameters:
+        Parameters:
             name: The name of the component or None such as ``VEVENT``.
-            select: A function that takes the component as first argument
-                and returns True/False.
+            select: A function that takes the component as first argument and returns True/False.
 
         Returns:
             A list of components that match.

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -250,18 +250,18 @@ class Component(CaselessDict):
     def _encode(cls, name, value, parameters=None, encode=1):
         """Encode values to icalendar property values.
 
-        Args:
-            name (str): Name of the property.
-            value: Value of the property. Either a basic Python type or
-                any of icalendar's own property types.
-            parameters (dict, optional): Property parameter dictionary for
-                the value. Only available if encode is set to True.
-            encode (bool): True, if the value should be encoded to one of
-                icalendar's own property types (fallback is "vText"), or
-                False, if not.
+         Parameters:
+        name: Required. Name of the property.
+        value: Required. Value of the property. Either a basic Python type
+            or any of icalendar's own property types.
+        encode: True if the value should be encoded to one of
+            icalendar's own property types (fallback is "vText"),
+            or False if not.
+        parameters: Property parameter dictionary for the value. Only
+            available if encode is set to True.
 
-        Returns:
-            icalendar property value.
+    Returns:
+        icalendar property value.
         """
         if not encode:
             return value
@@ -452,15 +452,14 @@ class Component(CaselessDict):
         """Recursively traverses component and subcomponents. Returns sequence
         of same. If name is passed, only components with name will be returned.
 
-        Args:
-            name (str, optional): The name of the component or None such as ``VEVENT``.
-            select (callable, optional): A function that takes the component
-                as first argument and returns True/False.
+         Parameters:
+            name: The name of the component or None such as ``VEVENT``.
+            select: A function that takes the component as first argument
+                and returns True/False.
 
         Returns:
-            list[Component]: A list of components that match.
+            A list of components that match.
         """
-       
         if name is not None:
             name = name.upper()
         return self._walk(name, select)
@@ -618,8 +617,8 @@ class Component(CaselessDict):
     def to_ical(self, sorted: bool = True):
         """Return this component as an iCalendar formatted string.
 
-        Args:
-            sorted (bool): Whether parameters and properties should be
+        Parameters:
+            sorted: Whether parameters and properties should be
                 lexicographically sorted.
         """
 

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -247,21 +247,23 @@ class Component(CaselessDict):
     # handling of property values
 
     @classmethod
-    def _encode(cls, name, value, parameters=None, encode=1):
+    def _encode(
+        cls, name: str, value, parameters: dict | None = None, encode: bool = True
+    ):
         """Encode values to icalendar property values.
 
-         Parameters:
-        name: Required. Name of the property.
-        value: Required. Value of the property. Either a basic Python type
-            or any of icalendar's own property types.
-        encode: True if the value should be encoded to one of
-            icalendar's own property types (fallback is "vText"),
-            or False if not.
-        parameters: Property parameter dictionary for the value. Only
-            available if encode is set to True.
+             Parameters:
+            name: Required. Name of the property.
+            value: Required. Value of the property. Either a basic Python type
+                or any of icalendar's own property types.
+            encode: True if the value should be encoded to one of
+                icalendar's own property types (fallback is "vText"),
+                or False if not.
+            parameters: Property parameter dictionary for the value. Only
+                available if encode is set to True.
 
-    Returns:
-        icalendar property value.
+        Returns:
+            icalendar property value.
         """
         if not encode:
             return value


### PR DESCRIPTION
## Linked issue
- See #1072

## Description
Converted the docstrings of `_encode`, `walk`, and `to_ical` methods in the
`Component` class from Sphinx-style (`:param:`) to
Google-style format, following the project's style guide. I used AI (Claude,
Anthropic) to help draft the Google-style docstrings; I reviewed each one
against the source code to verify accuracy. See the change log entry and
commit message for details of AI use.

## Checklist
- [x] I added a change log entry, following the instructions in Change log entry format.
- [x] I followed icalendar's Artificial intelligence policy and disclosed my Responsible AI use in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following Run tests.
- [x] I added or edited documentation as necessary...