### PR TITLE
Add a PyICU timezone provider (#692)

### DIFF
--- a/news/692.feature
+++ b/news/692.feature
@@ -1,0 +1,1 @@
+Added a PyICU timezone provider (``use_pyicu()``) implementing the timezone interface using ICU's :rfc:`5545` ``VTIMEZONE`` support. I used AI to explain the timezone architecture and to verify its behaviour; the code is my own. @h4syy

--- a/src/icalendar/timezone/__init__.py
+++ b/src/icalendar/timezone/__init__.py
@@ -15,6 +15,9 @@ def use_zoneinfo():
     """Use zoneinfo as the implementation that looks up and creates timezones."""
     tzp.use_zoneinfo()
 
+def use_pyicu():
+    """Use pyicu as the implementation that looks up and creates timezones."""
+    tzp.use_pyicu()
 
 __all__ = [
     "TZP",
@@ -25,4 +28,5 @@ __all__ = [
     "tzp",
     "use_pytz",
     "use_zoneinfo",
+    "use_pyicu",
 ]

--- a/src/icalendar/timezone/pyicu.py
+++ b/src/icalendar/timezone/pyicu.py
@@ -1,0 +1,81 @@
+"""Use PyICU timezones."""
+from __future__ import annotations
+from datetime import datetime, tzinfo
+import threading
+from typing import TYPE_CHECKING
+import icu  # the PyICU module
+from .provider import TZProvider
+
+if TYPE_CHECKING:
+  from dateutil.rrule import rrule
+  from icalendar import prop
+  from icalendar.cal import Timezone
+
+
+class PYICU(TZProvider):
+    """Provide icalendar with timezones from pyicu."""
+    name = "pyicu"
+    _utc: icu.PYICU | None = None
+    _init_lock = threading.Lock()
+
+    @property
+    def utc(self) -> icu.PYICU:
+        """Return the UTC timezone, initializing lazily on first access."""
+        if self._utc is None:
+            with self._init_lock:
+                # Double-check after acquiring lock
+                if self._utc is None:
+                    PYICU._utc = icu.ICUtzinfo.getInstance("UTC")
+        return self._utc  # type: ignore[return-value]
+
+    def localize_utc(self, dt: datetime) -> datetime:
+        """Return the datetime in UTC."""
+        if getattr(dt, "tzinfo", False) and dt.tzinfo is not None:
+            return dt.astimezone(self.utc)
+        return self.localize(dt, self.utc)
+    
+    def localize(self, dt: datetime, tz: tzinfo) -> datetime:
+        """Localize a datetime to a timezone."""
+        return dt.replace(tzinfo=tz)
+    
+    def knows_timezone_id(self, tzid: str) -> bool:
+        """Whether the timezone is already cached by the implementation."""
+        return tzid in list(icu.TimeZone.createEnumeration())
+    
+    def timezone(self, name: str) -> tzinfo | None:
+        """Return a timezone with a name or None if we cannot find it."""
+        if self.knows_timezone_id(name):
+            return icu.ICUtzinfo.getInstance(name)
+        return None
+
+    def fix_rrule_until(self, rrule: rrule, ical_rrule: prop.vRecur) -> None:
+        """Make sure the until value works for the rrule generated from the ical_rrule."""  # noqa: E501
+        if not {"UNTIL", "COUNT"}.intersection(ical_rrule.keys()):
+            # zoninfo does not know any transition dates after 2038
+            rrule._until = datetime(2038, 12, 31, tzinfo=self.utc)  # noqa: SLF001
+                
+    def create_timezone(self, tz: Timezone) -> tzinfo:
+        """Create a timezone from a VTIMEZONE component using PyICU."""
+        text = tz.to_ical().decode("UTF-8", "replace")
+        vtimezone = icu.VTimeZone.createVTimeZone(text)
+        # PyICU does not raise on an unparseable VTIMEZONE — it returns a zone with
+        # an empty id whose use segfaults the interpreter. Detect that and fail
+        # loudly with a catchable Python error instead.
+        tzid = icu.UnicodeString()
+        vtimezone.getID(tzid)
+        if not str(tzid):
+            raise ValueError(f"PyICU could not parse VTIMEZONE {tz.get('TZID')!r}")
+        return icu.ICUtzinfo(vtimezone)
+
+    def uses_pytz(self) -> bool:
+        """Whether we use pytz."""
+        return False
+    def uses_zoneinfo(self) -> bool:
+        """Whether we use zoneinfo."""
+        return False
+    def uses_pyicu(self) -> bool:
+        """Whether we use pyicu."""
+        return True
+
+
+__all__ = ["PYICU"]

--- a/src/icalendar/timezone/pytz.py
+++ b/src/icalendar/timezone/pytz.py
@@ -74,5 +74,8 @@ class PYTZ(TZProvider):
         """Whether we use zoneinfo."""
         return False
 
+    def uses_pyicu(self) -> bool:
+        """Whether we use pyicu."""
+        return False
 
 __all__ = ["PYTZ"]

--- a/src/icalendar/timezone/tzp.py
+++ b/src/icalendar/timezone/tzp.py
@@ -45,6 +45,13 @@ class TZP:
 
         self._use(ZONEINFO())
 
+    def use_pyicu(self) -> None:
+        """Use pyicu as the timezone provider."""
+        from .pyicu import PYICU # noqa: PLC0415, RUF100
+
+        self._use(PYICU())
+
+          
     def _use(self, provider: TZProvider) -> None:
         """Use a timezone implementation."""
         self.__tz_cache = {}

--- a/src/icalendar/timezone/zoneinfo.py
+++ b/src/icalendar/timezone/zoneinfo.py
@@ -115,6 +115,10 @@ class ZONEINFO(TZProvider):
         """Whether we use pytz."""
         return False
 
+    def uses_pyicu(self) -> bool:
+        """Whether we use pyicu."""
+        return False
+    
     def uses_zoneinfo(self) -> bool:
         """Whether we use zoneinfo."""
         return True


### PR DESCRIPTION
## Linked issue

- Contributes to #692

## Description

Adds a **PyICU timezone provider** — a `PYICU` implementation of `TZProvider`, selectable via `use_pyicu()` and wired through `TZP` and the `icalendar.timezone` package. This is **part 1 of #692** and is opened as a **draft / work in progress**.

Working so far (verified locally against the repo's VTIMEZONE fixtures — 37/38 `create_timezone` succeed):
- timezone lookup via `icu.ICUtzinfo`, UTC handling, and `knows_timezone_id`
- unknown ids return `None`, so the Windows→Olson and globally-unique-TZID fallbacks in `TZP` still work
- `create_timezone` parses the `VTIMEZONE` via `icu.VTimeZone.createVTimeZone` (DST transitions correct); a `VTIMEZONE` that ICU cannot parse raises `ValueError` instead of segfaulting the interpreter

Still to do (follow-up commits): parametrize `conftest.py` across the pyicu backend, add PyICU-specific tests, declare the optional PyICU test dependency (gated so it skips when ICU is absent), resolve `uses_pyicu()`, and lint/type-hint cleanup.

Questions I'd love input on, @niccokunzmann (I'll also add inline comments on the lines):
1. `create_timezone` uses `icu.VTimeZone.createVTimeZone` as you suggested. One fixture — `issue_321_assert_dst_offset_is_not_false.ics` (`Europe/Berlin`) — is rejected by ICU (empty id) where zoneinfo/pytz succeed. Prefer a fallback for those, or an `xfail` for pyicu?
2. `uses_pyicu()`: add it to the `TZProvider` ABC + `TZP` proxy for symmetry with `uses_pytz`/`uses_zoneinfo`, or keep providers reporting only pytz/zoneinfo?
3. PyICU is hard to install (especially in CI). How would you like the optional dependency and test-skipping handled?

## Checklist

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

Draft / WIP — tests, docs, and the conftest parametrization are coming in follow-up commits.

AI disclosure: I used Claude (Opus 4.8, via Claude Code) to explain the timezone-provider architecture and to verify the provider's behaviour by running it; the code is my own. This is also noted in the commit message and the `news/692.feature` entry.
