### PR TITLE
Enforce the source distribution root contract

### DIFF
--- a/news/1695.chore
+++ b/news/1695.chore
@@ -1,0 +1,1 @@
+Keep source distributions limited to reviewed root entries; I used OpenAI Codex (GPT-6) to assist with this change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,12 +141,12 @@ icalendar = "icalendar.cli:main"
 
 [tool.hatch.build]
 exclude = [
-  "/.*",
-  "/*.*",
-  "/src/icalendar/fuzzing",
-  "/dist",
-  "/build",
-  "/htmlcov",
+  "/.*",  # Local tool and development configuration.
+  "/*.*",  # Root project files; Hatch restores required package metadata.
+  "/build",  # Python build output.
+  "/dist",  # Release archives from an earlier build.
+  "/htmlcov",  # Generated coverage report.
+  "/src/icalendar/fuzzing",  # Development-only fuzzing helpers.
 ]
 
 [tool.hatch.build.targets.sdist.force-include]

--- a/src/icalendar/tests/test_create_release.sh
+++ b/src/icalendar/tests/test_create_release.sh
@@ -24,6 +24,26 @@ if ! [ -f "$archive" ]; then
 fi
 
 FILES="`tar -tf \"$archive\" | grep -o '/.*'`"
+ROOT_ENTRIES="`printf '%s\n' "$FILES" | sed 's#^/##; s#/.*##; /^$/d' | LC_ALL=C sort -u`"
+EXPECTED_ROOT_ENTRIES="`cat <<'EOF'
+.gitignore
+LICENSE.rst
+Makefile
+PKG-INFO
+README.rst
+docs
+funding.json
+news
+pyproject.toml
+src
+EOF
+`"
+
+if [ "$ROOT_ENTRIES" != "$EXPECTED_ROOT_ENTRIES" ]; then
+  echo "ERROR: Source distribution root entries differ from the reviewed allowlist."
+  diff -u <(printf '%s\n' "$EXPECTED_ROOT_ENTRIES") <(printf '%s\n' "$ROOT_ENTRIES") || true
+  exit 1
+fi
 
 if echo "$FILES" | grep -q '^/src/icalendar/fuzzing'; then
   echo "ERROR: Fuzzing files are included in the release."

--- a/src/icalendar/tests/test_create_release.sh
+++ b/src/icalendar/tests/test_create_release.sh
@@ -25,8 +25,7 @@ fi
 
 FILES="`tar -tf \"$archive\" | grep -o '/.*'`"
 ROOT_ENTRIES="`printf '%s\n' "$FILES" | sed 's#^/##; s#/.*##; /^$/d' | LC_ALL=C sort -u`"
-EXPECTED_ROOT_ENTRIES="`cat <<'EOF'
-.gitignore
+EXPECTED_ROOT_ENTRIES=".gitignore
 LICENSE.rst
 Makefile
 PKG-INFO
@@ -35,9 +34,7 @@ docs
 funding.json
 news
 pyproject.toml
-src
-EOF
-`"
+src"
 
 if [ "$ROOT_ENTRIES" != "$EXPECTED_ROOT_ENTRIES" ]; then
   echo "ERROR: Source distribution root entries differ from the reviewed allowlist."


### PR DESCRIPTION
## Linked issue

- Closes #1695

## Description

The Hatch exclusion list is now sorted and documents why each class of development artifact is omitted. The release check also treats the sdist root as an explicit contract: any new top-level entry fails with a diff until it is reviewed and added deliberately. Hatchling's forced `.gitignore` entry remains in the allowlist as discussed on the issue.

A mutation check with the exclusions disabled failed on 14 unexpected roots, including `.claude`, `.github`, coverage configuration, and contribution files. AI assistance is disclosed in the commit message and changelog entry.

## Checklist

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

Validation:
- `uv run tox -e py`: 18,406 passed, 24 skipped, 539 xfailed; 98% coverage
- `src/icalendar/tests/test_create_release.sh`: sdist/wheel build and Twine checks passed
- changed-file pre-commit hooks, Towncrier check, shell syntax, and diff check passed
