### PR TITLE
fix(fuzzing): log the from_ical call's full arguments alongside the calendar

### DIFF
--- a/src/icalendar/fuzzing/ical_fuzzer.py
+++ b/src/icalendar/fuzzing/ical_fuzzer.py
@@ -33,12 +33,16 @@ def TestOneInput(data):
     calendar_string = fdp.ConsumeString(fdp.remaining_bytes())
     print("--- start calendar ---")
     with contextlib.suppress(UnicodeEncodeError):
-        # print the ICS file for the test case extraction
+        # print the ICS file for the test case extraction, alongside the
+        # from_ical call's other arguments so a case can be reproduced
+        # without guessing multiple/should_walk
         # see https://stackoverflow.com/a/27367173/1320237
+        encoded = base64.b64encode(
+            calendar_string.encode("UTF-8", "surrogateescape")
+        ).decode("ASCII")
         print(
-            base64.b64encode(calendar_string.encode("UTF-8", "surrogateescape")).decode(
-                "ASCII"
-            )
+            f"{icalendar.cal.calendar.Calendar.from_ical.__qualname__} "
+            f"multiple={multiple} should_walk={should_walk} {encoded}"
         )
 
     fuzz_v1_calendar(


### PR DESCRIPTION
Closes #1758.

The fuzz harness (`src/icalendar/fuzzing/ical_fuzzer.py`) logs only the base64-encoded calendar content between the `--- start calendar ---`/`--- end calendar ---` markers. Reproducing a crash from those logs meant guessing the `multiple`/`should_walk` booleans the fuzzer happened to pick for that run.

Per the issue's suggested fix, the printed line is now prefixed with the call site's qualname and both arguments:

```
--- start calendar ---
Calendar.from_ical multiple=False should_walk=True QkVHSU46VlRJTUVaT05FCg==...
--- end calendar ---
```

Used `Calendar.from_ical.__qualname__` (the issue notes this is enough, no need for `__module__`) since `TestOneInput` already has a direct reference to `icalendar.cal.calendar.Calendar.from_ical`, same object passed to `fuzz_v1_calendar`.

`atheris` isn't installable in my environment (Linux-only libFuzzer wrapper) and isn't exercised by the regular pytest suite, so I verified with `python -m py_compile`, `ruff check`, and `ruff format --check` rather than running the fuzzer itself.