### PR TITLE
ci: enable uv cache for test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
       if: ${{ !matrix.skip }}
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
-        enable-cache: false
+        enable-cache: true
         # Install a specific version of uv.
         version: "0.11.6"
         python-version: ${{ matrix.python_version }}


### PR DESCRIPTION
Closes #1757

Enable setup-uv caching for the run-tests matrix, where dependency caching is safe and speeds up repeated CI runs. The release and distribution jobs keep caching disabled as requested by the issue context.

Tests: workflow-only change; no local test suite run.