### PR TITLE
Test source distributions outside the checkout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,9 +92,13 @@ jobs:
 
   test-distribution:
     name: Check built packages
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
     - name: Install uv and Python
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
@@ -102,6 +106,36 @@ jobs:
         version: "0.11.6"
     - name: Check the release files
       run: make test-dist
+    - name: Upload built packages
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: built-packages
+        path: dist/*
+
+  test-source-distribution:
+    name: Test source distribution
+    needs: test-distribution
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download built packages
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: built-packages
+        path: dist
+    - name: Install uv and Python 3.14
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        enable-cache: false
+        version: "0.11.6"
+        python-version: "3.14"
+    - name: Unpack source distribution
+      run: |
+        mkdir source-distribution
+        tar --extract --gzip --file dist/*.tar.gz --directory source-distribution --strip-components=1
+    - name: Test source distribution
+      working-directory: source-distribution
+      run: uv run --group test pytest
 
   deploy-tag-to-pypi:
     # only deploy on tags, see https://stackoverflow.com/a/58478262/1320237
@@ -109,6 +143,7 @@ jobs:
     needs:
     - run-tests
     - test-distribution
+    - test-source-distribution
     runs-on: ubuntu-latest
     # This environment stores the TWINE_USERNAME and TWINE_PASSWORD
     # see https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
@@ -157,6 +192,7 @@ jobs:
     needs:
     - run-tests
     - test-distribution
+    - test-source-distribution
     runs-on: ubuntu-latest
     environment:
       name: github-release

--- a/news/1708.bugfix
+++ b/news/1708.bugfix
@@ -1,0 +1,1 @@
+Source distributions now include all files required to run their test suite, and CI verifies them outside the repository checkout. I used OpenAI Codex based on GPT-5 to assist with this change. @ryux1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ exclude = [
 # Tests for files included in the distribution reside here:
 # src/icalendar/tests/test_create_release.sh
 "funding.json" = "funding.json"
+"generate_windows_to_olson_mapping.py" = "generate_windows_to_olson_mapping.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/icalendar"]


### PR DESCRIPTION
## Linked issue

- Closes #1708

## Description

Source distributions omitted `generate_windows_to_olson_mapping.py`, so two tests shipped in the archive failed outside a repository checkout. This includes the required file and adds an isolated CI job that downloads, unpacks, and tests the built source archive. Release jobs now depend on that test.

The isolated source-distribution result changes from two failures to a passing suite. After rebasing onto the current `main`, the full checkout suite passes with 18,382 tests, 24 skips, and 526 expected failures.

## Checklist

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [ ] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [x] I added or updated tests, if applicable.
- [x] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

Prepared with OpenAI Codex assistance. The contributor's personal review, responsibility, and understanding attestation remains pending; the PR will stay in draft until that is complete.
