### PR TITLE
refactor: make get_equivalent_tzids private

### DIFF
--- a/news/1011.internal
+++ b/news/1011.internal
@@ -1,0 +1,1 @@
+Renamed the internal ``get_equivalent_tzids`` helper to ``_get_equivalent_tzids`` for icalendar version 8. It was never part of the public API (not listed in ``__all__``), so no deprecation warning was added. I used AI to assist me with this change. @Solaris-star

--- a/src/icalendar/timezone/tzid.py
+++ b/src/icalendar/timezone/tzid.py
@@ -49,30 +49,30 @@ def tzids_from_tzinfo(tzinfo: tzinfo | None) -> tuple[str]:
         return ()
     if isinstance(tzinfo, timezone):
         # fixed offset timezone with name
-        return get_equivalent_tzids(tzinfo.tzname(None))
+        return _get_equivalent_tzids(tzinfo.tzname(None))
     if hasattr(tzinfo, "zone"):
-        return get_equivalent_tzids(tzinfo.zone)  # pytz implementation
+        return _get_equivalent_tzids(tzinfo.zone)  # pytz implementation
     if hasattr(tzinfo, "key"):
-        return get_equivalent_tzids(tzinfo.key)  # ZoneInfo implementation
+        return _get_equivalent_tzids(tzinfo.key)  # ZoneInfo implementation
     if isinstance(tzinfo, tz._tzicalvtz):  # noqa: SLF001
-        return get_equivalent_tzids(tzinfo._tzid)  # noqa: SLF001
+        return _get_equivalent_tzids(tzinfo._tzid)  # noqa: SLF001
     if isinstance(tzinfo, tz.tzstr):
-        return get_equivalent_tzids(tzinfo._s)  # noqa: SLF001
+        return _get_equivalent_tzids(tzinfo._s)  # noqa: SLF001
     if _tzwin is not None and isinstance(tzinfo, _tzwin):
         olson = WINDOWS_TO_OLSON.get(tzinfo._name)  # noqa: SLF001
         if olson is not None:
-            return get_equivalent_tzids(olson)
-        return get_equivalent_tzids(tzinfo._name)  # noqa: SLF001
+            return _get_equivalent_tzids(olson)
+        return _get_equivalent_tzids(tzinfo._name)  # noqa: SLF001
     if hasattr(tzinfo, "_filename"):  # dateutil.tz.tzfile  # noqa: SIM102
         if DATEUTIL_ZONEINFO_PATH is not None:
             # tzfile('/usr/share/zoneinfo/Europe/Berlin')
             path = tzinfo._filename  # noqa: SLF001
             if path.startswith(str(DATEUTIL_ZONEINFO_PATH)):
                 tzid = str(Path(path).relative_to(DATEUTIL_ZONEINFO_PATH))
-                return get_equivalent_tzids(tzid)
-            return get_equivalent_tzids(path)
+                return _get_equivalent_tzids(tzid)
+            return _get_equivalent_tzids(path)
     if isinstance(tzinfo, tz.tzutc):
-        return get_equivalent_tzids("UTC")
+        return _get_equivalent_tzids("UTC")
     return ()
 
 
@@ -125,8 +125,11 @@ def _add_equivalent_ids(value: tuple | dict | set):
 _add_equivalent_ids(equivalent_timezone_ids_result.lookup)
 
 
-def get_equivalent_tzids(tzid: str) -> tuple[str]:
-    """This returns the tzids which are equivalent to this one."""
+def _get_equivalent_tzids(tzid: str) -> tuple[str]:
+    """This returns the tzids which are equivalent to this one.
+
+    :meta private:
+    """
     ids = _EQUIVALENT_IDS.get(tzid, set())
     return (tzid,) + tuple(sorted(ids - {tzid}))
 


### PR DESCRIPTION
## Linked issue

- Contributes to #1011

## Description

This renames the internal `get_equivalent_tzids` helper in `icalendar.timezone.tzid` to `_get_equivalent_tzids` and updates every internal call site.

The helper is not exported by `icalendar.timezone.tzid.__all__`, and the change is limited to the timezone-identification implementation. It is the next independent slice of #1011; #1675 already handled `timezone_datetime_property`. Runtime behavior is unchanged.

## Checklist

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

Commit `6d33d5fbb2c065c82a18f07d759a8ea9681ce441` is authored as `Solaris-star <820622658@qq.com>`, carries a valid SSH signature, and includes a DCO sign-off.

Verification run on the clean branch:

- `./.venv/bin/python -m pytest -q`: 18210 passed, 28 skipped, 540 xfailed.
- Focused timezone tests: 1843 passed, 2 skipped.
- `./.venv/bin/ruff check src/icalendar/timezone/tzid.py`: passed.
- `./.venv/bin/pre-commit run --all-files`: passed.
- `uv build`: passed.
- Full tracked-tree secret scan: 640 files scanned, no matches.

The repository-wide `mypy src/icalendar` command is currently red on the clean main baseline as well; this branch does not change any type annotations. The changed-file invocation reports the existing `tzid.py` typing errors, so I have not marked type checking as green.
