### PR TITLE
docs: add versionchanged directives for recent API changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,4 +182,5 @@ changes-draft: dev
 changes: dev
 	@test -n "$(VERSION)" || (echo "VERSION is not set. Run 'export VERSION=x.y.z' first." && exit 1)
 	$(TOWNCRIERPATH) build --version ${VERSION} --yes
+	uv run python -c "import pathlib, re; [p.write_text(re.sub(r'(\.\.\s+version(?:changed|added|deprecated)::)\s+0\.0\.0', r'\g<1> ' + '${VERSION}', p.read_text(encoding='utf-8')), encoding='utf-8') for p in pathlib.Path().rglob('*') if p.suffix in ('.py', '.rst') and 'docs/_build' not in p.parts and '.venv' not in p.parts and '.git' not in p.parts]"
 # /release

--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -445,6 +445,23 @@ All links must be valid.
     See how to check links in :ref:`make-linkcheckbroken`.
 
 
+Describing changes between versions
+'''''''''''''''''''''''''''''''''''
+
+When adding version directives (``versionchanged``, ``versionadded``, ``versiondeprecated``) in docstrings or narrative documentation to describe an unreleased API change, always use the version ``0.0.0``.
+
+.. code-block:: rst
+
+    .. versionadded:: 0.0.0
+       Added a new feature.
+
+During the release process, the ``0.0.0`` string will be automatically updated to the actual release version number.
+
+.. seealso::
+
+    `Sphinx documentation on describing changes between versions <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#describing-changes-between-versions>`_
+
+
 Spelling and grammar
 ''''''''''''''''''''
 


### PR DESCRIPTION
Fixes #1683. Added a step in the Makefile release \changes\ target to automatically replace unreleased \