### PR TITLE
add docs/conf.py to commit

### DIFF
--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -155,7 +155,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
     .. code-block:: shell
 
-        git add --all CHANGES.rst news/ docs/conf.py
+        git add CHANGES.rst news/ docs/conf.py
         git add .github/workflows/tests.yml  # Only for a new major release
         git commit -m"version $VERSION"
         git push  # to collective/icalendar

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -155,7 +155,7 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
     .. code-block:: shell
 
-        git add CHANGES.rst news/
+        git add --all CHANGES.rst news/ docs/conf.py
         git add .github/workflows/tests.yml  # Only for a new major release
         git commit -m"version $VERSION"
         git push  # to collective/icalendar

--- a/news/1681.documentation
+++ b/news/1681.documentation
@@ -1,0 +1,1 @@
+Added :file:`docs/conf.py` to commit during release. @niccokunzmann


### PR DESCRIPTION
<!--

INSTRUCTIONS

Fill out the pull request template as described below.

Do not edit or remove section headings as they are required, except "Additional information" which is optional.

Comments, which consist of the content between each pair of `<!--` and `-->` delimiters, inclusively, may be removed.
-->

## Linked issue

<!--
You must provide a link to an open issue that your pull request addresses.
Only Admins and Maintainers are excluded from this requirement.

Replace `ISSUE_NUMBER` with the issue number that your pull request addresses. This links the pull request to the related issue. Choose the appropriate form.

If you completely resolve the issue, then use `"Closes"`.
GitHub will automatically close the related issue when the PR gets merged.
-->

- Contributes to #1681 

<!--
If you resolve only a part of the issue, then use `"See"`.
This form keeps the issue open for future work.
-->

<!--
You may also link to open pull requests that address the same issue, if applicable.

- See #PULL_REQUEST_NUMBER
-->

## Description

<!--
Write a description of the fixes or improvements.
-->

The docs/conf.py was changed but not part of the commit.
While `make changes` adds these directories, they need to be added with --all, to accommodate deletions.

## Checklist

<!--
Do not edit the checkbox list items.

To indicate that you completed an item, place an `x` inside the checkbox, such as `[x]`.
-->

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

Upload screenshots, videos, links to documentation, or any other relevant information.
