### PR TITLE
refactor: simplify type check imports

### DIFF
--- a/news/1707.chore.1
+++ b/news/1707.chore.1
@@ -1,0 +1,2 @@
+Simplified type checking imports in :mod:`icalendar.cal.alarm`, `icalendar.cal.availability`, `icalendar.cal.event`, `icalendar.cal.free_busy`, `icalendar.cal.journal`, `icalendar.cal.lazy`, `icalendar.cal.timezone`, and `icalendar.cal.todo` to import directly from the package instead of submodules.
+@Priyanshu-pulak

--- a/src/icalendar/cal/alarm.py
+++ b/src/icalendar/cal/alarm.py
@@ -31,8 +31,10 @@ if TYPE_CHECKING:
     import uuid
     from collections.abc import Sequence
 
-    from icalendar.compatibility import Self
-    from icalendar.prop import vCalAddress
+    from icalendar import (
+        Self,
+        vCalAddress,
+    )
 
 
 class Alarm(Component):

--- a/src/icalendar/cal/availability.py
+++ b/src/icalendar/cal/availability.py
@@ -39,10 +39,13 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
     from datetime import date
 
-    from icalendar.cal.available import Available
-    from icalendar.compatibility import Self
-    from icalendar.enums import BUSYTYPE, CLASS
-    from icalendar.prop import vCalAddress
+    from icalendar import (
+        BUSYTYPE,
+        CLASS,
+        Self,
+        vCalAddress,
+    )
+    from icalendar.cal import Available
 
 
 class Availability(Component):

--- a/src/icalendar/cal/event.py
+++ b/src/icalendar/cal/event.py
@@ -52,11 +52,15 @@ from icalendar.cal.examples import get_example
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
-    from icalendar.alarms import Alarms
-    from icalendar.compatibility import Self
-    from icalendar.enums import CLASS, STATUS, TRANSP
-    from icalendar.prop import vCalAddress
-    from icalendar.prop.conference import Conference
+    from icalendar import (
+        CLASS,
+        STATUS,
+        TRANSP,
+        Alarms,
+        Self,
+        vCalAddress,
+    )
+    from icalendar.prop import Conference
 
 
 class Event(Component):

--- a/src/icalendar/cal/free_busy.py
+++ b/src/icalendar/cal/free_busy.py
@@ -21,8 +21,10 @@ from icalendar.cal.component import Component
 from icalendar.cal.examples import get_example
 
 if TYPE_CHECKING:
-    from icalendar.compatibility import Self
-    from icalendar.prop import vCalAddress
+    from icalendar import (
+        Self,
+        vCalAddress,
+    )
 
 
 class FreeBusy(Component):

--- a/src/icalendar/cal/journal.py
+++ b/src/icalendar/cal/journal.py
@@ -36,9 +36,12 @@ from icalendar.error import IncompleteComponent
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from icalendar.compatibility import Self
-    from icalendar.enums import CLASS, STATUS
-    from icalendar.prop import vCalAddress
+    from icalendar import (
+        CLASS,
+        STATUS,
+        Self,
+        vCalAddress,
+    )
 
 
 class Journal(Component):

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -12,8 +12,10 @@ from .calendar import Calendar
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from icalendar.parser.ical.component import ComponentIcalParser
-    from icalendar.parser.ical.lazy import LazySubcomponent
+    from icalendar.parser.ical import (
+        ComponentIcalParser,
+        LazySubcomponent,
+    )
 
     from .component import Component
 

--- a/src/icalendar/cal/timezone.py
+++ b/src/icalendar/cal/timezone.py
@@ -23,7 +23,7 @@ from icalendar.timezone.tzid import tzid_from_tzinfo
 from icalendar.tools import to_datetime
 
 if TYPE_CHECKING:
-    from icalendar.cal.calendar import Calendar
+    from icalendar.cal import Calendar
 
 
 class Timezone(Component):

--- a/src/icalendar/cal/todo.py
+++ b/src/icalendar/cal/todo.py
@@ -51,11 +51,14 @@ from icalendar.cal.examples import get_example
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
-    from icalendar.alarms import Alarms
-    from icalendar.compatibility import Self
-    from icalendar.enums import CLASS, STATUS
-    from icalendar.prop import vCalAddress
-    from icalendar.prop.conference import Conference
+    from icalendar import (
+        CLASS,
+        STATUS,
+        Alarms,
+        Self,
+        vCalAddress,
+    )
+    from icalendar.prop import Conference
 
 
 class Todo(Component):


### PR DESCRIPTION
imports from icalendar.cal package

<!--

INSTRUCTIONS

Fill out the pull request template as described below.

Do not edit or remove section headings as they are required, except "Additional information" which is optional.

Comments may be removed.
Comments consist of the content between each pair of HTML comment delimiters, inclusively.

-->

## Linked issue

<!--
Replace `ISSUE_NUMBER` with the issue number that your pull request addresses.
This links the pull request to the related issue.

Choose the appropriate form:

- If you completely resolve the issue, then use `"Closes"`.
  This form will automatically close the related issue when the PR gets merged.
- If you contribute to solving part of the issue, use "Contributes to".
  This form keeps the issue open for future work.
-->

- Refs #1707 


<!--
You may also link to open pull requests that address the same issue, if applicable.

- See #PULL_REQUEST_NUMBER
-->

## Description
Simplified type checking imports in : 
`icalendar.cal.alarm`,
`icalendar.cal.availability`,
`icalendar.cal.event`,
`icalendar.cal.free_busy`,
`icalendar.cal.journal`,
`icalendar.cal.lazy`,
`icalendar.cal.timezone`,
`icalendar.cal.todo` 
to import directly from the package instead of submodules.
<!--
Write a description of the fixes or improvements.
-->

## Checklist

<!--
Do not edit the checkbox list items.

To indicate that you completed an item, place an `x` inside the checkbox, such as `[x]`.
-->

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

<!--
Upload screenshots, videos, links to documentation, or any other relevant information.
-->
