### PR TITLE
Change version directives to actual version released

### DIFF
--- a/news/1595.documentation.1
+++ b/news/1595.documentation.1
@@ -1,0 +1,1 @@
+Correct version directives from 7.2.3 to 7.3.0. @niccokunzmann

--- a/src/icalendar/attr.py
+++ b/src/icalendar/attr.py
@@ -414,7 +414,7 @@ def single_int_property(
         prop: Required. The name of the property.
         min_value: If set, the value must be greater than or equal to this minimum.
 
-    ..  versionadded:: 7.2.3
+    ..  versionadded:: 7.3.0
         Added the ``min_value`` parameter.
     """
 
@@ -636,7 +636,7 @@ Examples:
 
         ~icalendar.error.InvalidCalendar: If the value is negative.
 
-    ..  versionchanged:: 7.2.3
+    ..  versionchanged:: 7.3.0
         Negative values are no longer accepted.
     """,  # noqa: E501
     min_value=0,
@@ -1321,7 +1321,7 @@ Raises:
 
     ~icalendar.error.InvalidCalendar: If the value is negative.
 
-..  versionchanged:: 7.2.3
+..  versionchanged:: 7.3.0
     Negative values are no longer accepted.
 """,
         min_value=0,
@@ -1380,7 +1380,7 @@ Description:
 
         ~icalendar.error.InvalidCalendar: If the value is negative.
 
-    ..  versionchanged:: 7.2.3
+    ..  versionchanged:: 7.3.0
         Negative values are no longer accepted.
 """,
     min_value=0,

--- a/src/icalendar/cal/alarm.py
+++ b/src/icalendar/cal/alarm.py
@@ -126,7 +126,7 @@ class Alarm(Component):
 
             ~icalendar.error.InvalidCalendar: If the value is negative.
 
-        ..  versionchanged:: 7.2.3
+        ..  versionchanged:: 7.3.0
             Negative values are no longer accepted.
         """,
         min_value=0,

--- a/src/icalendar/error.py
+++ b/src/icalendar/error.py
@@ -207,6 +207,10 @@ class JCalParsingError(InvalidCalendar):
 
         Raises:
             ~error.JCalParsingError: if the property is not valid.
+
+        ..  versionchanged:: 7.3.0:
+            The name (first item of the list) is validated by
+            :meth:`validate_jcal_token`.
         """
         path = cls._get_path(path)
         if not isinstance(jcal_property, list) or len(jcal_property) < 4:
@@ -322,6 +326,9 @@ class JCalParsingError(InvalidCalendar):
 
         See also:
             :meth:`~icalendar.parser.string.validate_token`
+
+        ..  versionadded:: 7.3.0:
+            This method was added.
         """
         from icalendar.parser.string import validate_token
 

--- a/src/icalendar/error.py
+++ b/src/icalendar/error.py
@@ -208,7 +208,7 @@ class JCalParsingError(InvalidCalendar):
         Raises:
             ~error.JCalParsingError: if the property is not valid.
 
-        ..  versionchanged:: 7.3.0:
+        ..  versionchanged:: 7.3.0
             The name (first item of the list) is validated by
             :meth:`validate_jcal_token`.
         """
@@ -327,8 +327,7 @@ class JCalParsingError(InvalidCalendar):
         See also:
             :meth:`~icalendar.parser.string.validate_token`
 
-        ..  versionadded:: 7.3.0:
-            This method was added.
+        ..  versionadded:: 7.3.0
         """
         from icalendar.parser.string import validate_token
 

--- a/src/icalendar/prop/dt/period.py
+++ b/src/icalendar/prop/dt/period.py
@@ -116,7 +116,7 @@ class vPeriod(TimeBase):
             >>> vPeriod(vPeriod.from_ical("19970101/19970102")).to_ical()
             b'19970101T000000/19970102T000000'
 
-    ..  versionchanged:: 7.2.3
+    ..  versionchanged:: 7.3.0
 
         A period written with dates is read as midnight.
     """


### PR DESCRIPTION
<!--

INSTRUCTIONS

Fill out the pull request template as described below.

Do not edit or remove section headings as they are required, except "Additional information" which is optional.

Comments may be removed.
Comments consist of the content between each pair of HTML comment delimiters, inclusively.

-->

## Linked issue

<!--
Replace `ISSUE_NUMBER` with the issue number that your pull request addresses.
This links the pull request to the related issue.

Choose the appropriate form:

- If you completely resolve the issue, then use `"Closes"`.
  This form will automatically close the related issue when the PR gets merged.
- If you contribute to solving part of the issue, use "Contributes to".
  This form keeps the issue open for future work.
-->

- Contributes to #1595 #1681

<!--
You may also link to open pull requests that address the same issue, if applicable.

- See #PULL_REQUEST_NUMBER
-->

## Description

<!--
Write a description of the fixes or improvements.
-->

We released a different version. not 7.2.3 but 7.3.0.
This updates the version directives.

## Checklist

<!--
Do not edit the checkbox list items.

To indicate that you completed an item, place an `x` inside the checkbox, such as `[x]`.
-->

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

TODO:

- [ ] after merge: also merge this into 7.x. Or maybe merge this into 7.x and 7.x into main? See #1692 