### PR TITLE
Reject control characters in TEXT values on parse

### DIFF
--- a/news/1712.bugfix
+++ b/news/1712.bugfix
@@ -1,1 +1,1 @@
-TEXT property values now reject :rfc:`5545` control characters such as NUL on parse instead of passing them through to serialized output. Invalid lines are collected in ``errors`` or raise, like invalid parameter values. @abhijeet117 (`Issue #1712 <https://github.com/collective/icalendar/issues/1712>`_)
+TEXT property values now reject :rfc:`5545` control characters such as NUL on parse instead of passing them through to serialized output. Invalid lines are collected in ``errors`` or raise, like invalid parameter values. @abhijeet117

--- a/news/1712.bugfix
+++ b/news/1712.bugfix
@@ -1,0 +1,1 @@
+TEXT property values now reject :rfc:`5545` control characters such as NUL on parse instead of passing them through to serialized output. Invalid lines are collected in ``errors`` or raise, like invalid parameter values. @abhijeet117 (`Issue #1712 <https://github.com/collective/icalendar/issues/1712>`_)

--- a/src/icalendar/prop/text.py
+++ b/src/icalendar/prop/text.py
@@ -9,11 +9,20 @@ from icalendar.parser import Parameters, _escape_char
 from icalendar.parser_tools import DEFAULT_ENCODING, ICAL_TYPE, to_unicode
 
 # :rfc:`5545#section-3.3.11` defines TEXT as
-# ``*(TSAFE-CHAR / ":" / DQUOTE / ESCAPED-CHAR)`` and
-# ``CONTROL = %x00-08 / %x0A-1F / %x7F``, so no control character except the
-# horizontal tab may appear in a TEXT value. The line feed is additionally
-# accepted here because it is the result of the escaped sequences ``\N``
-# and ``\n``.
+# ``*(TSAFE-CHAR / ":" / DQUOTE / ESCAPED-CHAR)`` where TSAFE-CHAR is in turn
+# defined by the following grammar in :rfc:`5545#section-3.1`.
+#
+# ..  code-block:: text
+#
+#     TSAFE-CHAR = WSP / %x21 / %x23-2B / %x2D-39 / %x3C-5B /
+#              %x5D-7E / NON-US-ASCII
+#        ; Any character except CONTROLs not needed by the current
+#        ; character set, DQUOTE, ";", ":", "\", ","
+#
+# CONTROL is defined in the same section as ``%x00-08 / %x0A-1F / %x7F``, so no
+# control character except the horizontal tab may appear in a TEXT value.
+# The line feed, ``\x0a``, is additionally accepted here because it is the
+# result of the escaped sequences ``\N`` and ``\n``.
 UNSAFE_TEXT_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
 
 

--- a/src/icalendar/prop/text.py
+++ b/src/icalendar/prop/text.py
@@ -1,11 +1,20 @@
 """TEXT values from :rfc:`5545`."""
 
+import re
 from typing import Any, ClassVar
 
 from icalendar.compatibility import Self
 from icalendar.error import JCalParsingError
 from icalendar.parser import Parameters, _escape_char
 from icalendar.parser_tools import DEFAULT_ENCODING, ICAL_TYPE, to_unicode
+
+# :rfc:`5545#section-3.3.11` defines TEXT as
+# ``*(TSAFE-CHAR / ":" / DQUOTE / ESCAPED-CHAR)`` and
+# ``CONTROL = %x00-08 / %x0A-1F / %x7F``, so no control character except the
+# horizontal tab may appear in a TEXT value. The line feed is additionally
+# accepted here because it is the result of the escaped sequences ``\N``
+# and ``\n``.
+UNSAFE_TEXT_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
 
 
 class vText(str):
@@ -97,7 +106,22 @@ class vText(str):
 
     @classmethod
     def from_ical(cls, ical: ICAL_TYPE) -> Self:
