### PR TITLE
Clarify RECURRENCE-ID datetime spelling

### DIFF
--- a/news/1655.documentation
+++ b/news/1655.documentation
@@ -1,1 +1,1 @@
-Clarified that a ``RECURRENCE-ID`` describes an occurrence's original start datetime rather than its :rfc:`5545` ``DATE-TIME`` value type. AI-assisted. @atirna
+Changed ``date-time`` to ``datetime`` in the narrative parts of the ``RECURRENCE-ID`` and ``ACKNOWLEDGED`` documentation. AI-assisted. @atirna

--- a/news/1655.documentation
+++ b/news/1655.documentation
@@ -1,0 +1,1 @@
+Clarified that a ``RECURRENCE-ID`` describes an occurrence's original start datetime rather than its :rfc:`5545` ``DATE-TIME`` value type. AI-assisted. @atirna

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -1176,7 +1176,7 @@ Identify a specific occurrence of a recurring calendar object.
 
 This property is used together with ``UID`` and ``SEQUENCE`` to refer to one
 particular instance in a recurrence set. The value is the original start
-date or date-time of that instance, not the rescheduled time.
+date or datetime of that instance, not the rescheduled time.
 
 The value is usually a DATE-TIME and must use the same value type as the
 ``DTSTART`` property in the same component. A DATE value may be used for

--- a/src/icalendar/cal/alarm.py
+++ b/src/icalendar/cal/alarm.py
@@ -170,7 +170,7 @@ class Alarm(Component):
     It also allows clients to track repeating alarms or alarms on recurring events or
     to-dos to ensure that the right number of missed alarms can be tracked.
 
-    Clients SHOULD set this property to the current date-time value in UTC
+    Clients SHOULD set this property to the current datetime value in UTC
     when a calendar user acknowledges a pending alarm. Certain kinds of alarms,
     such as email-based alerts, might not provide feedback as to when the calendar user
     sees them. For those kinds of alarms, the client SHOULD set this property


### PR DESCRIPTION
## Linked issue

- Closes #1655

## Description

Fixed spelling.

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).