### PR TITLE
test(fuzzing): include full parameter list in fuzzer log output

### DIFF
--- a/news/1758.internal
+++ b/news/1758.internal
@@ -1,0 +1,1 @@
+Included the full parameter list in the fuzzer log output for test reproduction. I used AI to assist me with this change. @webdevsamran

--- a/src/icalendar/fuzzing/ical_fuzzer.py
+++ b/src/icalendar/fuzzing/ical_fuzzer.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 ################################################################################
-import base64
 import contextlib
 import sys
 
@@ -31,15 +30,21 @@ def TestOneInput(data):
     multiple = fdp.ConsumeBool()
     should_walk = fdp.ConsumeBool()
     calendar_string = fdp.ConsumeString(fdp.remaining_bytes())
-    from_ical = icalendar.cal.calendar.Calendar.from_ical
     print("--- start calendar ---")
     with contextlib.suppress(UnicodeEncodeError):
         # print the ICS file for the test case extraction
         # see https://stackoverflow.com/a/27367173/1320237
-        print(format_fuzz_log(from_ical, multiple, should_walk, calendar_string))
+        print(
+            format_fuzz_log(
+                icalendar.cal.calendar.Calendar.from_ical,
+                multiple,
+                should_walk,
+                calendar_string,
+            )
+        )
 
     fuzz_v1_calendar(
-        from_ical,
+        icalendar.cal.calendar.Calendar.from_ical,
         calendar_string,
         multiple,
         should_walk,

--- a/src/icalendar/fuzzing/ical_fuzzer.py
+++ b/src/icalendar/fuzzing/ical_fuzzer.py
@@ -22,7 +22,7 @@ import atheris
 
 with atheris.instrument_imports():
     import icalendar.cal.calendar
-    from icalendar.tests.fuzzed import fuzz_v1_calendar
+    from icalendar.tests.fuzzed import format_fuzz_log, fuzz_v1_calendar
 
 
 @atheris.instrument_func
@@ -31,18 +31,15 @@ def TestOneInput(data):
     multiple = fdp.ConsumeBool()
     should_walk = fdp.ConsumeBool()
     calendar_string = fdp.ConsumeString(fdp.remaining_bytes())
+    from_ical = icalendar.cal.calendar.Calendar.from_ical
     print("--- start calendar ---")
     with contextlib.suppress(UnicodeEncodeError):
         # print the ICS file for the test case extraction
         # see https://stackoverflow.com/a/27367173/1320237
-        print(
-            base64.b64encode(calendar_string.encode("UTF-8", "surrogateescape")).decode(
-                "ASCII"
-            )
-        )
+        print(format_fuzz_log(from_ical, multiple, should_walk, calendar_string))
 
     fuzz_v1_calendar(
-        icalendar.cal.calendar.Calendar.from_ical,
+        from_ical,
         calendar_string,
         multiple,
         should_walk,

--- a/src/icalendar/tests/fuzzed/__init__.py
+++ b/src/icalendar/tests/fuzzed/__init__.py
@@ -39,6 +39,26 @@ _value_error_matches = [
 ]
 
 
+def format_fuzz_log(
+    from_ical, multiple: bool, should_walk: bool, calendar_string: str
+) -> str:
+    """Format the log entry for fuzzed test case extraction.
+
+    Outputs entrypoint name, parameter values, and base64-encoded calendar content.
+    """
+    import base64
+
+    encoded = base64.b64encode(
+        calendar_string.encode("UTF-8", "surrogateescape")
+        if isinstance(calendar_string, str)
+        else calendar_string
+    ).decode("ASCII")
+    return (
+        f"{from_ical.__qualname__} multiple={multiple} "
+        f"should_walk={should_walk} {encoded}"
+    )
+
+
 def fuzz_v1_calendar(
     from_ical, calendar_string: str, multiple: bool, should_walk: bool
 ):

--- a/src/icalendar/tests/fuzzed/test_fuzzed_calendars.py
+++ b/src/icalendar/tests/fuzzed/test_fuzzed_calendars.py
@@ -31,6 +31,7 @@ def test_fuzz_v1(fuzz_v1_calendar_path):
 
 def test_format_fuzz_log():
     import base64
+
     from icalendar.tests.fuzzed import format_fuzz_log
 
     content = "BEGIN:VCALENDAR\r\nEND:VCALENDAR"
@@ -43,4 +44,3 @@ def test_format_fuzz_log():
     assert log.startswith("Calendar.from_ical multiple=False should_walk=True ")
     encoded = log.split()[-1]
     assert base64.b64decode(encoded).decode("utf-8") == content
-

--- a/src/icalendar/tests/fuzzed/test_fuzzed_calendars.py
+++ b/src/icalendar/tests/fuzzed/test_fuzzed_calendars.py
@@ -27,3 +27,20 @@ def test_fuzz_v1(fuzz_v1_calendar_path):
         multiple=True,
         should_walk=True,
     )
+
+
+def test_format_fuzz_log():
+    import base64
+    from icalendar.tests.fuzzed import format_fuzz_log
+
+    content = "BEGIN:VCALENDAR\r\nEND:VCALENDAR"
+    log = format_fuzz_log(
+        icalendar.cal.calendar.Calendar.from_ical,
+        multiple=False,
+        should_walk=True,
+        calendar_string=content,
+    )
+    assert log.startswith("Calendar.from_ical multiple=False should_walk=True ")
+    encoded = log.split()[-1]
+    assert base64.b64decode(encoded).decode("utf-8") == content
+


### PR DESCRIPTION
## Linked issue

- Closes #1758

## Description

Includes the full parameter list (\multiple\, \should_walk\) alongside the entrypoint name and base64-encoded calendar payload in the fuzzer log output (\src/icalendar/fuzzing/ical_fuzzer.py\), formatted via \ormat_fuzz_log\ in \src/icalendar/tests/fuzzed/__init__.py\. This enables reproducing fuzzed test cases with their exact execution parameters. \Calendar.from_ical\ is kept inlined in the fuzzer per review feedback.

AI disclosure: I used AI assistance (Claude 3.7 Sonnet / Gemini 2.5) to help draft and refine the implementation, test coverage, and changelog entry for this change.

## Checklist

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).