### PR TITLE
Add make test-dist target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,7 @@ jobs:
         enable-cache: false
         version: "0.11.6"
     - name: Check the release files
-      run: src/icalendar/tests/test_create_release.sh
+      run: make test-dist
 
   deploy-tag-to-pypi:
     # only deploy on tags, see https://stackoverflow.com/a/58478262/1320237

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,10 @@ docs-all: .venv clean vale doctest docstring html linkcheckbroken  ## Clean docs
 .PHONY: test
 test: .venv  ## Run code tests and coverage
 	@uv run tox
+
+.PHONY: test-dist
+test-dist:  ## Build and test the distribution files
+	@src/icalendar/tests/test_create_release.sh
 # /test
 
 

--- a/docs/contribute/development.rst
+++ b/docs/contribute/development.rst
@@ -119,6 +119,21 @@ The following command shows how to run tests in Python 3.14.
     tox's `CLI interface documentation <https://tox.wiki/en/stable/reference/cli.html>`_.
 
 
+Test distribution files
+-----------------------
+
+To build and check the source distribution and wheel, run the following command.
+
+..  code-block:: shell
+
+    make test-dist
+
+This command runs :file:`src/icalendar/tests/test_create_release.sh`, which
+builds the distribution files, checks that required files are included and
+unwanted files are excluded, and verifies the package metadata with
+:program:`twine`.
+
+
 Format code
 -----------
 

--- a/docs/contribute/development.rst
+++ b/docs/contribute/development.rst
@@ -119,21 +119,6 @@ The following command shows how to run tests in Python 3.14.
     tox's `CLI interface documentation <https://tox.wiki/en/stable/reference/cli.html>`_.
 
 
-Test distribution files
------------------------
-
-To build and check the source distribution and wheel, run the following command.
-
-..  code-block:: shell
-
-    make test-dist
-
-This command runs :file:`src/icalendar/tests/test_create_release.sh`, which
-builds the distribution files, checks that required files are included and
-unwanted files are excluded, and verifies the package metadata with
-:program:`twine`.
-
-
 Format code
 -----------
 
@@ -175,6 +160,16 @@ If your virtual environment already exists, update it with the following command
 
     -   :file:`.github/workflows/zizmor.yml`
     -   zizmor's `documentation <https://docs.zizmor.sh/>`_
+
+
+Test distribution files
+-----------------------
+
+To build the source distribution and wheel, check that required files are included and unwanted files are excluded, and verify the package metadata, run the following command.
+
+..  code-block:: shell
+
+    make test-dist
 
 
 Code conventions

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -151,12 +151,6 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
         make changes
 
-#.  Verify the source distribution and wheel before committing the release changes.
-
-    ..  code-block:: shell
-
-        make test-dist
-
 #.  Add the changes, create a commit on the ``main`` branch, and push the changes to prepare a release of this version.
 
     .. code-block:: shell

--- a/docs/contribute/maintenance.rst
+++ b/docs/contribute/maintenance.rst
@@ -151,6 +151,12 @@ However, only people with ``Environments/Configure PyPI`` access can approve an 
 
         make changes
 
+#.  Verify the source distribution and wheel before committing the release changes.
+
+    ..  code-block:: shell
+
+        make test-dist
+
 #.  Add the changes, create a commit on the ``main`` branch, and push the changes to prepare a release of this version.
 
     .. code-block:: shell

--- a/news/1706.documentation
+++ b/news/1706.documentation
@@ -1,0 +1,1 @@
+Added the :program:`make test-dist` command to build and check the distribution files. I used AI to assist with this change. @cananoo

--- a/news/1706.documentation
+++ b/news/1706.documentation
@@ -1,1 +1,1 @@
-Added the :program:`make test-dist` command to build and check the distribution files. I used AI to assist with this change. @cananoo
+Added and documented the usage of the :program:`make test-dist` command to build and check the distribution files. I used AI to assist with this change. @cananoo


### PR DESCRIPTION
## Linked issue

Closes #1706

## Description

Added a `make test-dist` target that runs the existing distribution-file checks from the repository root. The distribution CI job now uses the same target, and the development documentation explains what it builds and verifies.

The target builds the source distribution and wheel, checks that required files are included and unwanted files are excluded, and runs `twine check` on the generated artifacts.

## Checklist

- [x] I added a change log entry, following the instructions in [Change log entry format](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-entry-format).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
  The local equivalent distribution checks passed (`python -m build`, `python -m twine check`, and archive-content checks), but the full test suite and `make test-dist` could not be run because this Windows environment does not have GNU Make or uv installed.
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

The existing `src/icalendar/tests/test_create_release.sh` script is intentionally unchanged; `make test-dist` provides a documented local entry point and keeps CI and developer checks on the same command.
