### PR TITLE
Fixed the display of the overloaded method localize

### DIFF
--- a/news/1140.documentation
+++ b/news/1140.documentation
@@ -1,0 +1,1 @@
+Fixed the display of the overloaded method :meth:`TZP.localize <icalendar.timezone.tzp.TZP.localize>`. @stevepiercy

--- a/src/icalendar/timezone/tzp.py
+++ b/src/icalendar/timezone/tzp.py
@@ -74,14 +74,10 @@ class TZP:
         return self.__provider.localize_utc(to_datetime(dt))
 
     @overload
-    def localize(
-        self, dt: datetime, tz: datetime.tzinfo | str | None
-    ) -> datetime: ...
+    def localize(self, dt: datetime, tz: datetime.tzinfo | str | None) -> datetime: ...
 
     @overload
-    def localize(
-        self, dt: time, tz: datetime.tzinfo | str | None
-    ) -> time: ...
+    def localize(self, dt: time, tz: datetime.tzinfo | str | None) -> time: ...
 
     def localize(
         self, dt: datetime.date | time, tz: datetime.tzinfo | str | None

--- a/src/icalendar/timezone/tzp.py
+++ b/src/icalendar/timezone/tzp.py
@@ -75,17 +75,17 @@ class TZP:
 
     @overload
     def localize(
-        self, dt: datetime.datetime, tz: datetime.tzinfo | str | None
-    ) -> datetime.datetime: ...
+        self, dt: datetime, tz: datetime.tzinfo | str | None
+    ) -> datetime: ...
 
     @overload
     def localize(
-        self, dt: datetime.time, tz: datetime.tzinfo | str | None
-    ) -> datetime.time: ...
+        self, dt: time, tz: datetime.tzinfo | str | None
+    ) -> time: ...
 
     def localize(
-        self, dt: datetime.date | datetime.time, tz: datetime.tzinfo | str | None
-    ) -> datetime.datetime | datetime.time:
+        self, dt: datetime.date | time, tz: datetime.tzinfo | str | None
+    ) -> datetime | datetime.time:
         """Localize a datetime or time to a timezone.
 
         Returns:
@@ -146,7 +146,7 @@ class TZP:
         timezone name, or a "globally unique" identifier
         (:rfc:`5545#section-3.2.19`) such as
         ``/freeassociation.sourceforge.net/Europe/Berlin``. We try the
-        candidate IDs from :meth:`_lookup_ids` in order, checking the cache
+        candidate IDs from ``_lookup_ids`` in order, checking the cache
         before the provider for each one, and cache the first match under the
         primary ID so the next lookup is fast.
         """


### PR DESCRIPTION
## Linked issue

- Contributes to #1140

## Description

Fixed the display of the overloaded method localize

## Checklist

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).
