### PR TITLE
Added mention of chat space and room to the README.rst and Contribute guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,13 +12,16 @@ icalendar supports multiple timezone implementations, including `zoneinfo <https
 ----
 
 :Homepage: https://icalendar.readthedocs.io/en/stable/
-:Community Discussions: https://github.com/collective/icalendar/discussions
-:Issue Tracker: https://github.com/collective/icalendar/issues
+:Discussions: https://github.com/collective/icalendar/discussions
+:Issues: https://github.com/collective/icalendar/issues
 :Code: https://github.com/collective/icalendar
 :Dependencies: `python-dateutil <https://pypi.org/project/python-dateutil/>`_ and `tzdata <https://pypi.org/project/tzdata/>`_.
 :License: `2-Clause BSD License <https://github.com/collective/icalendar/blob/main/LICENSE.rst>`_
 :Contribute: `Contribute to icalendar <https://icalendar.readthedocs.io/en/latest/contribute/index.html>`_
 :Funding: `Open Collective <https://opencollective.com/python-icalendar>`_
+:icalendar chat: https://matrix.to/#/%23icalendar:chat.pycal.org
+:PyCal chat: https://matrix.to/#/%23pycal:chat.pycal.org
+:Python Calendaring Ecosystem: https://pycal.org
 
 ----
 

--- a/docs/contribute/index.rst
+++ b/docs/contribute/index.rst
@@ -22,6 +22,7 @@ Examples of how to contribute
 -   Submit pull requests from your fork of the icalendar repository.
 -   Extend the :doc:`documentation/index`.
 -   Create or comment on a topic in `Discussions <https://github.com/collective/icalendar/discussions>`_.
+-   Join a live chat with icalendar team members in the `icalendar room <https://matrix.to/#/%23icalendar:chat.pycal.org>`_ or its parent organization in the `Python Calendaring Ecosystem (PyCal) space <https://matrix.to/#/%23pycal:chat.pycal.org>`_ via `Matrix <https://matrix.org/>`_.
 -   Write a blog post about icalendar.
 -   Share announcements on social media from :doc:`core contributors <credits>` to icalendar.
 -   Sponsor development of icalendar through `Open Collective <https://opencollective.com/python-icalendar>`_.

--- a/news/1740.documentation
+++ b/news/1740.documentation
@@ -1,0 +1,1 @@
+Added mention of chat space and room to the :file:`README.rst` and Contribute guide. @stevepiercy


### PR DESCRIPTION
## Linked issue

Choose the appropriate form:

- Closes #1740

## Description

Added mention of chat space and room to the README.rst and Contribute guide

## Checklist

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).
