### PR TITLE
refactor: use public icalendar.cal exports in TYPE_CHECKING imports

### DIFF
--- a/src/icalendar/cal/availability.py
+++ b/src/icalendar/cal/availability.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
     from datetime import date
 
-    from icalendar.cal.available import Available
+    from icalendar.cal import Available
     from icalendar.compatibility import Self
     from icalendar.enums import BUSYTYPE, CLASS
     from icalendar.prop import vCalAddress

--- a/src/icalendar/cal/lazy.py
+++ b/src/icalendar/cal/lazy.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from icalendar.parser.ical.component import ComponentIcalParser
     from icalendar.parser.ical.lazy import LazySubcomponent
 
-    from .component import Component
+    from icalendar.cal import Component
 
 
 class ParsedSubcomponentsStrategy:

--- a/src/icalendar/cal/timezone.py
+++ b/src/icalendar/cal/timezone.py
@@ -23,7 +23,7 @@ from icalendar.timezone.tzid import tzid_from_tzinfo
 from icalendar.tools import to_datetime
 
 if TYPE_CHECKING:
-    from icalendar.cal.calendar import Calendar
+    from icalendar.cal import Calendar
 
 
 class Timezone(Component):


### PR DESCRIPTION
## Summary

Refactors `TYPE_CHECKING` imports in three `icalendar.cal` modules to use the **public exports** from `icalendar.cal` instead of importing classes from internal implementation modules, per #1707:

- `src/icalendar/cal/availability.py`: `from icalendar.cal.available import Available` → `from icalendar.cal import Available`
- `src/icalendar/cal/timezone.py`: `from icalendar.cal.calendar import Calendar` → `from icalendar.cal import Calendar`
- `src/icalendar/cal/lazy.py`: `from .component import Component` → `from icalendar.cal import Component`

## Motivation

Using the public exports keeps `TYPE_CHECKING` imports consistent with the public API of `icalendar.cal` and reduces coupling to internal module structure, which also makes future internal reorganization easier.

## Trade-off

The location of the class is slightly less explicit, but the imports now align with the public API — same trade-off accepted in #1698 for `calendar.py`.

## Changes

- 3 files, TYPE_CHECKING imports only; no runtime import changes (these imports are only used for type checking).

## Verification

- Syntax check passed for all three files
- No runtime import changes (guarded by `TYPE_CHECKING`)