### PR TITLE
Document that change log entries must be a single line

### DIFF
--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -263,7 +263,7 @@ Write a good change log entry
 
 The content of this file must include the following.
 
--   A brief message that summarizes the changes in your contribution.
+-   A brief message that summarizes the changes in your contribution, written as a single line, without wrapped or multi-line paragraphs.
 -   Use :ref:`reStructuredText markup <markup-examples>` to link to relevant RFCs, API usage, and other references.
 -   A brief disclosure of AI use, per icalendar's :ref:`responsible-ai-use` policy, if applicable.
 -   An attribution to yourself, in the format of ``@github_username``, at the end of the entry.

--- a/news/1737.documentation
+++ b/news/1737.documentation
@@ -1,1 +1,1 @@
-Stated in the contributing guide that change log entries must be written as a single line. @nityanand123gupta
+Stated in the contributing guide that change log entries must be written as a single line. I used AI (Claude, Sonnet 5) to assist me with this change. @nityanand123gupta

--- a/news/1737.documentation
+++ b/news/1737.documentation
@@ -1,0 +1,1 @@
+Stated in the contributing guide that change log entries must be written as a single line. @nityanand123gupta


### PR DESCRIPTION
## Linked issue

- Closes #1737

## Description

The contributing guide describes what a good change log entry should contain, but never states that entries must be written as a single line — even though every existing entry in `news/` follows that convention. Adds it explicitly to reduce ambiguity for first-time contributors.

## Checklist

- [x] I added a change log entry, following the instructions in all subsections under Change log requirements.
- [x] I followed icalendar's Artificial intelligence policy and disclosed my Responsible AI use in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following Run tests.
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the Style guide.

## Additional information

This is a docs-only change to `docs/contribute/index.rst` (adding one clause to an existing bullet point) — no code was touched, so the test-related checklist items don't apply here.