### PR TITLE
typing: add type hints to parser helper functions (#938)

### DIFF
--- a/news/938.chore.2
+++ b/news/938.chore.2
@@ -1,0 +1,1 @@
+Added type annotations to :func:`~icalendar.parser.parameter.single_string_parameter` and expanded docstrings in :mod:`icalendar.parser_tools`. I used AI to assist me with this change. (Issue #938)

--- a/src/icalendar/parser/parameter.py
+++ b/src/icalendar/parser/parameter.py
@@ -189,7 +189,7 @@ def q_join(lst: Sequence[str], sep: str = ",", always_quote: bool = False) -> st
     return sep.join(dquote(itm, always_quote=always_quote) for itm in lst)
 
 
-def single_string_parameter(func: Callable | None = None, upper=False):
+def single_string_parameter(func: Callable | None = None, upper: bool = False) -> Callable:
     """Create a parameter getter/setter for a single string parameter.
 
     Parameters:
@@ -201,18 +201,18 @@ def single_string_parameter(func: Callable | None = None, upper=False):
         if func is ``None``.
     """
 
-    def decorator(func):
+    def decorator(func: Callable) -> property:
         name = func.__name__
 
         @functools.wraps(func)
-        def fget(self: Parameters):
+        def fget(self: Parameters) -> str | None:
             """Get the value."""
             value = self.get(name)
             if value is not None and upper:
                 value = value.upper()
             return value
 
-        def fset(self: Parameters, value: str | None):
+        def fset(self: Parameters, value: str | None) -> None:
             """Set the value"""
             if value is None:
                 fdel(self)
@@ -221,7 +221,7 @@ def single_string_parameter(func: Callable | None = None, upper=False):
                     value = value.upper()
                 self[name] = value
 
-        def fdel(self: Parameters):
+        def fdel(self: Parameters) -> None:
             """Delete the value."""
             self.pop(name, None)
 

--- a/src/icalendar/parser_tools.py
+++ b/src/icalendar/parser_tools.py
@@ -30,6 +30,9 @@ def to_unicode(value: ICAL_TYPE, encoding: str = "utf-8-sig") -> str:
     Parameters:
         value: The value to convert.
         encoding: The encoding to use in the conversion.
+
+    Returns:
+        The string representation of the value.
     """
     if isinstance(value, str):
         return value


### PR DESCRIPTION
## Linked issue

- Contributes to #938

## Description

This pull request adds comprehensive type hints to parser helper functions in the icalendar library, contributing to issue #938's goal of adding type hints throughout the codebase.

### Changes Made

1. **`src/icalendar/parser_tools.py`**:
   - Enhanced `to_unicode()` docstring with a "Returns" section to better document the function's return behavior

2. **`src/icalendar/parser/parameter.py`**:
   - Added return type annotation `-> Callable` to the `single_string_parameter()` decorator function
   - Added parameter type annotation `upper: bool = False` to clarify the `upper` parameter's type
   - Added return type hints to inner functions:
     - `decorator()`: `-> property` 
     - `fget()`: `-> str | None` (getter returns optional string)
     - `fset()`: `-> None` (setter returns None)
     - `fdel()`: `-> None` (deleter returns None)

3. **`news/938.chore.2`**:
   - Added changelog entry documenting the type hint improvements

### Benefits

- Improved IDE autocompletion and type checking support
- Better documentation through explicit type hints
- Compatibility with static type checkers (mypy, pyright, etc.)
- No changes to runtime behavior or logic

## Checklist

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).

## Additional information

- All existing tests pass (`pytest src/icalendar/tests/test_unit_parser_tools.py` and parameter-related tests)
- Type hints follow PEP 484 conventions using Python 3.10+ union syntax (`|`)
- Changes are backward compatible and contain no breaking changes