### PR TITLE
Replace RFC copy-paste with Pythonic docstrings for LazyCalendar and subcomponent strategies

### DIFF
--- a/news/1244.documentation
+++ b/news/1244.documentation
@@ -1,1 +1,1 @@
-Replaced RFC copy-paste in LazyCalendar and subcomponent strategy docstrings. I used AI to assist with this change. @SemTiOne
+Replaced RFC copy-paste and expanded docstrings in both the classes :class:`~icalendar.cal.lazy.LazyCalendar` and :class:`~icalendar.cal.lazy.ParsedSubcomponentsStrategy` and their methods. I used AI to assist with this change. @SemTiOne

--- a/news/1244.documentation
+++ b/news/1244.documentation
@@ -1,0 +1,1 @@
+Replaced RFC copy-paste in LazyCalendar and subcomponent strategy docstrings. I used AI to assist with this change. @SemTiOne

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -268,7 +268,7 @@ class LazyCalendar(Calendar):
             False
 
     See also:
-        :meth:`~icalendar.cal.calendar.Calendar.from_ical`
+        :meth:`~icalendar.parser.ical.component.ComponentIcalParser.parse`
     """
 
     _subcomponents: (

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -268,7 +268,7 @@ class LazyCalendar(Calendar):
             False
 
     See also:
-        :class:`~icalendar.cal.calendar.Calendar`
+        :meth:`~icalendar.cal.calendar.Calendar.example()`
     """
 
     _subcomponents: (

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -268,7 +268,7 @@ class LazyCalendar(Calendar):
             False
 
     See also:
-        :meth:`~icalendar.parser.ical.component.ComponentIcalParser.parse`
+        :meth:`ComponentIcalParser.parse <icalendar.parser.ical.component.ComponentIcalParser.parse>`
     """
 
     _subcomponents: (

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -268,7 +268,7 @@ class LazyCalendar(Calendar):
             False
 
     See also:
-        :meth:`~icalendar.cal.calendar.Calendar`
+        :class:`~icalendar.cal.calendar.Calendar`
     """
 
     _subcomponents: (
@@ -297,7 +297,7 @@ class LazyCalendar(Calendar):
             A list of parsed subcomponents.
 
         See also:
-            -   :attr:`~icalendar.cal.calendar.Calendar.subcomponents`
+            -   :attr:`~icalendar.cal.component.Component.subcomponents`
             -   :meth:`is_lazy`
 
         """

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -25,27 +25,46 @@ class ParsedSubcomponentsStrategy:
         self._components: list[Component] = []
 
     def get_all_components(self) -> tuple[ParsedSubcomponentsStrategy, list[Component]]:
-        """Get the subcomponents of the calendar."""
+        """Get the parsed subcomponents of the calendar.
+
+        Returns:
+            A tuple of this strategy and the list of parsed subcomponents.
+        """
         return self, self._components
 
     def set_components(
         self, components: list[Component]
     ) -> ParsedSubcomponentsStrategy:
-        """Set the subcomponents of the calendar."""
+        """Set the subcomponents of the calendar.
+
+        Parameters:
+            components: The parsed subcomponents to store.
+        """
         self._components = components
         return self
 
     def add_component(self, component: Component) -> ParsedSubcomponentsStrategy:
-        """Add a component to the calendar."""
+        """Add a component to the calendar, parsing it immediately.
+
+        Parameters:
+            component: The component to add.
+        """
         self._components.append(component.parse())
         return self
 
     def is_lazy(self) -> Literal[False]:
-        """Returns ``False`` because subcomponents are not lazily parsed."""
+        """Return ``False`` because subcomponents are not lazily parsed."""
         return False
 
     def walk(self, name: str) -> tuple[ParsedSubcomponentsStrategy, list[Component]]:
-        """Get the subcomponents of the calendar with the given name."""
+        """Get the subcomponents of the calendar with the given name.
+
+        Parameters:
+            name: The component name to filter by, e.g. ``"VEVENT"``.
+
+        Returns:
+            A tuple of this strategy and the matching subcomponents.
+        """
         result = []
         for component in self._components:
             result += component.walk(name)
@@ -54,7 +73,14 @@ class ParsedSubcomponentsStrategy:
     def with_uid(
         self, name: str
     ) -> tuple[ParsedSubcomponentsStrategy, list[Component]]:
-        """Get the subcomponents of the calendar with the given uid."""
+        """Get the subcomponents of the calendar with the given UID.
+
+        Parameters:
+            name: The UID to search for.
+
+        Returns:
+            A tuple of this strategy and the matching subcomponents.
+        """
         result = []
         for component in self._components:
             result += component.with_uid(name)
@@ -73,15 +99,20 @@ class LazySubcomponentsStrategy:
 
     @property
     def as_parsed(self) -> ParsedSubcomponentsStrategy:
-        """Return the parsed components."""
+        """Return a parsed strategy with all subcomponents parsed.
+
+        Returns:
+            A :class:`ParsedSubcomponentsStrategy` with all subcomponents.
+        """
         return ParsedSubcomponentsStrategy().set_components(
             [component.parse() for component in self._components]
         )
 
     def get_all_components(self) -> tuple[ParsedSubcomponentsStrategy, list[Component]]:
-        """Get the subcomponents of the calendar.
+        """Get the subcomponents of the calendar, parsing all of them.
 
-        Parse all subcomponents.
+        Returns:
+            A tuple of a parsed strategy and the list of subcomponents.
         """
         self.parse_initial_components()
         return self.as_parsed.get_all_components()
@@ -89,13 +120,24 @@ class LazySubcomponentsStrategy:
     def set_components(
         self, components: list[Component]
     ) -> ParsedSubcomponentsStrategy:
-        """Set the subcomponents of the calendar."""
+        """Set the subcomponents of the calendar.
+
+        Parameters:
+            components: The subcomponents to store.
+
+        Returns:
+            A :class:`ParsedSubcomponentsStrategy` holding the components.
+        """
         return ParsedSubcomponentsStrategy().set_components(components)
 
     def add_component(
         self, component: Component | LazySubcomponent
     ) -> LazySubcomponentsStrategy:
-        """Add a component to the calendar."""
+        """Add a component to the calendar without parsing it.
+
+        Parameters:
+            component: The component to add.
+        """
         self._components.append(component)
         return self
 
@@ -122,6 +164,12 @@ class LazySubcomponentsStrategy:
         """Get the subcomponents of the calendar with the given name.
 
         Parse only the minimal number of subcomponents.
+
+        Parameters:
+            name: The component name to filter by, or ``None`` for all.
+
+        Returns:
+            A tuple of this strategy and the matching subcomponents.
         """
         if name is None:
             return self.as_parsed.walk(name)
@@ -135,6 +183,12 @@ class LazySubcomponentsStrategy:
         """Get the subcomponents of the calendar with the given ``uid``.
 
         Parse only the minimal number of subcomponents.
+
+        Parameters:
+            uid: The UID to search for.
+
+        Returns:
+            A tuple of this strategy and the matching subcomponents.
         """
         self.parse_initial_components()
         result = []
@@ -150,6 +204,16 @@ class InitialSubcomponentsStrategy:
     """
 
     def set_components(self, components: list[Component]) -> LazySubcomponentsStrategy:
+        """Set the subcomponents, switching to lazy parsing.
+
+        Parameters:
+            components: The subcomponents to store. Must be empty for an
+                uninitialised calendar.
+
+        Raises:
+            ValueError: If ``components`` is not empty. Parse the calendar
+                first or use :meth:`LazyCalendar.add_component` instead.
+        """
         if components:
             raise ValueError(
                 "Cannot set subcomponents on an uninitialised LazyCalendar. "
@@ -159,15 +223,12 @@ class InitialSubcomponentsStrategy:
 
 
 class LazyCalendar(Calendar):
-    """A calendar that can handle big files.
+    """A calendar that parses subcomponents lazily for memory efficiency.
 
-    Subcomponents of this calendar are evaluated lazily,
-    meaning that they are not parsed until they are accessed.
-    This allows the calendar to handle large files without
-    consuming too much memory or time.
-
-    All properties of the calendar component are parsed immediately.
-    Subcomponents and their properties are parsed lazily.
+    Subcomponents of this calendar are parsed only when accessed,
+    allowing the calendar to handle large files without consuming
+    too much memory or time. All calendar-level properties are parsed
+    immediately; subcomponents and their properties are deferred.
 
     Examples:
 
@@ -197,6 +258,8 @@ class LazyCalendar(Calendar):
             >>> calendar.is_lazy()
             False
 
+    See also:
+        :class:`~icalendar.cal.calendar.Calendar`
     """
 
     _subcomponents: (
@@ -213,12 +276,20 @@ class LazyCalendar(Calendar):
 
     @property
     def subcomponents(self) -> list[Component]:
-        """The subcomponents of the calendar.
+        """Parse and return all subcomponents of this calendar.
 
-        Parse all subcomponents of the calendar and return them as a list.
+        Accessing this property triggers the parsing of all deferred
+        subcomponents. Once accessed, the calendar is no longer lazy
+        (see :meth:`is_lazy`).
 
-        You can manipulate this list or set it.
-        It has the same behavior as in :class:`~icalendar.cal.calendar.Calendar`.
+        You can manipulate the returned list or set it to replace all
+        subcomponents. Setting the list does not re-enable lazy parsing.
+
+        Returns:
+            A list of parsed subcomponents.
+
+        See also:
+            :attr:`Calendar.subcomponents`
         """
         self._subcomponents, result = self._subcomponents.get_all_components()
         return result
@@ -243,23 +314,33 @@ class LazyCalendar(Calendar):
         return factory
 
     def add_component(self, component: Component) -> None:
-        """Add a component to the calendar.
+        """Add a component to this calendar.
 
+        This adds a subcomponent without parsing the entire calendar.
         Use this instead of appending to
         :attr:`~icalendar.cal.lazy.LazyCalendar.subcomponents`,
-        as the latter does not parse the whole calendar.
+        which forces all subcomponents to be parsed first.
+
+        Parameters:
+            component: The component to add as a subcomponent.
+
+        See also:
+            :meth:`Component.add_component`
         """
         self._subcomponents = self._subcomponents.add_component(component)
 
     def is_lazy(self) -> bool:
-        """Whether the subcomponents will be parsed lazily.
+        """Whether the subcomponents are still deferred and not yet parsed.
 
-        .. note:: If you believe that the calendar parses more than it should,
-            please `open an issue <https://github.com/collective/icalendar/issues/new?template=bug_report.md>`_.
+        Returns ``True`` if subcomponents have not been accessed yet.
+        Returns ``False`` once all subcomponents have been parsed,
+        for example by accessing :attr:`subcomponents`.
+
+        If you believe the calendar parses more subcomponents than it should,
+        please `open an issue <https://github.com/collective/icalendar/issues/new?template=bug_report.md>`_.
 
         Returns:
-            ``True`` if subcomponents are deferred and not yet parsed.
-            ``False`` if all subcomponents have been parsed.
+            ``True`` if subcomponents are deferred, ``False`` if parsed.
         """
         return self._subcomponents.is_lazy()
 
@@ -273,12 +354,26 @@ class LazyCalendar(Calendar):
         return result
 
     def with_uid(self, uid: str) -> list[Component]:
+        """Return subcomponents matching the given UID without parsing all subcomponents.
+
+        This searches lazily, parsing only the minimal subcomponents
+        needed to find matches. If this calendar's own UID matches,
+        it is included as the first element.
+
+        Parameters:
+            uid: The UID to search for.
+
+        Returns:
+            A list of components whose UID matches, with the calendar itself
+            first if it matches.
+
+        See also:
+            :meth:`Component.with_uid`
+        """
         self._subcomponents, result = self._subcomponents.with_uid(uid)
         if self.uid == uid:
             result.insert(0, self)
         return result
-
-    with_uid.__doc__ = Calendar.with_uid.__doc__
 
 
 __all__ = ["LazyCalendar"]

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -297,8 +297,8 @@ class LazyCalendar(Calendar):
             A list of parsed subcomponents.
 
         See also:
-            :attr:`~icalendar.cal.calendar.Calendar.subcomponents`
-            :meth:`is_lazy`
+            -   :attr:`~icalendar.cal.calendar.Calendar.subcomponents`
+            -   :meth:`is_lazy`
 
         """
         self._subcomponents, result = self._subcomponents.get_all_components()

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -268,7 +268,7 @@ class LazyCalendar(Calendar):
             False
 
     See also:
-        :meth:`~icalendar.cal.calendar.Calendar.example()`
+        :meth:`~icalendar.cal.calendar.Calendar._get_ical_parser()`
     """
 
     _subcomponents: (

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -268,7 +268,7 @@ class LazyCalendar(Calendar):
             False
 
     See also:
-        :meth:`~icalendar.cal.calendar.Calendar._get_ical_parser()`
+        :meth:`~icalendar.cal.calendar.Calendar.from_ical`
     """
 
     _subcomponents: (

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -39,6 +39,9 @@ class ParsedSubcomponentsStrategy:
 
         Parameters:
             components: The parsed subcomponents to store.
+
+        Returns:
+            This strategy with the subcomponents stored.
         """
         self._components = components
         return self
@@ -48,6 +51,9 @@ class ParsedSubcomponentsStrategy:
 
         Parameters:
             component: The component to add.
+
+        Returns:
+            This strategy with the component added.
         """
         self._components.append(component.parse())
         return self
@@ -137,6 +143,9 @@ class LazySubcomponentsStrategy:
 
         Parameters:
             component: The component to add.
+
+        Returns:
+            This strategy with the component added.
         """
         self._components.append(component)
         return self
@@ -259,7 +268,7 @@ class LazyCalendar(Calendar):
             False
 
     See also:
-        :class:`~icalendar.cal.calendar.Calendar`
+        :meth:`~icalendar.cal.calendar.Calendar`
     """
 
     _subcomponents: (
@@ -288,8 +297,8 @@ class LazyCalendar(Calendar):
             A list of parsed subcomponents.
 
         See also:
-            -   :attr:`Calendar.subcomponents` [Needs fixing]
-            -   :meth:`is_lazy`
+            :attr:`~icalendar.cal.calendar.Calendar.subcomponents`
+            :meth:`is_lazy`
 
         """
         self._subcomponents, result = self._subcomponents.get_all_components()
@@ -326,7 +335,7 @@ class LazyCalendar(Calendar):
             component: The component to add as a subcomponent.
 
         See also:
-            :meth:`Component.add_component`
+            :meth:`Component.add_component <icalendar.cal.component.Component.add_component>`
         """
         self._subcomponents = self._subcomponents.add_component(component)
 
@@ -337,8 +346,9 @@ class LazyCalendar(Calendar):
         Returns ``False`` once all subcomponents have been parsed,
         for example, by accessing :attr:`subcomponents`.
 
-        If you believe the calendar parses more subcomponents than it should,
-        please `open an issue <https://github.com/collective/icalendar/issues/new?template=bug_report.md>`_.
+        .. note:: If you believe the calendar parses more subcomponents than
+            it should, please `open an issue
+            <https://github.com/collective/icalendar/issues/new?template=bug_report.md>`_.
 
         Returns:
             ``True`` if subcomponent parsing is deferred.
@@ -370,7 +380,7 @@ class LazyCalendar(Calendar):
             first if it matches.
 
         See also:
-            :meth:`Component.with_uid`
+            :meth:`Component.with_uid <icalendar.cal.component.Component.with_uid>`
         """
         self._subcomponents, result = self._subcomponents.with_uid(uid)
         if self.uid == uid:

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -60,7 +60,7 @@ class ParsedSubcomponentsStrategy:
         """Get the subcomponents of the calendar with the given name.
 
         Parameters:
-            name: The component name to filter by, e.g. ``"VEVENT"``.
+            name: The component name to filter by, for example, ``"VEVENT"``.
 
         Returns:
             A tuple of this strategy and the matching subcomponents.
@@ -279,8 +279,7 @@ class LazyCalendar(Calendar):
         """Parse and return all subcomponents of this calendar.
 
         Accessing this property triggers the parsing of all deferred
-        subcomponents. Once accessed, the calendar is no longer lazy
-        (see :meth:`is_lazy`).
+        subcomponents. Once accessed, the calendar is no longer lazy.
 
         You can manipulate the returned list or set it to replace all
         subcomponents. Setting the list does not re-enable lazy parsing.
@@ -289,7 +288,9 @@ class LazyCalendar(Calendar):
             A list of parsed subcomponents.
 
         See also:
-            :attr:`Calendar.subcomponents`
+            -   :attr:`Calendar.subcomponents` [Needs fixing]
+            -   :meth:`is_lazy`
+
         """
         self._subcomponents, result = self._subcomponents.get_all_components()
         return result
@@ -317,8 +318,8 @@ class LazyCalendar(Calendar):
         """Add a component to this calendar.
 
         This adds a subcomponent without parsing the entire calendar.
-        Use this instead of appending to
-        :attr:`~icalendar.cal.lazy.LazyCalendar.subcomponents`,
+        Use this, instead of appending to
+        :attr:`~icalendar.cal.lazy.LazyCalendar.subcomponents`
         which forces all subcomponents to be parsed first.
 
         Parameters:
@@ -334,13 +335,14 @@ class LazyCalendar(Calendar):
 
         Returns ``True`` if subcomponents have not been accessed yet.
         Returns ``False`` once all subcomponents have been parsed,
-        for example by accessing :attr:`subcomponents`.
+        for example, by accessing :attr:`subcomponents`.
 
         If you believe the calendar parses more subcomponents than it should,
         please `open an issue <https://github.com/collective/icalendar/issues/new?template=bug_report.md>`_.
 
         Returns:
-            ``True`` if subcomponents are deferred, ``False`` if parsed.
+            ``True`` if subcomponent parsing is deferred.
+            ``False`` if all subcomponents have been parsed.
         """
         return self._subcomponents.is_lazy()
 


### PR DESCRIPTION
## Linked issue

- Contributes to #1244

## Description

Replaced copy-pasted RFC text with Pythonic docstrings in `src/icalendar/cal/lazy.py` for:

  - [InitialSubcomponentsStrategy.set_components()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.InitialSubcomponentsStrategy.set_components)
- [LazyCalendar](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazyCalendar)
  - [LazyCalendar.add_component()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazyCalendar.add_component)
  - [LazyCalendar.is_lazy()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazyCalendar.is_lazy)
  - [LazyCalendar.subcomponents](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazyCalendar.subcomponents)
  - [LazyCalendar.with_uid()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazyCalendar.with_uid)
- [LazySubcomponentsStrategy](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazySubcomponentsStrategy)
  - [LazySubcomponentsStrategy.add_component()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazySubcomponentsStrategy.add_component)
  - [LazySubcomponentsStrategy.as_parsed](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazySubcomponentsStrategy.as_parsed)
  - [LazySubcomponentsStrategy.get_all_components()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazySubcomponentsStrategy.get_all_components)
  - [LazySubcomponentsStrategy.initial_components_to_parse](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazySubcomponentsStrategy.initial_components_to_parse)
  - [LazySubcomponentsStrategy.is_lazy()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazySubcomponentsStrategy.is_lazy)
  - [LazySubcomponentsStrategy.parse_initial_components()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazySubcomponentsStrategy.parse_initial_components)
  - [LazySubcomponentsStrategy.set_components()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazySubcomponentsStrategy.set_components)
  - [LazySubcomponentsStrategy.walk()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazySubcomponentsStrategy.walk)
  - [LazySubcomponentsStrategy.with_uid()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.LazySubcomponentsStrategy.with_uid)
- [ParsedSubcomponentsStrategy](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.ParsedSubcomponentsStrategy)
  - [ParsedSubcomponentsStrategy.add_component()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.ParsedSubcomponentsStrategy.add_component)
  - [ParsedSubcomponentsStrategy.get_all_components()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.ParsedSubcomponentsStrategy.get_all_components)
  - [ParsedSubcomponentsStrategy.is_lazy()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.ParsedSubcomponentsStrategy.is_lazy)
  - [ParsedSubcomponentsStrategy.set_components()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.ParsedSubcomponentsStrategy.set_components)
  - [ParsedSubcomponentsStrategy.walk()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.ParsedSubcomponentsStrategy.walk)
  - [ParsedSubcomponentsStrategy.with_uid()](https://icalendar.readthedocs.io/en/latest/reference/api/icalendar.cal.lazy.html#icalendar.cal.lazy.ParsedSubcomponentsStrategy.with_uid)

## Checklist

- [X] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [X] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [X] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [X] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

Unchanged (already fine):

- LazySubcomponentsStrategy class
- LazySubcomponentsStrategy.initial_components_to_parse
- LazySubcomponentsStrategy.is_lazy()
- LazySubcomponentsStrategy.parse_initial_components()
- ParsedSubcomponentsStrategy class

Also, I removed `with_uid.__doc__ = Calendar.with_uid.__doc__` because the task is to give LazyCalendar.with_uid() its own Pythonic docstring. That line was borrowing Calendar.with_uid.__doc__ (which actually resolves to Component.with_uid's generic docstring):
```docstring
Return a list of components with the given UID.
Parameters:
    uid: The UID of the component.
Returns:
    list[Component]: List of components with the given UID.
```
That generic text doesn't describe LazyCalendar.with_uid's actual behavior, it searches lazily (parsing only the minimal subcomponents) and prepends the calendar itself when its UID matches.