### PR TITLE
docs: show how to load Calendar.example

### DIFF
--- a/news/743.documentation
+++ b/news/743.documentation
@@ -1,0 +1,1 @@
+Documented how to load the built-in ``Calendar`` example in the :class:`~icalendar.cal.calendar.Calendar` class docstring. I used OpenAI Codex (GPT-5) to help identify and draft this documentation change, then reviewed and verified the output locally. @cananoo

--- a/news/743.documentation
+++ b/news/743.documentation
@@ -1,1 +1,1 @@
-Documented how to load the built-in ``Calendar`` example in the :class:`~icalendar.cal.calendar.Calendar` class docstring. I used OpenAI Codex (GPT-5) to help identify and draft this documentation change, then reviewed and verified the output locally. @cananoo
+Added a usage example for :meth:`Calendar.example <icalendar.cal.calendar.Calendar.example>`. I used AI to assist with this change. @cananoo

--- a/news/743.documentation
+++ b/news/743.documentation
@@ -1,1 +1,1 @@
-Added a usage example for :meth:`Calendar.example <icalendar.cal.calendar.Calendar.example>`. I used AI to assist with this change. @cananoo
+Added and documented the usage example for :meth:`Calendar.example <icalendar.cal.calendar.Calendar.example>`. I used OpenAI Codex (GPT-5) to help identify and draft this documentation change, then reviewed and verified the output locally. @cananoo

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -51,19 +51,13 @@ class Calendar(Component):
         "VEVENT", "VTODO", "VJOURNAL", "VFREEBUSY", "VTIMEZONE", or any
         other type of calendar component.
 
-    Examples:
+    Example:
         Create a new Calendar:
 
             >>> from icalendar import Calendar
             >>> calendar = Calendar.new(name="My Calendar")
             >>> print(calendar.calendar_name)
             My Calendar
-
-        Get the example Calendar:
-
-            >>> calendar = Calendar.example()
-            >>> print(calendar.calendar_name)
-            Holidays
 
     """
 
@@ -97,7 +91,55 @@ class Calendar(Component):
 
     @classmethod
     def example(cls, name: str = "example") -> Calendar:
-        """Return the calendar example with the given name."""
+        """Return the calendar example with the given name.
+
+        Example:
+
+            .. code-block:: pycon
+
+                >>> from icalendar import Calendar
+                >>> print(Calendar.example().to_ical().decode())
+                BEGIN:VCALENDAR
+                VERSION:2.0
+                PRODID:collective/icalendar
+                CALSCALE:GREGORIAN
+                METHOD:PUBLISH
+                X-WR-CALNAME:Holidays
+                X-WR-TIMEZONE:Etc/GMT
+                BEGIN:VEVENT
+                SUMMARY:New Year's Day
+                DTSTART:20220101
+                DTEND:20220101
+                DTSTAMP:20221108T080105Z
+                UID:636a0cc1dbd5a1667894465@icalendar
+                SEQUENCE:0
+                DESCRIPTION:Happy New Year!
+                STATUS:CONFIRMED
+                TRANSP:TRANSPARENT
+                END:VEVENT
+                BEGIN:VEVENT
+                SUMMARY:Orthodox Christmas
+                DTSTART:20220107
+                DTEND:20220107
+                UID:636a0cc1dbfd91667894465@icalendar
+                SEQUENCE:0
+                DESCRIPTION:It is Christmas again!
+                LOCATION:Russia
+                STATUS:CONFIRMED
+                TRANSP:TRANSPARENT
+                END:VEVENT
+                BEGIN:VEVENT
+                SUMMARY:International Women's Day
+                DTSTART:20220308
+                DTEND:20220308
+                UID:636a0cc1dc0f11667894465@icalendar
+                SEQUENCE:0
+                DESCRIPTION:May the feminine be honoured!
+                STATUS:CONFIRMED
+                TRANSP:TRANSPARENT
+                END:VEVENT
+                END:VCALENDAR
+        """
         return cls.from_ical(get_example("calendars", name))
 
     @classmethod

--- a/src/icalendar/cal/calendar.py
+++ b/src/icalendar/cal/calendar.py
@@ -59,6 +59,12 @@ class Calendar(Component):
             >>> print(calendar.calendar_name)
             My Calendar
 
+        Get the example Calendar:
+
+            >>> calendar = Calendar.example()
+            >>> print(calendar.calendar_name)
+            Holidays
+
     """
 
     name = "VCALENDAR"


### PR DESCRIPTION
## Linked issue

- Contributes to #743

## Description

Adds a runnable Calendar.example() example to the Calendar class docstring. No runtime behavior changes.

## Checklist

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

Targeted example tests (38 passed), the Calendar doctest, and ruff checks pass. The GitHub Actions test matrix, documentation builds, fuzzing, changelog verifier, and package checks are green. The local Windows full suite currently has unrelated RFC 6868 and dateutil timezone failures.

AI use: OpenAI Codex (GPT-5) helped draft this change; I reviewed it.
