### PR TITLE
Chore/add type hints alarms

### DIFF
--- a/news/938.chore.1
+++ b/news/938.chore.1
@@ -1,2 +1,2 @@
-Add return type annotations to function in `src.icalendar.alarms`. @Priyanshu-pulak
+Add return type annotations to functions in `src.icalendar.alarms`. @Priyanshu-pulak
 

--- a/news/938.chore.1
+++ b/news/938.chore.1
@@ -1,2 +1,2 @@
-Add return type annotations to functions in `src.icalendar.alarms`. @Priyanshu-pulak
+Added return type annotations to functions in the :mod:`icalendar.alarms` module. @Priyanshu-pulak
 

--- a/news/938.chore.1
+++ b/news/938.chore.1
@@ -1,0 +1,2 @@
+Add return type annotations to function in `src.icalendar.alarms`. @Priyanshu-pulak
+

--- a/src/icalendar/alarms.py
+++ b/src/icalendar/alarms.py
@@ -325,7 +325,7 @@ class Alarms:
             for i in range(1, repeat + 1):
                 yield self._add(first, duration * i)
 
-    def _alarm_time(self, alarm: Alarm, trigger: date)  -> AlarmTime:
+    def _alarm_time(self, alarm: Alarm, trigger: date) -> AlarmTime:
         """Create an alarm time with the additional attributes."""
         if getattr(trigger, "tzinfo", None) is None and self._local_tzinfo is not None:
             trigger = normalize_pytz(trigger.replace(tzinfo=self._local_tzinfo))

--- a/src/icalendar/alarms.py
+++ b/src/icalendar/alarms.py
@@ -14,7 +14,7 @@ This takes different calendar software into account and the RFC 9074 (Alarm Exte
 from __future__ import annotations
 
 from datetime import date, timedelta, tzinfo
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 from icalendar.cal.event import Event
 from icalendar.cal.todo import Todo
@@ -254,6 +254,12 @@ class Alarms:
         If you have alarms relative to the end of a component, set the end here.
         """
         self._end = dt
+
+    @overload
+    def _add(self, dt: datetime, td: timedelta) -> datetime: ...
+
+    @overload
+    def _add(self, dt: date, td: timedelta) -> date: ...
 
     def _add(self, dt: date, td: timedelta) -> date | datetime:
         """Add a timedelta to a datetime."""

--- a/src/icalendar/alarms.py
+++ b/src/icalendar/alarms.py
@@ -218,7 +218,7 @@ class Alarms:
         for alarm in component.walk("VALARM"):
             self.add_alarm(alarm)
 
-    def set_parent(self, parent: Parent):
+    def set_parent(self, parent: Parent) -> None:
         """Set the parent of all the alarms.
 
         If you would like to collect alarms from a component, use add_component
@@ -239,7 +239,7 @@ class Alarms:
         else:
             self._end_alarms.append(alarm)
 
-    def set_start(self, dt: date | None):
+    def set_start(self, dt: date | None) -> None:
         """Set the start of the component.
 
         If you have only absolute alarms, this is not required.
@@ -247,7 +247,7 @@ class Alarms:
         """
         self._start = dt
 
-    def set_end(self, dt: date | None):
+    def set_end(self, dt: date | None) -> None:
         """Set the end of the component.
 
         If you have only absolute alarms, this is not required.
@@ -255,7 +255,7 @@ class Alarms:
         """
         self._end = dt
 
-    def _add(self, dt: date, td: timedelta):
+    def _add(self, dt: date, td: timedelta) -> date | datetime:
         """Add a timedelta to a datetime."""
         if is_date(dt):
             if td.seconds == 0:
@@ -286,7 +286,7 @@ class Alarms:
         """
         self._snooze_until = tzp.localize_utc(dt) if dt is not None else None
 
-    def set_local_timezone(self, tzinfo: tzinfo | str | None):
+    def set_local_timezone(self, tzinfo: tzinfo | str | None) -> None:
         """Set the local timezone.
 
         Events are sometimes in local time.
@@ -325,7 +325,7 @@ class Alarms:
             for i in range(1, repeat + 1):
                 yield self._add(first, duration * i)
 
-    def _alarm_time(self, alarm: Alarm, trigger: date):
+    def _alarm_time(self, alarm: Alarm, trigger: date)  -> AlarmTime:
         """Create an alarm time with the additional attributes."""
         if getattr(trigger, "tzinfo", None) is None and self._local_tzinfo is not None:
             trigger = normalize_pytz(trigger.replace(tzinfo=self._local_tzinfo))


### PR DESCRIPTION
<!--

INSTRUCTIONS

Fill out the pull request template as described below.

Do not edit or remove section headings as they are required, except "Additional information" which is optional.

Comments may be removed.
Comments consist of the content between each pair of HTML comment delimiters, inclusively.

-->

## Linked issue

<!--
Replace `ISSUE_NUMBER` with the issue number that your pull request addresses.
This links the pull request to the related issue.

Choose the appropriate form:

- If you completely resolve the issue, then use `"Closes"`.
  This form will automatically close the related issue when the PR gets merged.
- If you contribute to solving part of the issue, use "Contributes to".
  This form keeps the issue open for future work.
-->

- Refs #938 


<!--
You may also link to open pull requests that address the same issue, if applicable.

- See #PULL_REQUEST_NUMBER
-->

## Description

<!--
Write a description of the fixes or improvements.
-->
Add return type annotations to following functions : 
`set_parent`
`set_start`
`set_end`
`add`
`set_local_timezone`
`_alarm_time` 
## Checklist

<!--
Do not edit the checkbox list items.

To indicate that you completed an item, place an `x` inside the checkbox, such as `[x]`.
-->

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).
