### PR TITLE
chore:update .gitignore to ignore macOS Finder metadata tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 __pycache__
 /_build/
 /.coverage
@@ -13,4 +14,4 @@ __pycache__
 /htmlcov/
 /src/icalendar/_version.py
 /uv.lock
-.DS_Store
+

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__
 /htmlcov/
 /src/icalendar/_version.py
 /uv.lock
+.DS_Store

--- a/news/1659.chore.1
+++ b/news/1659.chore.1
@@ -1,1 +1,1 @@
-Added `.DS_Store` to .gitignore so macOS Finder metadata files are ignored across the repository and no longer appear as untracked files
+Added ``.DS_Store`` to :file:`.gitignore` so macOS Finder metadata files are ignored and no longer appear as untracked files. @Priyanshu-pulak

--- a/news/1659.chore.1
+++ b/news/1659.chore.1
@@ -1,0 +1,1 @@
+Added `.DS_Store` to .gitignore so macOS Finder metadata files are ignored across the repository and no longer appear as untracked files


### PR DESCRIPTION
## Linked issue

- Refs #1659

## Description

Add `.DS_STORE` to stop tracking of MacOS Finder metadata

## Checklist

- [X] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [X] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [X] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).
