### PR TITLE
Include reproduction parameters in fuzzing logs

### DIFF
--- a/news/1758.internal
+++ b/news/1758.internal
@@ -1,0 +1,1 @@
+Added the parser name and option values alongside the encoded calendar in fuzzing failure logs, making failures easier to reproduce. AI assistance was used to help implement and test this change. @ritik26ce020-arch

--- a/src/icalendar/fuzzing/ical_fuzzer.py
+++ b/src/icalendar/fuzzing/ical_fuzzer.py
@@ -14,15 +14,16 @@
 # limitations under the License.
 #
 ################################################################################
-import base64
-import contextlib
 import sys
 
 import atheris
 
 with atheris.instrument_imports():
     import icalendar.cal.calendar
-    from icalendar.tests.fuzzed import fuzz_v1_calendar
+    from icalendar.tests.fuzzed import (
+        format_fuzz_v1_calendar_log,
+        fuzz_v1_calendar,
+    )
 
 
 @atheris.instrument_func
@@ -32,14 +33,14 @@ def TestOneInput(data):
     should_walk = fdp.ConsumeBool()
     calendar_string = fdp.ConsumeString(fdp.remaining_bytes())
     print("--- start calendar ---")
-    with contextlib.suppress(UnicodeEncodeError):
-        # print the ICS file for the test case extraction
-        # see https://stackoverflow.com/a/27367173/1320237
-        print(
-            base64.b64encode(calendar_string.encode("UTF-8", "surrogateescape")).decode(
-                "ASCII"
-            )
+    print(
+        format_fuzz_v1_calendar_log(
+            icalendar.cal.calendar.Calendar.from_ical,
+            calendar_string,
+            multiple,
+            should_walk,
         )
+    )
 
     fuzz_v1_calendar(
         icalendar.cal.calendar.Calendar.from_ical,

--- a/src/icalendar/tests/fuzzed/__init__.py
+++ b/src/icalendar/tests/fuzzed/__init__.py
@@ -5,6 +5,8 @@ These test cases reproduce the failure.
 Some more tests can be added to make sure that the behavior works properly.
 """
 
+import base64
+
 _value_error_matches = [
     "component",
     "parse",
@@ -37,6 +39,19 @@ _value_error_matches = [
     "not enough values to unpack",  # dateutil rejects a malformed VTIMEZONE content line
     "not allowed in TEXT values",  # RFC 5545 control character rejection in TEXT
 ]
+
+
+def format_fuzz_v1_calendar_log(
+    from_ical, calendar_string: str, multiple: bool, should_walk: bool
+) -> str:
+    """Format the information needed to reproduce a fuzzed calendar."""
+    encoded_calendar = base64.b64encode(
+        calendar_string.encode("UTF-8", "surrogateescape")
+    ).decode("ASCII")
+    return (
+        f"{from_ical.__qualname__} multiple={multiple} "
+        f"should_walk={should_walk} {encoded_calendar}"
+    )
 
 
 def fuzz_v1_calendar(

--- a/src/icalendar/tests/fuzzed/test_fuzzed_calendars.py
+++ b/src/icalendar/tests/fuzzed/test_fuzzed_calendars.py
@@ -13,8 +13,26 @@ Templace code to create a new test case:
 
 """
 
+import base64
+
 import icalendar.cal.calendar
-from icalendar.tests.fuzzed import fuzz_v1_calendar
+from icalendar.tests.fuzzed import (
+    format_fuzz_v1_calendar_log,
+    fuzz_v1_calendar,
+)
+
+
+def test_fuzz_v1_calendar_log_contains_reproduction_parameters():
+    """The fuzzing log includes all parameters needed to reproduce a failure."""
+    calendar = "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n"
+    encoded_calendar = base64.b64encode(calendar.encode()).decode("ASCII")
+
+    assert format_fuzz_v1_calendar_log(
+        icalendar.cal.calendar.Calendar.from_ical,
+        calendar,
+        multiple=False,
+        should_walk=True,
+    ) == ("Calendar.from_ical multiple=False should_walk=True " + encoded_calendar)
 
 
 def test_fuzz_v1(fuzz_v1_calendar_path):


### PR DESCRIPTION
Include the parser name and boolean options alongside the base64 calendar, and cover the formatter with a focused test.

AI model: OpenAI GPT-5 (Codex)
AI use: Helped inspect issue #1758, draft the implementation and test, run verification, and review the change against the repository contribution policy.

<!--

INSTRUCTIONS

Fill out the pull request template as described below.

Do not edit or remove section headings as they are required, except "Additional information" which is optional.

Comments may be removed.
Comments consist of the content between each pair of HTML comment delimiters, inclusively.

-->

## Linked issue

<!--
Replace `ISSUE_NUMBER` with the issue number that your pull request addresses.
This links the pull request to the related issue.

Choose the appropriate form:

- If you completely resolve the issue, then use `"Closes"`.
  This form will automatically close the related issue when the PR gets merged.
- If you contribute to solving part of the issue, use "Contributes to".
  This form keeps the issue open for future work.
-->

- Closes #ISSUE_NUMBER
- Contributes to #ISSUE_NUMBER

<!--
You may also link to open pull requests that address the same issue, if applicable.

- See #PULL_REQUEST_NUMBER
-->

## Description

<!--
Write a description of the fixes or improvements.
-->

## Checklist

<!--
Do not edit the checkbox list items.

To indicate that you completed an item, place an `x` inside the checkbox, such as `[x]`.
-->

- [ ] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [ ] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [ ] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

<!--
Upload screenshots, videos, links to documentation, or any other relevant information.
-->
