### PR TITLE
Update method references in usage documentation

### DIFF
--- a/docs/how-to/usage.rst
+++ b/docs/how-to/usage.rst
@@ -51,7 +51,7 @@ The rendered view is easier to read.
     SUMMARY:Python meeting about calendaring
     END:VCALENDAR
 
-You can define a function to display :meth:`~icalendar.cal.component.Component.to_ical` output, as shown in the following example.
+You can define a function to display :meth:`icalendar.cal.component.Component.to_ical` output, as shown in the following example.
 
 .. code-block:: pycon
 
@@ -145,7 +145,7 @@ This is impractical if you want to use the data for further computation.
 The datetime format, for example, looks like `20050404T080000`.
 icalendar can parse and generate iCalendar formatted strings.
 
-You can either use the :meth:`~icalendar.cal.component.Component.add()` method to do the work, or you can do it manually.
+You can either use the :meth:`icalendar.cal.component.Component.add()` method to do the work, or you can do it manually.
 
 To add a datetime value, you can use Python's built in :mod:`datetime` types, and the set the encode parameter to ``True``, and it will convert to the type defined in the specification.
 
@@ -170,11 +170,11 @@ Thus, to parse it manually, you would do the following.
     >>> vDatetime(now).to_ical()
     b'20050404T080000'
 
-To summarize, initialize the object with a Python built in type, then call the :meth:`~icalendar.cal.component.Component.to_ical` method on the object.
+To summarize, initialize the object with a Python built in type, then call the :meth:`icalendar.cal.component.Component.to_ical` method on the object.
 That will return an iCal-encoded string.
 
 You can do it the other way around, too.
-To parse an encoded string, call the :meth:`~icalendar.cal.component.Component.from_ical` method, and it will return an instance of the corresponding Python type.
+To parse an encoded string, call the :meth:`icalendar.cal.component.Component.from_ical` method, and it will return an instance of the corresponding Python type.
 
 .. code-block:: pycon
 
@@ -216,7 +216,7 @@ For example, for date or time related properties, the value type and timezone id
     ...     in lines)
 
 
-You can also add arbitrary property parameters by passing a parameters dictionary to the :meth:`~icalendar.cal.component.Component.add()` method as shown.
+You can also add arbitrary property parameters by passing a parameters dictionary to the :meth:`icalendar.cal.component.Component.add()` method as shown.
 
 .. code-block:: pycon
 
@@ -487,7 +487,7 @@ By extending the event with subcomponents, you can create multiple alarms.
     >>> event.add_component(alarm_24h_before)
 
 You can even add a recurrence, either from a dictionary or a string.
-Note that if you want to add the recurrence rule from a string, you must use the :class:`~icalendar.prop.recur.recur.vRecur` property.
+Note that if you want to add the recurrence rule from a string, you must use the :class:`icalendar.prop.recur.recur.vRecur` property.
 Otherwise the rule will be escaped, making it invalid.
 
 .. code-block:: pycon
@@ -577,13 +577,13 @@ To print all events of an iCalendar, iterate through them and print each as show
 .. seealso::
 
     -   :attr:`Calendar.events <icalendar.cal.calendar.Calendar.events>`
-    -   :attr:`~icalendar.cal.component.Component.subcomponents`
-    -   :meth:`~icalendar.cal.component.Component.walk`
+    -   :attr:`icalendar.cal.component.Component.subcomponents`
+    -   :meth:`icalendar.cal.component.Component.walk`
 
 Modify specific events
 ''''''''''''''''''''''
 
-To find :attr:`~icalendar.cal.component.Component.subcomponents` that match specific requirements, use :meth:`~icalendar.cal.component.Component.walk`.
+To find :attr:`icalendar.cal.component.Component.subcomponents` that match specific requirements, use :meth:`icalendar.cal.component.Component.walk`.
 
 The following example filters through all subcomponents of the calendar, and if they have a specific word ``Christmas`` in their summary, makes the summary uppercase.
 
@@ -624,4 +624,4 @@ The following example creates a calendar with an event in ``Europe/Zurich``, and
     >>> 'Europe/Zurich' in [tz.tz_name for tz in calendar.timezones]
     True
 
-After running :meth:`~icalendar.cal.calendar.Calendar.add_missing_timezones`, the calendar now contains all needed timezones and can be saved as a file with :meth:`~icalendar.cal.component.Component.to_ical`.
+After running :meth:`icalendar.cal.calendar.Calendar.add_missing_timezones`, the calendar now contains all needed timezones and can be saved as a file with :meth:`icalendar.cal.component.Component.to_ical`.

--- a/news/1158.doc
+++ b/news/1158.doc
@@ -1,0 +1,1 @@
+Fixed broken Python object links in the usage documentation.

--- a/news/1158.doc
+++ b/news/1158.doc
@@ -1,1 +1,0 @@
-Fixed broken Python object links in the usage documentation.

--- a/news/1670.documentation
+++ b/news/1670.documentation
@@ -1,0 +1,1 @@
+Fixed broken Python object links in the usage documentation.


### PR DESCRIPTION
Update python object links to fully qualified names in usage.rst

## Linked issue

* Contributes to #1158 

## Description

This PR fixes broken Python object links in `docs/how-to/usage.rst` by providing fully qualified names and removing the `~` shortcuts, exactly as requested in the documentation issue.

## Checklist

- [x] I added a change log entry, following the instructions in Change log entry format.
- [x] I followed icalendar's Artificial intelligence policy and disclosed my Responsible AI use in my commit messages, if applicable. 
- [ ] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following Run tests.
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the Style guide.

## Additional information

No additional information.