### PR TITLE
Add return type hint to use_default

### DIFF
--- a/news/938.documentation.3
+++ b/news/938.documentation.3
@@ -1,1 +1,0 @@
-Add a return type hint to the use_default function.

--- a/news/938.documentation.3
+++ b/news/938.documentation.3
@@ -1,1 +1,1 @@
-Add a return type hint to the use_default function.
+Added return type annotations to the ``new()`` factory methods of the :mod:`icalendar.cal` components, such as :meth:`Event.new <icalendar.cal.event.Event.new>`. @ShirayukiRin

--- a/news/938.documentation.3
+++ b/news/938.documentation.3
@@ -1,0 +1,1 @@
+Add a return type hint to the use_default function.

--- a/news/938.documentation.4
+++ b/news/938.documentation.4
@@ -1,0 +1,1 @@
+Add a return type hint to the use_default function. @Vishwa0223

--- a/news/938.documentation.4
+++ b/news/938.documentation.4
@@ -1,1 +1,1 @@
-Add a return type hint to the use_default function. @Vishwa0223
+Added a return type hint to the :meth:`TZP.use_default <icalendar.timezone.TZP.use_default>` method. @Vishwa0223

--- a/src/icalendar/timezone/tzp.py
+++ b/src/icalendar/timezone/tzp.py
@@ -62,7 +62,7 @@ class TZP:
         else:
             self._use(provider)
 
-    def use_default(self):
+    def use_default(self) -> None:
         """Use the default timezone provider."""
         self.use(DEFAULT_TIMEZONE_PROVIDER)
 


### PR DESCRIPTION
Add the missing None return type hint to TZP.use_default().

Tests:
python -m pytest src/icalendar/tests/test_timezoned.py -q

15 passed, 6 skipped