### PR TITLE
docs: show Event.example() usage in the class docstring

### DIFF
--- a/news/743.documentation
+++ b/news/743.documentation
@@ -1,1 +1,1 @@
-Added and documented the usage example for :meth:`Calendar.example <icalendar.cal.calendar.Calendar.example>`. I used OpenAI Codex (GPT-5) to help identify and draft this documentation change, then reviewed and verified the output locally. @cananoo
+Documented how to use :meth:`Event.example <icalendar.cal.event.Event.example>` in the class docstring. I used AI to assist with this change. @NullPointerC

--- a/src/icalendar/cal/event.py
+++ b/src/icalendar/cal/event.py
@@ -186,6 +186,35 @@ class Event(Component):
             UID:d755cef5-2311-46ed-a0e1-6733c9e15c63
             END:VEVENT
 
+        Use one of the bundled event examples:
+
+        .. code-block:: pycon
+
+            >>> from icalendar import Event
+            >>> print(Event.example().to_ical().decode())
+            BEGIN:VEVENT
+            SUMMARY:Meeting
+            DTSTART;TZID=America/New_York:20210302T103000
+            DTEND;TZID=America/New_York:20210302T113000
+            DTSTAMP:20210302T152026Z
+            UID:AC67C078-CED3-4BF5-9726-832C3749F627
+            CREATED:20210302T151004Z
+            BEGIN:VALARM
+            ACKNOWLEDGED:20210302T152024Z
+            ACTION:DISPLAY
+            DESCRIPTION:Event reminder
+            TRIGGER:-PT15M
+            UID:8297C37D-BA2D-4476-91AE-C1EAA364F8E1
+            END:VALARM
+            BEGIN:VALARM
+            ACTION:DISPLAY
+            DESCRIPTION:Event reminder
+            RELATED-TO;RELTYPE=SNOOZE:8297C37D-BA2D-4476-91AE-C1EAA364F8E1
+            TRIGGER;VALUE=DATE-TIME:20210302T152500Z
+            UID:87D690A7-B5E8-4EB4-8500-491F50AFE394
+            END:VALARM
+            END:VEVENT
+
     """
 
     name = "VEVENT"


### PR DESCRIPTION
## Linked issue

- Closes #743

## Description

Adds an example showing how to use `Event.example()` to the `Event` class docstring, as requested by the issue.

## Checklist

- [x] I added a change log entry, following the instructions in all subsections under [Change log requirements](https://icalendar.readthedocs.io/en/latest/contribute/#change-log-requirements).
- [x] I followed icalendar's [Artificial intelligence policy](https://icalendar.readthedocs.io/en/latest/contribute/index.html#artificial-intelligence-policy) and disclosed my [Responsible AI use](https://icalendar.readthedocs.io/en/latest/contribute/index.html#responsible-ai-use) in my commit messages, if applicable.
- [ ] I added or updated tests, if applicable.
- [ ] I ran and ensured all tests pass locally by following [Run tests](https://icalendar.readthedocs.io/en/latest/contribute/development.html#run-tests).
- [x] I added or edited documentation as necessary, both as docstrings to be rendered in the API documentation and narrative documentation, following the [Style guide](https://icalendar.readthedocs.io/en/latest/contribute/documentation/style-guide.html).

## Additional information

I used AI to assist with drafting the docstring example; the final output was reviewed and verified manually.