-        return cls(ical)
+        r"""Parse a TEXT value from its iCalendar representation.
+
+        Raises:
+            ValueError: If the value contains a control character that
+                :rfc:`5545#section-3.3.11` does not allow in TEXT values.
+                The line feed is exempt because it can only enter a parsed
+                value through the escaped sequences ``\N`` and ``\n``.
+        """
+        text = to_unicode(ical)
+        match = UNSAFE_TEXT_CHARS.search(text)
+        if match is not None:
+            raise ValueError(
+                f"Control character {match.group()!a} at index "
+                f"{match.start()} is not allowed in TEXT values."
+            )
+        return cls(text)
 
     @property
     def ical_value(self) -> str:

--- a/src/icalendar/tests/fuzzed/__init__.py
+++ b/src/icalendar/tests/fuzzed/__init__.py
@@ -35,6 +35,7 @@ _value_error_matches = [
     "must have exactly",  # vCard field count validation (ADR, N)
     "must have at least",  # vCard ORG minimum field validation
     "not enough values to unpack",  # dateutil rejects a malformed VTIMEZONE content line
+    "not allowed in TEXT values",  # RFC 5545 control character rejection in TEXT
 ]
 
 

--- a/src/icalendar/tests/prop/test_control_chars_in_text_values.py
+++ b/src/icalendar/tests/prop/test_control_chars_in_text_values.py
@@ -1,10 +1,30 @@
 r"""TEXT values must reject control characters on parse.
 
 :rfc:`5545#section-3.3.11` defines TEXT as
-``*(TSAFE-CHAR / ":" / DQUOTE / ESCAPED-CHAR)`` with
-``CONTROL = %x00-08 / %x0A-1F / %x7F``, so control characters other than
-the horizontal tab cannot appear in a valid TEXT value. A NUL byte in a
-property value previously passed through :meth:`vText.from_ical`
+``*(TSAFE-CHAR / ":" / DQUOTE / ESCAPED-CHAR)`` where TSAFE-CHAR is defined by
+the following grammar.
+
+..  code-block:: text
+
+    TSAFE-CHAR = WSP / %x21 / %x23-2B / %x2D-39 / %x3C-5B /
+             %x5D-7E / NON-US-ASCII
+       ; Any character except CONTROLs not needed by the current
+       ; character set, DQUOTE, ";", ":", "\", ","
+
+In turn, CONTROL is defined by the following grammar in :rfc:`5545#section-3.1`.
+
+..  code-block:: text
+
+    CONTROL       = %x00-08 / %x0A-1F / %x7F
+    ; All the controls except HTAB
+
+Although "the current character set" may be one of many, it is UTF-8 by default
+per :rfc:`5545#section-3.1.4`. Thus TEXT should reject all the CONTROLs except
+the horizontal tab, ``%x09``. Additionally the new line, ``%x0A``, is needed by
+the current character set because it is the result of the escaped sequences
+``\N`` and ``\n``.
+
+A NUL byte in a property value previously passed through :meth:`vText.from_ical`
 unchanged, and consumers written in C truncate strings at NUL, silently
 changing the round-tripped value. TEXT values now reject them like
 invalid parameter values do.
@@ -15,15 +35,17 @@ import pytest
 from icalendar import Calendar, Event, vText
 from icalendar.prop import vBroken
 
+#: Every CONTROL from :rfc:`5545#section-3.1`. The horizontal tab, ``%x09``,
+#: is not a CONTROL, and the new line, ``%x0A``, is not forbidden because the
+#: escaped sequences ``\N`` and ``\n`` produce it.
+FORBIDDEN_CONTROL_CHARS = [
+    chr(control) for control in range(0x20) if control not in (0x09, 0x0A)
+] + ["\x7f"]
+
 FORBIDDEN_VALUES = [
+    *FORBIDDEN_CONTROL_CHARS,
     "A\x00B",  # NUL from the issue report
-    "\x00",
-    "\x01",
-    "\x08",
-    "\x0b",  # vertical tab
-    "\x0c",  # form feed
     "a\rb",  # lone carriage return
-    "\x7f",  # delete
 ]
 
 VALID_VALUES = [
@@ -31,7 +53,8 @@ VALID_VALUES = [
     'quotes " and colons : and semicolons ; and commas ,',
     r"escapes \; \, \\ stay verbatim here",
     "horizontal tab\tinside",
-    "line\nbreak from the escaped sequences",
+    "horizontal tab as hex\x09inside",
+    "newline\nfrom the escaped sequences",
     "non-US-ASCII: café ☕",
 ]
 

--- a/src/icalendar/tests/prop/test_control_chars_in_text_values.py
+++ b/src/icalendar/tests/prop/test_control_chars_in_text_values.py
@@ -1,0 +1,69 @@
+r"""TEXT values must reject control characters on parse.
+
+:rfc:`5545#section-3.3.11` defines TEXT as
+``*(TSAFE-CHAR / ":" / DQUOTE / ESCAPED-CHAR)`` with
+``CONTROL = %x00-08 / %x0A-1F / %x7F``, so control characters other than
+the horizontal tab cannot appear in a valid TEXT value. A NUL byte in a
+property value previously passed through :meth:`vText.from_ical`
+unchanged, and consumers written in C truncate strings at NUL, silently
+changing the round-tripped value. TEXT values now reject them like
+invalid parameter values do.
+"""
+
+import pytest
+
+from icalendar import Calendar, Event, vText
+from icalendar.prop import vBroken
+
+FORBIDDEN_VALUES = [
+    "A\x00B",  # NUL from the issue report
+    "\x00",
+    "\x01",
+    "\x08",
+    "\x0b",  # vertical tab
+    "\x0c",  # form feed
+    "a\rb",  # lone carriage return
+    "\x7f",  # delete
+]
+
+VALID_VALUES = [
+    "Hello World!",
+    'quotes " and colons : and semicolons ; and commas ,',
+    r"escapes \; \, \\ stay verbatim here",
+    "horizontal tab\tinside",
+    "line\nbreak from the escaped sequences",
+    "non-US-ASCII: café ☕",
+]
+
+
+@pytest.mark.parametrize("value", FORBIDDEN_VALUES)
+def test_vtext_rejects_control_characters(value):
+    with pytest.raises(ValueError):
+        vText.from_ical(value)
+
+
+@pytest.mark.parametrize("value", VALID_VALUES)
+def test_valid_text_values_still_parse(value):
+    assert vText.from_ical(value)
+
+
+def test_event_collects_nul_in_errors():
+    """The invalid line is collected like an invalid parameter value."""
+    event = Event.from_ical(b"BEGIN:VEVENT\r\nSUMMARY:A\x00B\r\nEND:VEVENT\r\n")
+    assert len(event.errors) == 1
+    assert isinstance(event["SUMMARY"], vBroken)
+
+
+def test_calendar_raises_for_nul_strictly():
+    with pytest.raises(ValueError):
+        Calendar.from_ical(
+            b"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:A\x00B\r\nEND:VCALENDAR\r\n"
+        )
+
+
+def test_escaped_newline_still_parses():
+    event = Event.from_ical(
+        b"BEGIN:VEVENT\r\nSUMMARY:first\\Nsecond\\nthird\r\nEND:VEVENT\r\n"
+    )
+    assert not event.errors
+    assert str(event["SUMMARY"]) == "first\nsecond\nthird"


### PR DESCRIPTION
﻿## Summary
RFC 5545 forbids control characters in TEXT values, but vText.from_ical accepted them, so a NUL in a property value round-tripped into serialized output where C-based consumers silently truncate it. TEXT values are now validated against the CONTROL production on parse: invalid values raise ValueError, which error-tolerant components like Event collect in errors as vBroken, matching how invalid parameter values are already handled.

## Testing
Reproduced with Event.from_ical of a VEVENT whose SUMMARY contained A<NUL>B: the NUL passed through to to_ical(). Added regression tests covering forbidden and valid characters, error collection for tolerant components, strict raising for Calendar, and escaped newline handling; they fail without the fix.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed
