### PR TITLE
docs: remove self-reference from DTSTAMP docstring See also

### DIFF
--- a/news/1663.documentation
+++ b/news/1663.documentation
@@ -1,1 +1,1 @@
-Remove the self-referential DTSTAMP cross-link from the shared DTSTAMP/stamp docstring's "See also" section so the DTSTAMP page no longer links to itself. I used Claude Opus 4.8 to assist me with this change. @asrith132
+Removed the self-referential DTSTAMP cross-link from the shared DTSTAMP/stamp docstring's "See also" section so the DTSTAMP page no longer links to itself. I used Claude Opus 4.8 to assist me with this change. @asrith132

--- a/news/1663.documentation
+++ b/news/1663.documentation
@@ -1,0 +1,1 @@
+Remove the self-referential DTSTAMP cross-link from the shared DTSTAMP/stamp docstring's "See also" section so the DTSTAMP page no longer links to itself. I used Claude Opus 4.8 to assist me with this change. @asrith132

--- a/src/icalendar/cal/component.py
+++ b/src/icalendar/cal/component.py
@@ -751,7 +751,7 @@ class Component(CaselessDict):
             datetime.datetime(2024, 6, 1, 12, 0, tzinfo=ZoneInfo(key='UTC'))
 
     See also:
-        :attr:`CREATED`, :attr:`DTSTAMP`, :attr:`LAST_MODIFIED`,
+        :attr:`CREATED`, :attr:`LAST_MODIFIED`,
         :attr:`created`, :attr:`stamp`, :attr:`last_modified`
     """,
     )


### PR DESCRIPTION
## Linked issue

- Closes #1663

## Description

The `DTSTAMP` and `stamp` attributes share one docstring via
`DTSTAMP = stamp = single_utc_property(...)` in `src/icalendar/cal/component.py`. Its
"See also" section listed `:attr:`DTSTAMP``, which renders as a self-link on the
`DTSTAMP` reference page. This drops it so the property page no longer links back to
itself, while `stamp` still cross-references the related attributes.

A `.documentation` news fragment is included.

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable. (N/A — docstring-only change; no behavior change to test.)
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

AI disclosure: drafted with Claude Code (Anthropic's Claude Opus) and reviewed locally.