### PR TITLE
docs: document single-line change log entries

### DIFF
--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -204,7 +204,7 @@ To avoid a filename conflict with an existing file or another pull request for t
     1158.documentation.1
     1158.documentation.2
 
-For orphan change log entries—that is, those that don't need to be linked to any issue ID or other identifier—start the file name with ``+``.
+For orphan change log entries, which don't need to be linked to any issue ID or other identifier, start the file name with ``+``.
 The content will still be included in the change log, at the end of the category corresponding to the file extension.
 
 ..  code-block:: text
@@ -271,6 +271,7 @@ The content of this file must include the following.
 You can write a good change log entry with the following guidance.
 
 -   Use a narrative format, in the past tense, proper English spelling and grammar, and inline markup as needed.
+-   Write the entire entry on a single line and let documentation tools wrap it for display.
 -   Write your change log entry for its appropriate audience.
 
     -   Most entries should address *users* of the software.

--- a/news/1737.documentation
+++ b/news/1737.documentation
@@ -1,0 +1,1 @@
+Clarified that contributors should write each change log entry as a single line. I used OpenAI Codex (GPT-5) to draft this documentation update. @Zer0codestuff


### PR DESCRIPTION
## Linked issue

- Closes #1737

## Description

Adds a direct rule that each change log entry must stay on one line while documentation tools handle display wrapping. The required news fragment follows that rule. It also rewrites one existing aside in the same guide with commas.

## Checklist

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

- `make html` passed with Sphinx warnings treated as errors.
- `make vale` passed with 0 errors. Existing documentation produced 34 warnings and 250 suggestions.
- `make changes-check` found the required `news/1737.documentation` fragment.
- focused pre-commit hooks passed for both changed files.

AI use: OpenAI Codex (GPT-5) helped inspect issue #1737, draft the documentation and news fragment, and run the checks. I reviewed the wording and results.
