### PR TITLE
Fix broken vXmlReference documentation link

### DIFF
--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -196,7 +196,7 @@ custom text label
 
     The above example will render as shown.
 
-        :class:`prop.vXmlReference <icalendar.prop.vXmlReference>`
+        :class:`prop.xml_reference.vXmlReference <icalendar.prop.xml_reference.vXmlReference>`
 
 .. seealso::
 

--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -180,7 +180,7 @@ full dotted Python path
 
     .. code-block:: rst
 
-        :class:`icalendar.prop.vXmlReference`
+        :class:`icalendar.prop.xml_reference.vXmlReference`
 
     The above example will render as shown.
 

--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -217,13 +217,13 @@ In the page in which the reference appears, you may use the :rst:dir:`currentmod
 
     .. currentmodule:: icalendar.prop
 
-    The class :class:`vXmlReference` is useful.
+    The class :class:`vXmlReference <icalendar.prop.xml_reference.vXmlReference>` is useful.
 
 .. currentmodule:: icalendar.prop
 
 The above example will render as shown.
 
-    The class :class:`vXmlReference` is useful.
+    The class :class:`vXmlReference <icalendar.prop.xml_reference.vXmlReference>` is useful.
 
 
 Calendar file code blocks

--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -215,7 +215,7 @@ In the page in which the reference appears, you may use the :rst:dir:`currentmod
 
 .. code-block:: rst
 
-    .. currentmodule:: icalendar.prop
+    .. currentmodule:: icalendar.prop.xml_reference
 
     The class :class:`vXmlReference <icalendar.prop.xml_reference.vXmlReference>` is useful.
 

--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -168,7 +168,7 @@ object only
 
     .. code-block:: rst
 
-        :class:`~icalendar.prop.vXmlReference`
+        :class:`~icalendar.prop.xml_reference.vXmlReference`
 
     The above example will render as shown.
 

--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -172,7 +172,7 @@ object only
 
     The above example will render as shown.
 
-        :class:`~icalendar.prop.vXmlReference`
+        :class:`~icalendar.prop.xml_reference.vXmlReference`
 
 full dotted Python path
     Use this form only when the object exists outside the rendered HTML page, such as in a superclass.

--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -217,13 +217,13 @@ In the page in which the reference appears, you may use the :rst:dir:`currentmod
 
     .. currentmodule:: icalendar.prop.xml_reference
 
-    The class :class:`vXmlReference <icalendar.prop.xml_reference.vXmlReference>` is useful.
+    The class :class:`vXmlReference` is useful.
 
 .. currentmodule:: icalendar.prop.xml_reference
 
 The above example will render as shown.
 
-    The class :class:`vXmlReference <icalendar.prop.xml_reference.vXmlReference>` is useful.
+    The class :class:`vXmlReference` is useful.
 
 
 Calendar file code blocks

--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -219,7 +219,7 @@ In the page in which the reference appears, you may use the :rst:dir:`currentmod
 
     The class :class:`vXmlReference <icalendar.prop.xml_reference.vXmlReference>` is useful.
 
-.. currentmodule:: icalendar.prop
+.. currentmodule:: icalendar.prop.xml_reference
 
 The above example will render as shown.
 

--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -192,7 +192,7 @@ custom text label
 
     .. code-block:: rst
 
-        :class:`prop.vXmlReference <icalendar.prop.vXmlReference>`
+        :class:`prop.xml_reference.vXmlReference <icalendar.prop.xml_reference.vXmlReference>`
 
     The above example will render as shown.
 

--- a/docs/contribute/documentation/style-guide.rst
+++ b/docs/contribute/documentation/style-guide.rst
@@ -184,7 +184,7 @@ full dotted Python path
 
     The above example will render as shown.
 
-        :class:`icalendar.prop.vXmlReference`
+        :class:`icalendar.prop.xml_reference.vXmlReference`
 
 custom text label
     As a compromise to showing the full dotted Python path, while retaining sufficient context of the object's location when displayed, use a custom text label.

--- a/news/1158.documentation
+++ b/news/1158.documentation
@@ -1,5 +1,1 @@
-Fix the broken ``vXmlReference`` cross-reference in the documentation style guide.
-
-AI-assisted: ChatGPT (GPT-5.6 Sol) was used to help identify and review the broken Sphinx reference. The final change was manually verified.
-
-@josemmiranda04
+Fix the broken ``vXmlReference`` cross-reference in the documentation style guide. AI-assisted: ChatGPT (GPT-5.6 Sol) was used to help identify and review the broken Sphinx reference. The final change was manually verified. @josemmiranda04

--- a/news/1158.documentation
+++ b/news/1158.documentation
@@ -1,1 +1,1 @@
-Fix the broken ``vXmlReference`` cross-reference in the documentation style guide. AI-assisted: ChatGPT (GPT-5.6 Sol) was used to help identify and review the broken Sphinx reference. The final change was manually verified. @josemmiranda04
+Fixed the broken ``vXmlReference`` cross-references in the documentation style guide. AI-assisted: ChatGPT (GPT-5.6 Sol) was used to help identify and review the broken Sphinx reference. The final change was manually verified. @josemmiranda04

--- a/news/1158.documentation
+++ b/news/1158.documentation
@@ -1,0 +1,5 @@
+Fix the broken ``vXmlReference`` cross-reference in the documentation style guide.
+
+AI-assisted: ChatGPT (GPT-5.6 Sol) was used to help identify and review the broken Sphinx reference. The final change was manually verified.
+
+@josemmiranda04


### PR DESCRIPTION
## Linked issue

- Contributes to #1158

## Description

Fixes the broken `vXmlReference` cross-reference in the documentation style guide by pointing it to the fully qualified class path:

`icalendar.prop.xml_reference.vXmlReference`

The previous reference produced a Sphinx nitpicky warning. After the change, the documentation build succeeds without that warning.

## Checklist

- [ ] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

Validated with:

`make clean livehtml SPHINXOPTS="-n"`

and:

`.venv/bin/sphinx-build -n -b html docs _build/html`

The documentation build completed successfully and the previous `vXmlReference` warning is no longer reported.