### PR TITLE
[WIP] Add support for Python 3.15 - check again in October 2026

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.15.0-rc.1']
+        python-version: ['3.11', '3.15']
     steps:
       - uses: actions/checkout@v7
         with:
@@ -38,12 +38,8 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # Install a specific version of uv.
-          version: "0.9.3"
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: ${{ matrix.python-version }}
+          # If you update this, also update all the other GitHub Actions
+          version: "0.11.6"
 
       - name: Create Python virtual environment, install requirements
         run: make .venv PYTHONVERSION=${{ matrix.python-version }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.14']
+        python-version: ['3.11', '3.15.0-rc.1']
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/generate_matrix.py
+++ b/.github/workflows/generate_matrix.py
@@ -148,20 +148,6 @@ def generate_matrix(git_ref, review):
         run.setdefault("test_name", run["python_version"])
         run.setdefault("test_command", COMMAND_TEST)
 
-    #
-    # Replacements for GitHub Actions.
-    #
-    # Versions need to appear in this file:
-    # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-    #
-    # Test names should be stabel.
-    # Rename the Python versions after setting the test names.
-    #
-
-    for run in matrix:
-        if run["python_version"] == "3.15":
-            run["python_version"] = "3.15.0-rc.1"
-
     include = list(matrix)
     skipped = [run["test_name"] for run in matrix if run["skip"]]
 

--- a/.github/workflows/generate_matrix.py
+++ b/.github/workflows/generate_matrix.py
@@ -28,7 +28,7 @@ import sys
 
 PYTHON_MINOR_VERSION_MIN = 10
 # Update this when a new Python minor version is released
-PYTHON_MINOR_VERSION_MAX = 14
+PYTHON_MINOR_VERSION_MAX = 15
 
 COMMAND_TEST = "uv run tox -e py"
 

--- a/.github/workflows/generate_matrix.py
+++ b/.github/workflows/generate_matrix.py
@@ -148,6 +148,20 @@ def generate_matrix(git_ref, review):
         run.setdefault("test_name", run["python_version"])
         run.setdefault("test_command", COMMAND_TEST)
 
+    #
+    # Replacements for GitHub Actions.
+    #
+    # Versions need to appear in this file:
+    # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+    #
+    # Test names should be stabel.
+    # Rename the Python versions after setting the test names.
+    #
+
+    for run in matrix:
+        if run["python_version"] == "3.15":
+            run["python_version"] = "3.15.0-rc.1"
+
     include = list(matrix)
     skipped = [run["test_name"] for run in matrix if run["skip"]]
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: 3.14
+          python-version: 3.15
           cache: pip
       - name: Install dependencies
         run: |

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: 3.15
+          python-version: 3.15.0-rc.1
           cache: pip
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_generate_matrix.py
+++ b/.github/workflows/test_generate_matrix.py
@@ -9,8 +9,8 @@ Run with:
 import pytest
 from generate_matrix import generate_matrix
 
-CASES_ALL = {"3.10", "3.11", "3.12", "3.13", "3.14", "3.10 (nopytz)", "pypy3"}
-CASES_MIN = {"3.10", "3.14", "3.10 (nopytz)"}
+CASES_ALL = {"3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "3.10 (nopytz)", "pypy3"}
+CASES_MIN = {"3.10", "3.15", "3.10 (nopytz)"}
 CASES_0 = set()
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: "3.14"
+        python-version: "3.15"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -125,7 +125,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: "3.14"
+        python-version: "3.15"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: "3.15"
+        python-version: "3.15.0-rc.1"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -125,7 +125,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: "3.15"
+        python-version: "3.15.0-rc.1"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,12 +49,12 @@ jobs:
         enable-cache: true
         # Install a specific version of uv.
         version: "0.11.6"
-        python-version: ${{ matrix.python_version }}
     - name: Install dependencies
       if: ${{ !matrix.skip }}
       run: |
         make dev PYTHONVERSION=${{ matrix.python_version }}
         uv tree
+        uv run python --version
     - name: Test
       if: ${{ !matrix.skip }}
       run: ${{ matrix.test_command }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,14 +42,15 @@ jobs:
       run: echo "Skipped ${{ matrix.test_name }} (not required for this trigger)"
     - uses: actions/checkout@v7
       if: ${{ !matrix.skip }}
-    - name: Install uv and Python ${{ matrix.python_version }}
+    - name: Install uv
       if: ${{ !matrix.skip }}
       uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
         # Install a specific version of uv.
+        # If you update this, also update all the other GitHub Actions
         version: "0.11.6"
-    - name: Install dependencies
+    - name: Install Python ${{ matrix.python_version }} and dependencies with uv
       if: ${{ !matrix.skip }}
       run: |
         make dev PYTHONVERSION=${{ matrix.python_version }}

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -369,10 +369,17 @@ Updating Python versions
 
 When adding support for a new Python version, or removing support for an old one, the following files need to be updated:
 
+:file:`.github/workflows/documentation.yml`
+    Upgrade the latest Python version.
+:file:`.github/workflows/ruff.yml`
+    Upgrade the latest Python version.
 :file:`.github/workflows/tests.yml`
     Upgrade Python versions.
-:file:`.github/workflows/*.py`
-    Add or remove the Python version from the test matrix.
+:file:`.github/workflows/test_generate_matrix.py`
+    Remove or add the version from ``CASES_ALL`` and ``CASES_MIN``.
+    The lowest and the highest Python version must be in ``CASES_MIN``.
+:file:`.github/workflows/generate_matrix.py`
+    Adjust ``PYTHON_MINOR_VERSION_MIN`` or ``PYTHON_MINOR_VERSION_MAX``.
 :file:`tox.ini`
     Update the ``envlist`` to include or remove the Python version.
 :file:`pyproject.toml`

--- a/docs/reference/versions-branches.rst
+++ b/docs/reference/versions-branches.rst
@@ -25,11 +25,11 @@ This section describes the branches used in icalendar development.
 ``main``
     The `main <https://github.com/collective/icalendar/tree/main/>`_ branch receives the latest updates and features.
     Active development takes place on this branch.
-    It's compatible with Python versions 3.10 - 3.14, and PyPy3.10, subject to change because it's an active development branch.
+    It's compatible with Python versions 3.10 - 3.15, and PyPy3.10, subject to change because it's an active development branch.
 
 ``7.x``
     icalendar version 7 is on the branch `7.x <https://github.com/collective/icalendar/tree/7.x/>`_.
-    It's compatible with Python versions 3.10 - 3.14, and PyPy3.10.
+    It's compatible with Python versions 3.10 - 3.15, and PyPy3.10.
     Security updates, bug fixes, and new features that are not breaking changes are continuously backported from `main` and released on this branch.
 
 ``6.x``

--- a/news/1635.feature
+++ b/news/1635.feature
@@ -1,0 +1,1 @@
+Test support for Python 3.15. @niccokunzmann

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # to run for a specific environment, use ``tox -e ENVNAME``
 [tox]
-envlist = py310,py311,py312,py313,py314,pypy3,docs,nopytz
+envlist = py310,py311,py312,py313,py314,py315,pypy3,docs,nopytz
 # Note: the 'docs' env creates a 'build' directory which may interfere in strange ways
 # with the other environments.  You might see this when you run the tests in parallel.
 # See https://github.com/collective/icalendar/pull/359#issuecomment-1214150269


### PR DESCRIPTION
<!--

INSTRUCTIONS

Fill out the pull request template as described below.

Do not edit or remove section headings as they are required, except "Additional information" which is optional.

Comments, which consist of the content between each pair of `<!--` and `-->` delimiters, inclusively, may be removed.
-->

## Linked issue

<!--
You must provide a link to an open issue that your pull request addresses.
Only Admins and Maintainers are excluded from this requirement.

Replace `ISSUE_NUMBER` with the issue number that your pull request addresses. This links the pull request to the related issue. Choose the appropriate form.

If you completely resolve the issue, then use `"Closes"`.
GitHub will automatically close the related issue when the PR gets merged.
-->

- Closes #1635 

<!--
You may also link to open pull requests that address the same issue, if applicable.

- See #PULL_REQUEST_NUMBER
-->

## Description

<!--
Write a description of the fixes or improvements.
-->

This adds Python 3.15 to all the files listed in the issue.


## Checklist

<!--
Do not edit the checkbox list items.

To indicate that you completed an item, place an `x` inside the checkbox, such as `[x]`.
-->

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

Upload screenshots, videos, links to documentation, or any other relevant information.
